### PR TITLE
Fix undo/redo for drag-dropped GLB assets

### DIFF
--- a/crates/jackdaw_feathers/src/tokens.rs
+++ b/crates/jackdaw_feathers/src/tokens.rs
@@ -223,6 +223,10 @@ pub const CATEGORY_PREFAB: Color = Color::srgb(0.95, 0.7, 0.3);
 /// Inherited-from-prefab entity dot color (muted amber, signals "not authored here")
 pub const CATEGORY_INHERITED: Color = Color::srgba(0.65, 0.55, 0.42, 0.75);
 /// Generic entity dot color (green)
+/// Parts of a loaded asset (glTF nodes/meshes). Muted like the inherited
+/// tone: the rows are inspectable but not editable.
+pub const CATEGORY_ASSET_PART: Color = Color::srgba(0.0, 0.667, 0.733, 0.55);
+
 pub const CATEGORY_ENTITY: Color = Color::srgba(0.259, 0.725, 0.514, 1.0);
 
 // ---------------------------------------------------------------------------

--- a/crates/jackdaw_feathers/src/tree_view.rs
+++ b/crates/jackdaw_feathers/src/tree_view.rs
@@ -37,6 +37,7 @@ pub fn category_color(category: EntityCategory, inherited: bool) -> Color {
         EntityCategory::Scene => tokens::CATEGORY_SCENE,
         EntityCategory::Prefab => tokens::CATEGORY_PREFAB,
         EntityCategory::Inherited => tokens::CATEGORY_INHERITED,
+        EntityCategory::AssetPart => tokens::CATEGORY_ASSET_PART,
         EntityCategory::Group | EntityCategory::Entity => tokens::CATEGORY_ENTITY,
     }
 }
@@ -451,6 +452,7 @@ fn category_dot(
         EntityCategory::Prefab => Icon::Package,
         EntityCategory::Scene => Icon::Clapperboard,
         EntityCategory::Inherited | EntityCategory::Mesh => Icon::Box,
+        EntityCategory::AssetPart => Icon::Component,
         EntityCategory::Group => Icon::Folder,
         EntityCategory::Entity => Icon::Dot,
     });

--- a/crates/jackdaw_widgets/src/tree_view.rs
+++ b/crates/jackdaw_widgets/src/tree_view.rs
@@ -60,6 +60,11 @@ pub enum EntityCategory {
     /// `IsA`). Drawn with a faint tinge to signal it's a materialized
     /// child of an instance rather than authored directly.
     Inherited,
+    /// A node of a loaded asset (a glTF scene's own nodes and meshes) rather
+    /// than something authored. Shown so the model's structure is inspectable,
+    /// but drawn with its own icon and a muted tone because it has no document
+    /// node and so cannot be duplicated, deleted or reparented.
+    AssetPart,
     /// A container entity: it has children but no more specific type of its
     /// own, so it reads as a grouping node (e.g. a "Trees" parent).
     Group,

--- a/src/entity_ops.rs
+++ b/src/entity_ops.rs
@@ -58,7 +58,8 @@ impl Plugin for EntityOpsPlugin {
                 warn!("Failed to initialize system clipboard: {e}");
             }
         }
-        app.register_type::<EmptyEntity>()
+        app.add_observer(derive_world_asset_root)
+            .register_type::<EmptyEntity>()
             .register_type::<SceneCamera>()
             .register_type::<SceneLight>()
             .register_type::<SceneFogVolume>()
@@ -66,6 +67,38 @@ impl Plugin for EntityOpsPlugin {
             .register_type::<SceneAnimationPlayer>()
             .register_type::<SceneAudioSource>();
     }
+}
+
+/// Derive the render-side `WorldAssetRoot` from the authored `GltfSource`,
+/// the way reference images and terrains derive their render state.
+///
+/// Undo, redo, tab swaps and file loads all re-insert `GltfSource` from the
+/// document, so deriving it here is what brings the model back on each of
+/// those paths without the handle ever being written to the document.
+fn derive_world_asset_root(
+    insert: On<Insert, GltfSource>,
+    sources: Query<&GltfSource>,
+    existing: Query<&WorldAssetRoot>,
+    asset_server: Res<AssetServer>,
+    mut commands: Commands,
+) {
+    let entity = insert.entity;
+    let Ok(source) = sources.get(entity) else {
+        return;
+    };
+    // Scenes authored before paths were normalised still hold an absolute
+    // path; `to_asset_path` reduces those and passes a relative one through.
+    let asset_path = to_asset_path(&source.path);
+    let scene: Handle<bevy::world_serialization::WorldAsset> =
+        asset_server.load(GltfAssetLabel::Scene(source.scene_index).from_asset(asset_path));
+    // Re-inserting an equal handle still trips `Changed`, and the world-asset
+    // spawner despawns and respawns the whole instance on every change.
+    // Applying the document re-inserts `GltfSource` wholesale, so without this
+    // the model is rebuilt on every undo.
+    if existing.get(entity).is_ok_and(|root| root.0 == scene) {
+        return;
+    }
+    commands.entity(entity).insert(WorldAssetRoot(scene));
 }
 
 /// Marks an entity as an intentionally-empty scene entity (`Add > Empty`).
@@ -419,7 +452,6 @@ pub fn create_entity_in_world(world: &mut World, template: EntityTemplate) {
 
 pub fn spawn_gltf(
     commands: &mut Commands,
-    asset_server: &AssetServer,
     path: &str,
     position: Vec3,
     selection: &mut Selection,
@@ -429,16 +461,17 @@ pub fn spawn_gltf(
         .map(|s| s.to_string_lossy().to_string())
         .unwrap_or_else(|| "GLTF Model".to_string());
     let scene_index = 0;
+    // Store the asset-relative path, not the browser's absolute one: the
+    // runtime and other machines cannot strip this project's assets prefix,
+    // and an unapproved absolute path is refused outright by the asset server.
     let asset_path = to_asset_path(path);
-    let scene = asset_server.load(GltfAssetLabel::Scene(scene_index).from_asset(asset_path));
     let entity = commands
         .spawn((
             Name::new(file_name),
             GltfSource {
-                path: path.to_string(),
+                path: asset_path,
                 scene_index,
             },
-            WorldAssetRoot(scene),
             Transform::from_translation(position),
         ))
         .id();
@@ -447,12 +480,11 @@ pub fn spawn_gltf(
 }
 
 fn spawn_gltf_in_world(world: &mut World, path: &str, position: Vec3) {
-    let mut system_state: SystemState<(Commands, Res<AssetServer>, ResMut<Selection>)> =
-        SystemState::new(world);
-    let Ok((mut commands, asset_server, mut selection)) = system_state.get_mut(world) else {
+    let mut system_state: SystemState<(Commands, ResMut<Selection>)> = SystemState::new(world);
+    let Ok((mut commands, mut selection)) = system_state.get_mut(world) else {
         return;
     };
-    let entity = spawn_gltf(&mut commands, &asset_server, path, position, &mut selection);
+    let entity = spawn_gltf(&mut commands, path, position, &mut selection);
     system_state.apply(world);
     crate::scene_io::register_entity_in_ast(world, entity);
 }

--- a/src/entity_ops.rs
+++ b/src/entity_ops.rs
@@ -446,14 +446,15 @@ pub fn spawn_gltf(
     entity
 }
 
-pub fn spawn_gltf_in_world(world: &mut World, path: &str, position: Vec3) {
+fn spawn_gltf_in_world(world: &mut World, path: &str, position: Vec3) {
     let mut system_state: SystemState<(Commands, Res<AssetServer>, ResMut<Selection>)> =
         SystemState::new(world);
     let Ok((mut commands, asset_server, mut selection)) = system_state.get_mut(world) else {
         return;
     };
-    spawn_gltf(&mut commands, &asset_server, path, position, &mut selection);
+    let entity = spawn_gltf(&mut commands, &asset_server, path, position, &mut selection);
     system_state.apply(world);
+    crate::scene_io::register_entity_in_ast(world, entity);
 }
 
 pub fn delete_selected(world: &mut World) {
@@ -1365,6 +1366,7 @@ use crate::core_extension::CoreExtensionInputContext;
 pub(crate) fn add_to_extension(ctx: &mut ExtensionContext) {
     ctx.register_operator::<EntityDeleteOp>()
         .register_operator::<EntityDuplicateOp>()
+        .register_operator::<EntityPlaceGltfOp>()
         .register_operator::<EntityCopyComponentsOp>()
         .register_operator::<EntityPasteComponentsOp>()
         .register_operator::<EntityToggleVisibilityOp>()
@@ -1444,6 +1446,45 @@ fn can_act_on_entities(
 }
 
 // -- Entity lifecycle --------------------------------------------
+
+#[operator(
+    id = "entity.place_gltf",
+    label = "Place GLTF",
+    description = "Place a GLTF asset into the active scene at a world position.",
+    allows_undo = true,
+    params(
+        path(String, doc = "Path to the GLTF asset."),
+        pos_x(f64, doc = "World-space X position."),
+        pos_y(f64, doc = "World-space Y position."),
+        pos_z(f64, doc = "World-space Z position."),
+    )
+)]
+pub(crate) fn entity_place_gltf(
+    params: In<OperatorParameters>,
+    mut commands: Commands,
+) -> OperatorResult {
+    let Some(path) = params.as_str("path").map(str::to_owned) else {
+        warn!("entity.place_gltf: missing `path` param");
+        return OperatorResult::Cancelled;
+    };
+    let Some(x) = params.as_float("pos_x") else {
+        warn!("entity.place_gltf: missing `pos_x` param");
+        return OperatorResult::Cancelled;
+    };
+    let Some(y) = params.as_float("pos_y") else {
+        warn!("entity.place_gltf: missing `pos_y` param");
+        return OperatorResult::Cancelled;
+    };
+    let Some(z) = params.as_float("pos_z") else {
+        warn!("entity.place_gltf: missing `pos_z` param");
+        return OperatorResult::Cancelled;
+    };
+    let position = Vec3::new(x as f32, y as f32, z as f32);
+    commands.queue(move |world: &mut World| {
+        spawn_gltf_in_world(world, &path, position);
+    });
+    OperatorResult::Finished
+}
 
 #[operator(
     id = "entity.delete",

--- a/src/hierarchy.rs
+++ b/src/hierarchy.rs
@@ -148,12 +148,41 @@ impl Plugin for HierarchyPlugin {
     }
 }
 
+/// True when `entity` was spawned by the glTF loader under a `GltfSource`
+/// root rather than authored by the user. Authored entities parented under a
+/// model keep a document node, so the absence of one is what separates the
+/// loader's nodes from anything the user put there.
+fn is_asset_part(world: &World, entity: Entity) -> bool {
+    if world
+        .get_resource::<jackdaw_bsn::SceneBsnAst>()
+        .is_some_and(|doc| doc.ast_for(entity).is_some())
+    {
+        return false;
+    }
+    let mut current = entity;
+    while let Some(ChildOf(parent)) = world.get::<ChildOf>(current) {
+        if world
+            .get::<jackdaw_scene_types::GltfSource>(*parent)
+            .is_some()
+        {
+            return true;
+        }
+        current = *parent;
+    }
+    false
+}
+
 /// Classify a scene entity by its primary component for tree display.
 /// Returns the underlying category (Brush mesh, Camera, Light, etc.)
 /// regardless of whether the entity is inherited from a prefab. Inherited
 /// status is conveyed separately via [`is_inherited_descendant`] so the
 /// outliner can pair the right icon with a muted color.
 fn classify_entity(world: &World, entity: Entity) -> EntityCategory {
+    // Checked before the component-based arms below: a glTF leaf carries
+    // `Mesh3d` and would otherwise read as an ordinary authored mesh.
+    if is_asset_part(world, entity) {
+        return EntityCategory::AssetPart;
+    }
     if world.get::<crate::prefab::IsA>(entity).is_some() {
         return EntityCategory::Prefab;
     }
@@ -178,7 +207,14 @@ fn classify_entity(world: &World, entity: Entity) -> EntityCategory {
     {
         return EntityCategory::Scene;
     }
-    if world.get::<WorldAssetRoot>(entity).is_some() {
+    // `GltfSource` is the authored component and `WorldAssetRoot` the handle
+    // derived from it, so match the former first: otherwise the row's icon
+    // depends on whether the asset has finished loading yet.
+    if world
+        .get::<jackdaw_scene_types::GltfSource>(entity)
+        .is_some()
+        || world.get::<WorldAssetRoot>(entity).is_some()
+    {
         return EntityCategory::Scene;
     }
     // An entity with no type of its own but with children reads as a grouping
@@ -2470,6 +2506,57 @@ mod tests {
         let plain = world.spawn_empty().id();
         assert_eq!(classify_entity(&world, root), EntityCategory::Scene);
         assert_ne!(classify_entity(&world, plain), EntityCategory::Scene);
+    }
+
+    #[test]
+    fn gltf_descendants_classify_as_asset_parts() {
+        // The glTF root is authored; everything the loader spawned under it is
+        // not, including the mesh leaf, which would otherwise read as Mesh.
+        let mut world = World::new();
+        let root = world
+            .spawn(jackdaw_scene_types::GltfSource {
+                path: "models/dungeon.glb".into(),
+                scene_index: 0,
+            })
+            .id();
+        let scene = world.spawn(ChildOf(root)).id();
+        let mesh_leaf = world.spawn((ChildOf(scene), Mesh3d::default())).id();
+
+        assert_eq!(classify_entity(&world, root), EntityCategory::Scene);
+        assert_eq!(classify_entity(&world, scene), EntityCategory::AssetPart);
+        assert_eq!(
+            classify_entity(&world, mesh_leaf),
+            EntityCategory::AssetPart
+        );
+
+        // An authored mesh outside any glTF subtree is unaffected.
+        let authored_mesh = world.spawn(Mesh3d::default()).id();
+        assert_eq!(classify_entity(&world, authored_mesh), EntityCategory::Mesh);
+    }
+
+    #[test]
+    fn authored_children_of_a_model_keep_their_own_category() {
+        // Parenting your own entity under a model is normal (a light on a lamp
+        // prop). It has a document node, so it stays editable and must not be
+        // lumped in with the nodes the loader spawned.
+        let mut world = World::new();
+        world.insert_resource(jackdaw_bsn::SceneBsnAst::default());
+        let root = world
+            .spawn(jackdaw_scene_types::GltfSource {
+                path: "models/dungeon.glb".into(),
+                scene_index: 0,
+            })
+            .id();
+
+        let loader_node = world.spawn(ChildOf(root)).id();
+        assert_eq!(
+            classify_entity(&world, loader_node),
+            EntityCategory::AssetPart
+        );
+
+        let authored = world.spawn((ChildOf(root), PointLight::default())).id();
+        jackdaw_bsn::create_entity_in_ast(&mut world, authored, None);
+        assert_eq!(classify_entity(&world, authored), EntityCategory::Light);
     }
 
     #[test]

--- a/src/scene_io/mod.rs
+++ b/src/scene_io/mod.rs
@@ -69,6 +69,10 @@ const SKIP_COMPONENT_PATHS: &[&str] = &[
     // runtime mesh/material assets into the scene.
     "bevy_mesh::components::Mesh3d",
     "bevy_pbr::mesh_material::MeshMaterial3d<bevy_pbr::pbr_material::StandardMaterial>",
+    // The GLTF instance handle, derived from the authored `GltfSource` by
+    // `derive_world_asset_root`. Writing it into the document would put a
+    // raw asset handle in a file that other machines and the runtime read.
+    "bevy_world_serialization::components::WorldAssetRoot",
     // UI layout output. Bevy recomputes all of it every frame from `Node`, and
     // `ComputedUiTargetCamera` additionally holds a view-local camera entity
     // that means nothing in a saved document.

--- a/src/viewport.rs
+++ b/src/viewport.rs
@@ -679,9 +679,17 @@ fn handle_viewport_drop(
     } else if is_template {
         warn!(".template.json files are no longer supported; use prefabs instead");
     } else {
-        commands.queue(move |world: &mut World| {
-            crate::entity_ops::spawn_gltf_in_world(world, &path, snapped_pos);
-        });
+        commands
+            .operator(crate::entity_ops::EntityPlaceGltfOp::ID)
+            .settings(CallOperatorSettings {
+                creates_history_entry: true,
+                ..default()
+            })
+            .param("path", path)
+            .param("pos_x", snapped_pos.x as f64)
+            .param("pos_y", snapped_pos.y as f64)
+            .param("pos_z", snapped_pos.z as f64)
+            .call();
     }
 }
 

--- a/tests/gltf_authoring.rs
+++ b/tests/gltf_authoring.rs
@@ -1,0 +1,118 @@
+//! Verification for the GLB authoring model:
+//! `GltfSource` is authored, `WorldAssetRoot` is derived.
+
+use bevy::prelude::*;
+use bevy::reflect::TypePath;
+use bevy::world_serialization::WorldAssetRoot;
+use jackdaw_api::prelude::*;
+use jackdaw_api_internal::operator::{CallOperatorSettings, ExecutionContext};
+use jackdaw_commands::CommandHistory;
+
+mod util;
+
+trait Finished {
+    fn assert_finished(self);
+}
+impl Finished for OperatorResult {
+    fn assert_finished(self) {
+        assert_eq!(self, OperatorResult::Finished, "place_gltf did not finish");
+    }
+}
+
+fn place(app: &mut App, path: &str) {
+    app.world_mut()
+        .operator("entity.place_gltf")
+        .settings(CallOperatorSettings {
+            execution_context: ExecutionContext::Invoke,
+            creates_history_entry: true,
+        })
+        .param("path", path.to_string())
+        .param("pos_x", 1.0f64)
+        .param("pos_y", 0.0f64)
+        .param("pos_z", 0.0f64)
+        .call()
+        .expect("dispatch")
+        .assert_finished();
+}
+
+/// The skip list is matched by string, so a typo silently reverts the fix.
+#[test]
+fn world_asset_root_skip_path_matches_real_type_path() {
+    assert!(
+        jackdaw::scene_io::should_skip_component(WorldAssetRoot::type_path()),
+        "WorldAssetRoot type path is {:?}, which the skip list does not match",
+        WorldAssetRoot::type_path()
+    );
+}
+
+#[test]
+fn gltf_source_derives_world_asset_root_and_stays_out_of_the_document() {
+    let mut app = util::editor_test_app();
+    place(&mut app, "models/dungeon.glb");
+
+    let mut q = app
+        .world_mut()
+        .query::<(Entity, &jackdaw_scene_types::GltfSource)>();
+    let (entity, source) = q.single(app.world()).expect("one GltfSource");
+    assert_eq!(source.path, "models/dungeon.glb");
+
+    // Derived, not authored.
+    assert!(
+        app.world().get::<WorldAssetRoot>(entity).is_some(),
+        "the observer should have derived WorldAssetRoot from GltfSource"
+    );
+    let ast = app.world().resource::<jackdaw_bsn::SceneBsnAst>();
+    let node = ast.ast_for(entity).expect("GLB must be in the document");
+    assert!(
+        ast.find_patch_by_type_path(node, WorldAssetRoot::type_path())
+            .is_none(),
+        "the derived handle must not be written into the document"
+    );
+    assert!(
+        ast.find_patch_by_type_path(node, jackdaw_scene_types::GltfSource::type_path())
+            .is_some(),
+        "GltfSource is the authored truth and must be in the document"
+    );
+}
+
+#[test]
+fn undo_redo_restores_a_loadable_gltf() {
+    let mut app = util::editor_test_app();
+    place(&mut app, "models/dungeon.glb");
+
+    let handle_before = current_handle(&mut app);
+
+    app.world_mut()
+        .resource_scope(|world, mut h: Mut<CommandHistory>| h.undo(world));
+    let mut q = app.world_mut().query::<&jackdaw_scene_types::GltfSource>();
+    assert_eq!(q.iter(app.world()).count(), 0, "undo removes the GLB");
+
+    app.world_mut()
+        .resource_scope(|world, mut h: Mut<CommandHistory>| h.redo(world));
+
+    let handle_after = current_handle(&mut app);
+    assert_eq!(
+        handle_before, handle_after,
+        "redo must restore a handle pointing at the same asset, not a default one"
+    );
+}
+
+/// The asset path behind the derived handle, which is what actually decides
+/// whether anything renders. Asserting the component merely exists would pass
+/// with a defaulted handle.
+fn current_handle(app: &mut App) -> String {
+    let mut q = app
+        .world_mut()
+        .query::<(&jackdaw_scene_types::GltfSource, &WorldAssetRoot)>();
+    let (_, root) = q.single(app.world()).expect("one GLB root");
+    let server = app.world().resource::<AssetServer>();
+    let path = server
+        .get_path(root.0.id())
+        .map(|p| p.to_string())
+        .unwrap_or_else(|| panic!("derived handle has no asset path (defaulted handle?)"));
+    assert!(
+        path.contains("dungeon.glb"),
+        "handle points at {path:?}, not the placed model"
+    );
+    path
+}

--- a/tests/operator_undo.rs
+++ b/tests/operator_undo.rs
@@ -196,7 +196,7 @@ fn entity_place_gltf_survives_later_history_and_scene_tabs() {
 
 #[track_caller]
 fn assert_single_renderable_gltf(app: &mut App, path: &str, position: Vec3) -> Entity {
-    let (entity, source, transform, _) = app
+    let (entity, source, transform, root) = app
         .world_mut()
         .query::<(
             Entity,
@@ -208,6 +208,19 @@ fn assert_single_renderable_gltf(app: &mut App, path: &str, position: Vec3) -> E
         .expect("expected one GLB root with its derived render asset");
     assert_eq!(source.path, path);
     assert_eq!(transform.translation, position);
+    // Assert the derived handle actually resolves. Checking only that the
+    // component exists would pass with a defaulted handle, which is exactly
+    // the state that renders nothing.
+    let resolved = app
+        .world()
+        .resource::<AssetServer>()
+        .get_path(root.0.id())
+        .map(|p| p.to_string())
+        .expect("derived WorldAssetRoot handle has no asset path");
+    assert!(
+        resolved.contains("dungeon.glb"),
+        "derived handle points at {resolved:?}, not the placed model"
+    );
     entity
 }
 

--- a/tests/operator_undo.rs
+++ b/tests/operator_undo.rs
@@ -93,6 +93,125 @@ impl OperatorResultExt for OperatorResult {
 }
 
 #[test]
+fn entity_place_gltf_survives_later_history_and_scene_tabs() {
+    let path = "models/dungeon.glb";
+    let position = Vec3::new(1.25, -2.0, 3.5);
+    let mut app = util::editor_test_app();
+    let stack_before = app.world().resource::<CommandHistory>().undo_stack.len();
+
+    app.world_mut()
+        .operator("entity.place_gltf")
+        .settings(CallOperatorSettings {
+            execution_context: ExecutionContext::Invoke,
+            creates_history_entry: true,
+        })
+        .param("path", path.to_string())
+        .param("pos_x", position.x as f64)
+        .param("pos_y", position.y as f64)
+        .param("pos_z", position.z as f64)
+        .call()
+        .expect("entity.place_gltf dispatch resolves")
+        .assert_finished_or_panic("entity.place_gltf");
+
+    assert_eq!(
+        app.world().resource::<CommandHistory>().undo_stack.len(),
+        stack_before + 1,
+        "placement should create exactly one undo entry"
+    );
+
+    let placed = assert_single_renderable_gltf(&mut app, path, position);
+    assert!(
+        app.world()
+            .resource::<jackdaw_bsn::SceneBsnAst>()
+            .ast_for(placed)
+            .is_some(),
+        "placed GLB must be part of the authoritative scene document"
+    );
+
+    // Reproduce the reported sequence: a later rotate action creates another
+    // snapshot, then undo/redo reloads the scene document. The authored GLB
+    // and its derived render root must both survive those reloads.
+    app.world_mut()
+        .operator("tool.rotate")
+        .settings(CallOperatorSettings {
+            execution_context: ExecutionContext::Invoke,
+            creates_history_entry: true,
+        })
+        .call()
+        .expect("tool.rotate dispatch resolves")
+        .assert_finished_or_panic("tool.rotate");
+    assert_eq!(
+        app.world().resource::<CommandHistory>().undo_stack.len(),
+        stack_before + 2,
+        "rotate should create the history entry after placement"
+    );
+
+    app.world_mut()
+        .resource_scope(|world, mut history: Mut<CommandHistory>| history.undo(world));
+    assert_single_renderable_gltf(&mut app, path, position);
+
+    app.world_mut()
+        .resource_scope(|world, mut history: Mut<CommandHistory>| history.redo(world));
+    assert_single_renderable_gltf(&mut app, path, position);
+
+    // Undo both actions, then redo just the placement to verify the placement
+    // snapshot itself also restores a renderable GLB.
+    app.world_mut()
+        .resource_scope(|world, mut history: Mut<CommandHistory>| history.undo(world));
+    app.world_mut()
+        .resource_scope(|world, mut history: Mut<CommandHistory>| history.undo(world));
+    assert_eq!(
+        app.world_mut()
+            .query::<&jackdaw_scene_types::GltfSource>()
+            .iter(app.world())
+            .count(),
+        0,
+        "undo should remove the placed GLB"
+    );
+    app.world_mut()
+        .resource_scope(|world, mut history: Mut<CommandHistory>| history.redo(world));
+    assert_single_renderable_gltf(&mut app, path, position);
+
+    // Scene tabs capture and restore the same authoritative document. A trip
+    // to an empty tab and back must rehydrate the GLB's derived render root.
+    {
+        let mut scenes = app.world_mut().resource_mut::<jackdaw::scenes::Scenes>();
+        *scenes = jackdaw::scenes::Scenes::default();
+        scenes.tabs.push(jackdaw::scenes::SceneTab::new_untitled(1));
+        scenes.tabs.push(jackdaw::scenes::SceneTab::new_untitled(2));
+        scenes.active = 0;
+    }
+    jackdaw::scenes::swap::swap_active_tab(app.world_mut(), 1);
+    assert_eq!(
+        app.world_mut()
+            .query::<&jackdaw_scene_types::GltfSource>()
+            .iter(app.world())
+            .count(),
+        0,
+        "the second tab should remain empty"
+    );
+    jackdaw::scenes::swap::swap_active_tab(app.world_mut(), 0);
+    assert_single_renderable_gltf(&mut app, path, position);
+}
+
+#[track_caller]
+fn assert_single_renderable_gltf(app: &mut App, path: &str, position: Vec3) -> Entity {
+    let (entity, source, transform, _) = app
+        .world_mut()
+        .query::<(
+            Entity,
+            &jackdaw_scene_types::GltfSource,
+            &Transform,
+            &bevy::world_serialization::WorldAssetRoot,
+        )>()
+        .single(app.world())
+        .expect("expected one GLB root with its derived render asset");
+    assert_eq!(source.path, path);
+    assert_eq!(transform.translation, position);
+    entity
+}
+
+#[test]
 fn view_toggle_wireframe_round_trip() {
     let mut app = util::editor_test_app();
     assert_undo_redo_round_trip(&mut app, "view.toggle_wireframe");


### PR DESCRIPTION
- Route GLB drag-and-drop through `entity.place_gltf`.
- Save placed GLBs in the scene document so undo and redo restore them correctly.
- Add regression coverage for rotation history and switching scene tabs.