### PR TITLE
Fix undo/redo for drag-dropped GLB assets

### DIFF
--- a/src/entity_ops.rs
+++ b/src/entity_ops.rs
@@ -446,14 +446,15 @@ pub fn spawn_gltf(
     entity
 }
 
-pub fn spawn_gltf_in_world(world: &mut World, path: &str, position: Vec3) {
+fn spawn_gltf_in_world(world: &mut World, path: &str, position: Vec3) {
     let mut system_state: SystemState<(Commands, Res<AssetServer>, ResMut<Selection>)> =
         SystemState::new(world);
     let Ok((mut commands, asset_server, mut selection)) = system_state.get_mut(world) else {
         return;
     };
-    spawn_gltf(&mut commands, &asset_server, path, position, &mut selection);
+    let entity = spawn_gltf(&mut commands, &asset_server, path, position, &mut selection);
     system_state.apply(world);
+    crate::scene_io::register_entity_in_ast(world, entity);
 }
 
 pub fn delete_selected(world: &mut World) {
@@ -1365,6 +1366,7 @@ use crate::core_extension::CoreExtensionInputContext;
 pub(crate) fn add_to_extension(ctx: &mut ExtensionContext) {
     ctx.register_operator::<EntityDeleteOp>()
         .register_operator::<EntityDuplicateOp>()
+        .register_operator::<EntityPlaceGltfOp>()
         .register_operator::<EntityCopyComponentsOp>()
         .register_operator::<EntityPasteComponentsOp>()
         .register_operator::<EntityToggleVisibilityOp>()
@@ -1444,6 +1446,45 @@ fn can_act_on_entities(
 }
 
 // -- Entity lifecycle --------------------------------------------
+
+#[operator(
+    id = "entity.place_gltf",
+    label = "Place GLTF",
+    description = "Place a GLTF asset into the active scene at a world position.",
+    allows_undo = true,
+    params(
+        path(String, doc = "Path to the GLTF asset."),
+        pos_x(f64, doc = "World-space X position."),
+        pos_y(f64, doc = "World-space Y position."),
+        pos_z(f64, doc = "World-space Z position."),
+    )
+)]
+pub(crate) fn entity_place_gltf(
+    params: In<OperatorParameters>,
+    mut commands: Commands,
+) -> OperatorResult {
+    let Some(path) = params.as_str("path").map(str::to_owned) else {
+        warn!("entity.place_gltf: missing `path` param");
+        return OperatorResult::Cancelled;
+    };
+    let Some(x) = params.as_float("pos_x") else {
+        warn!("entity.place_gltf: missing `pos_x` param");
+        return OperatorResult::Cancelled;
+    };
+    let Some(y) = params.as_float("pos_y") else {
+        warn!("entity.place_gltf: missing `pos_y` param");
+        return OperatorResult::Cancelled;
+    };
+    let Some(z) = params.as_float("pos_z") else {
+        warn!("entity.place_gltf: missing `pos_z` param");
+        return OperatorResult::Cancelled;
+    };
+    let position = Vec3::new(x as f32, y as f32, z as f32);
+    commands.queue(move |world: &mut World| {
+        spawn_gltf_in_world(world, &path, position);
+    });
+    OperatorResult::Finished
+}
 
 #[operator(
     id = "entity.delete",

--- a/src/viewport.rs
+++ b/src/viewport.rs
@@ -679,9 +679,17 @@ fn handle_viewport_drop(
     } else if is_template {
         warn!(".template.json files are no longer supported; use prefabs instead");
     } else {
-        commands.queue(move |world: &mut World| {
-            crate::entity_ops::spawn_gltf_in_world(world, &path, snapped_pos);
-        });
+        commands
+            .operator(crate::entity_ops::EntityPlaceGltfOp::ID)
+            .settings(CallOperatorSettings {
+                creates_history_entry: true,
+                ..default()
+            })
+            .param("path", path)
+            .param("pos_x", snapped_pos.x as f64)
+            .param("pos_y", snapped_pos.y as f64)
+            .param("pos_z", snapped_pos.z as f64)
+            .call();
     }
 }
 

--- a/tests/operator_undo.rs
+++ b/tests/operator_undo.rs
@@ -93,6 +93,125 @@ impl OperatorResultExt for OperatorResult {
 }
 
 #[test]
+fn entity_place_gltf_survives_later_history_and_scene_tabs() {
+    let path = "models/dungeon.glb";
+    let position = Vec3::new(1.25, -2.0, 3.5);
+    let mut app = util::editor_test_app();
+    let stack_before = app.world().resource::<CommandHistory>().undo_stack.len();
+
+    app.world_mut()
+        .operator("entity.place_gltf")
+        .settings(CallOperatorSettings {
+            execution_context: ExecutionContext::Invoke,
+            creates_history_entry: true,
+        })
+        .param("path", path.to_string())
+        .param("pos_x", position.x as f64)
+        .param("pos_y", position.y as f64)
+        .param("pos_z", position.z as f64)
+        .call()
+        .expect("entity.place_gltf dispatch resolves")
+        .assert_finished_or_panic("entity.place_gltf");
+
+    assert_eq!(
+        app.world().resource::<CommandHistory>().undo_stack.len(),
+        stack_before + 1,
+        "placement should create exactly one undo entry"
+    );
+
+    let placed = assert_single_renderable_gltf(&mut app, path, position);
+    assert!(
+        app.world()
+            .resource::<jackdaw_bsn::SceneBsnAst>()
+            .ast_for(placed)
+            .is_some(),
+        "placed GLB must be part of the authoritative scene document"
+    );
+
+    // Reproduce the reported sequence: a later rotate action creates another
+    // snapshot, then undo/redo reloads the scene document. The authored GLB
+    // and its derived render root must both survive those reloads.
+    app.world_mut()
+        .operator("tool.rotate")
+        .settings(CallOperatorSettings {
+            execution_context: ExecutionContext::Invoke,
+            creates_history_entry: true,
+        })
+        .call()
+        .expect("tool.rotate dispatch resolves")
+        .assert_finished_or_panic("tool.rotate");
+    assert_eq!(
+        app.world().resource::<CommandHistory>().undo_stack.len(),
+        stack_before + 2,
+        "rotate should create the history entry after placement"
+    );
+
+    app.world_mut()
+        .resource_scope(|world, mut history: Mut<CommandHistory>| history.undo(world));
+    assert_single_renderable_gltf(&mut app, path, position);
+
+    app.world_mut()
+        .resource_scope(|world, mut history: Mut<CommandHistory>| history.redo(world));
+    assert_single_renderable_gltf(&mut app, path, position);
+
+    // Undo both actions, then redo just the placement to verify the placement
+    // snapshot itself also restores a renderable GLB.
+    app.world_mut()
+        .resource_scope(|world, mut history: Mut<CommandHistory>| history.undo(world));
+    app.world_mut()
+        .resource_scope(|world, mut history: Mut<CommandHistory>| history.undo(world));
+    assert_eq!(
+        app.world_mut()
+            .query::<&jackdaw_scene_types::GltfSource>()
+            .iter(app.world())
+            .count(),
+        0,
+        "undo should remove the placed GLB"
+    );
+    app.world_mut()
+        .resource_scope(|world, mut history: Mut<CommandHistory>| history.redo(world));
+    assert_single_renderable_gltf(&mut app, path, position);
+
+    // Scene tabs capture and restore the same authoritative document. A trip
+    // to an empty tab and back must rehydrate the GLB's derived render root.
+    {
+        let mut scenes = app.world_mut().resource_mut::<jackdaw::scenes::Scenes>();
+        *scenes = jackdaw::scenes::Scenes::default();
+        scenes.tabs.push(jackdaw::scenes::SceneTab::new_untitled(1));
+        scenes.tabs.push(jackdaw::scenes::SceneTab::new_untitled(2));
+        scenes.active = 0;
+    }
+    jackdaw::scenes::swap::swap_active_tab(app.world_mut(), 1);
+    assert_eq!(
+        app.world_mut()
+            .query::<&jackdaw_scene_types::GltfSource>()
+            .iter(app.world())
+            .count(),
+        0,
+        "the second tab should remain empty"
+    );
+    jackdaw::scenes::swap::swap_active_tab(app.world_mut(), 0);
+    assert_single_renderable_gltf(&mut app, path, position);
+}
+
+#[track_caller]
+fn assert_single_renderable_gltf(app: &mut App, path: &str, position: Vec3) -> Entity {
+    let (entity, source, transform, _) = app
+        .world_mut()
+        .query::<(
+            Entity,
+            &jackdaw_scene_types::GltfSource,
+            &Transform,
+            &bevy::world_serialization::WorldAssetRoot,
+        )>()
+        .single(app.world())
+        .expect("expected one GLB root with its derived render asset");
+    assert_eq!(source.path, path);
+    assert_eq!(transform.translation, position);
+    entity
+}
+
+#[test]
 fn view_toggle_wireframe_round_trip() {
     let mut app = util::editor_test_app();
     assert_undo_redo_round_trip(&mut app, "view.toggle_wireframe");


### PR DESCRIPTION
- Route GLB drag-and-drop through `entity.place_gltf`.
- Save placed GLBs in the scene document so undo and redo restore them correctly.
- Add regression coverage for rotation history and switching scene tabs.