### PR TITLE
Fixes prefabs not being loaded in game

### DIFF
--- a/crates/jackdaw_bsn/src/lib.rs
+++ b/crates/jackdaw_bsn/src/lib.rs
@@ -15,11 +15,15 @@ pub mod loader;
 pub mod parse;
 pub mod sync;
 pub mod writer;
+pub mod resolver_bsn;
+
+
 
 pub use catalog::{
     CatalogAssetRef, CatalogEntry, LoadedBsnScene, append_assets_to_ast, asset_roots, entity_roots,
     is_asset_root, load_bsn_assets, load_bsn_scene, serialize_assets_to_bsn,
 };
+
 
 pub use parse::{ParseError, parse_bsn};
 
@@ -50,6 +54,7 @@ pub use writer::{
 };
 
 use bevy::prelude::*;
+
 
 /// Registers the BSN scene AST resource for the editor.
 ///

--- a/crates/jackdaw_bsn/src/resolver_bsn.rs
+++ b/crates/jackdaw_bsn/src/resolver_bsn.rs
@@ -13,7 +13,7 @@ use std::path::{Path, PathBuf};
 use bevy::ecs::entity::Entity;
 use bevy::platform::collections::{HashMap, HashSet};
 
-use jackdaw_bsn::{
+use crate::{
     BsnPatch, BsnValue, SceneBsnAst, apply_deltas, bsn_value_as_int, bsn_value_eq, clone_node_into,
     get_bsn_field, shallow_diff,
 };
@@ -69,9 +69,9 @@ impl fmt::Display for ResolveError {
 
 impl std::error::Error for ResolveError {}
 
-pub(crate) const PREFAB_TYPE: &str = "jackdaw::prefab::components::Prefab";
-pub(crate) const PREFAB_ENTITY_ID_TYPE: &str = "jackdaw::prefab::components::PrefabEntityId";
-pub(crate) const ISA_TYPE: &str = "jackdaw::prefab::components::IsA";
+pub const PREFAB_TYPE: &str = "jackdaw::prefab::components::Prefab";
+pub const PREFAB_ENTITY_ID_TYPE: &str = "jackdaw::prefab::components::PrefabEntityId";
+pub const ISA_TYPE: &str = "jackdaw::prefab::components::IsA";
 
 /// A prefab source lookup: maps a project-relative prefab path to its
 /// cached BSN document. Tests back this with a `HashMap<PathBuf,
@@ -467,13 +467,13 @@ fn remove_name_patch(ast: &mut SceneBsnAst, node: Entity) {
 /// The `PrefabEntityId` on `node`, read from its whole-component value. The
 /// id serializes as a tuple struct wrapping one integer; a bare integer is
 /// also accepted.
-pub(crate) fn read_prefab_entity_id(ast: &SceneBsnAst, node: Entity) -> Option<u32> {
+pub fn read_prefab_entity_id(ast: &SceneBsnAst, node: Entity) -> Option<u32> {
     let whole = get_bsn_field(ast, node, PREFAB_ENTITY_ID_TYPE, "")?;
     bsn_value_as_int(&whole).and_then(|i| u32::try_from(i).ok())
 }
 
 /// The `IsA.source` path on `isa_node`, read as a string subfield.
-pub(crate) fn read_isa_source(ast: &SceneBsnAst, isa_node: Entity) -> Option<PathBuf> {
+pub fn read_isa_source(ast: &SceneBsnAst, isa_node: Entity) -> Option<PathBuf> {
     match get_bsn_field(ast, isa_node, ISA_TYPE, "source")? {
         BsnValue::String(s) => Some(PathBuf::from(s)),
         _ => None,
@@ -482,7 +482,7 @@ pub(crate) fn read_isa_source(ast: &SceneBsnAst, isa_node: Entity) -> Option<Pat
 
 /// The `IsA.deleted` list on `isa_node`, read as a list of integer ids.
 /// An absent or non-list value yields an empty vector.
-pub(crate) fn read_isa_deleted(ast: &SceneBsnAst, isa_node: Entity) -> Vec<u32> {
+pub fn read_isa_deleted(ast: &SceneBsnAst, isa_node: Entity) -> Vec<u32> {
     match get_bsn_field(ast, isa_node, ISA_TYPE, "deleted") {
         Some(BsnValue::List(items)) => items
             .iter()
@@ -494,7 +494,7 @@ pub(crate) fn read_isa_deleted(ast: &SceneBsnAst, isa_node: Entity) -> Vec<u32> 
 
 /// Convert a whole-component `BsnValue` into the patch that stores it.
 /// Non-component shapes (scalars, lists, maps) yield `None`.
-pub(crate) fn value_to_patch(value: BsnValue) -> Option<BsnPatch> {
+pub fn value_to_patch(value: BsnValue) -> Option<BsnPatch> {
     match value {
         BsnValue::Struct(data) => Some(BsnPatch::Struct(data)),
         BsnValue::TupleStruct(data) => Some(BsnPatch::TupleStruct(data)),
@@ -507,7 +507,7 @@ pub(crate) fn value_to_patch(value: BsnValue) -> Option<BsnPatch> {
 /// existing patch or inserting a new one. Reflection-registry independent:
 /// it manipulates patches directly rather than routing through
 /// `set_bsn_field`, so it works for any authored type path.
-pub(crate) fn set_whole_component(
+pub fn set_whole_component(
     ast: &mut SceneBsnAst,
     node: Entity,
     type_path: &str,
@@ -528,13 +528,13 @@ pub(crate) fn set_whole_component(
 
 /// Deep-copy an entire scene document into a fresh one. Thin alias over
 /// [`SceneBsnAst::deep_clone`] kept for the resolver's call sites.
-pub(crate) fn clone_scene(src: &SceneBsnAst) -> SceneBsnAst {
+pub fn clone_scene(src: &SceneBsnAst) -> SceneBsnAst {
     src.deep_clone()
 }
 #[cfg(test)]
 mod tests {
     use super::*;
-    use jackdaw_bsn::{BsnField, BsnStructData, BsnStructFields, BsnTupleStructData};
+    use crate::{BsnField, BsnStructData, BsnStructFields, BsnTupleStructData};
 
     fn f(name: &str, value: BsnValue) -> BsnField {
         BsnField {

--- a/crates/jackdaw_runtime/src/lib.rs
+++ b/crates/jackdaw_runtime/src/lib.rs
@@ -10,15 +10,31 @@ use bevy::prelude::*;
 use bevy::reflect::TypeRegistry;
 #[cfg(feature = "render")]
 use bevy::world_serialization::{WorldAsset, WorldAssetRoot};
+use jackdaw_bsn::resolver_bsn::{ISA_TYPE, PREFAB_ENTITY_ID_TYPE, read_isa_source, resolve_scene};
 use jackdaw_bsn::{
-    BsnApplyAssets, BsnPatch, BsnSceneAssets, BsnValue, SceneBsnAst, apply_component_patch,
-    bsn_value_to_reflect, load_bsn_assets, parse_bsn_text,
+    BsnApplyAssets,
+    BsnPatch,
+    BsnSceneAssets,
+    BsnValue,
+    SceneBsnAst,
+    apply_component_patch,
+    bsn_value_to_reflect,
+    emit_scene,
+    load_bsn_assets,
+    parse_bsn_text,
 };
 use jackdaw_ui::UiCanvas;
 
 pub use jackdaw_scene_types::{
-    Brush, BrushFaceData, CustomProperties, EditorCategory, EditorDescription, EditorHidden,
-    GltfSource, PropertyValue, SkipSerialization,
+    Brush,
+    BrushFaceData,
+    CustomProperties,
+    EditorCategory,
+    EditorDescription,
+    EditorHidden,
+    GltfSource,
+    PropertyValue,
+    SkipSerialization,
 };
 
 #[cfg(feature = "pie")]
@@ -32,14 +48,23 @@ pub use pie_windowless::{maybe_windowless, windowless_requested};
 
 mod schema_cli;
 pub use schema_cli::{
-    SCHEMA_FLAG, extract_schema_and_exit_if_requested, extract_schema_json,
+    SCHEMA_FLAG,
+    extract_schema_and_exit_if_requested,
+    extract_schema_json,
     schema_extraction_requested,
 };
 
 pub mod prelude {
     pub use crate::{
-        EditorCategory, EditorDescription, EditorHidden, JackdawCatalog, JackdawCatalogPath,
-        JackdawPlugin, JackdawSceneMember, JackdawSceneRoot, SkipSerialization,
+        EditorCategory,
+        EditorDescription,
+        EditorHidden,
+        JackdawCatalog,
+        JackdawCatalogPath,
+        JackdawPlugin,
+        JackdawSceneMember,
+        JackdawSceneRoot,
+        SkipSerialization,
     };
 }
 
@@ -225,16 +250,63 @@ impl AssetLoader for JackdawSceneLoader {
         // error rather than silently spawning nothing later. The document is
         // rebuilt from `bsn` on spawn (it owns a `World` and cannot be stored
         // in the asset).
-        parse_bsn_text(text).map_err(|e| JackdawLoadError::Parse(e.to_string()))?;
+        let ast = parse_bsn_text(text).map_err(|e| JackdawLoadError::Parse(e.to_string()))?;
+        let isa_nodes = ast.entities_with_component(ISA_TYPE);
+        let nodes_path = isa_nodes
+            .iter()
+            .filter_map(|node| read_isa_source(&ast, *node))
+            .collect::<Vec<_>>();
+
+        let mut ast_prefabs: HashMap<PathBuf, SceneBsnAst> = HashMap::new();
+
+        for path in nodes_path {
+            let joined_path = load_context
+                .path()
+                .path()
+                .parent()
+                .unwrap_or(Path::new(""))
+                .to_owned()
+                .join(&path);
+
+            let asset_bytes = load_context
+                .read_asset_bytes(joined_path)
+                .await
+                .map_err(|e| JackdawLoadError::Parse(e.to_string()))?;
+
+            let bytes_to_str = std::str::from_utf8(&asset_bytes)
+                .map_err(|e| JackdawLoadError::Parse(e.to_string()))?;
+
+            let parsed_bytes =
+                parse_bsn_text(bytes_to_str).map_err(|e| JackdawLoadError::Parse(e.to_string()))?;
+            ast_prefabs.insert(path, parsed_bytes);
+        }
+
+        let lookup = |p: &Path| ast_prefabs.get(p);
+
+        let mut resolved_scene =
+            resolve_scene(&ast, &lookup).map_err(|e| JackdawLoadError::Parse(e.to_string()))?;
+
+        resolved_scene
+            .entities_with_component(ISA_TYPE)
+            .iter()
+            .for_each(|e| resolved_scene.remove_component_patch(*e, ISA_TYPE));
+
+        resolved_scene
+            .entities_with_component(PREFAB_ENTITY_ID_TYPE)
+            .iter()
+            .for_each(|e| resolved_scene.remove_component_patch(*e, PREFAB_ENTITY_ID_TYPE));
 
         let source_path = load_context.path().path();
         let parent_path = source_path.parent().unwrap_or(Path::new("")).to_owned();
+
         let stem = source_path
             .file_stem()
             .map(|s| s.to_string_lossy().into_owned());
 
+        let bsn = emit_scene(&resolved_scene);
+
         Ok(JackdawScene {
-            bsn: text.to_owned(),
+            bsn,
             parent_path,
             stem,
         })

--- a/src/prefab/mod.rs
+++ b/src/prefab/mod.rs
@@ -9,7 +9,7 @@ pub mod canonical_path;
 pub mod components;
 pub mod operators;
 pub mod overrides_bsn;
-pub mod resolver_bsn;
+
 pub mod save_load;
 pub mod sync;
 pub mod watcher;
@@ -17,6 +17,7 @@ pub mod watcher;
 pub use cache::PrefabAstCache;
 pub use canonical_path::{CanonicalPrefabPath, canonical_prefab_path};
 pub use components::{IsA, Prefab, PrefabEntityId};
+pub use jackdaw_bsn::resolver_bsn;
 
 use bevy::prelude::*;
 


### PR DESCRIPTION
Fix #362 

Based on instructions provided by Joe [on Discord
](https://discord.com/channels/1486394042563428388/1486394043096236117/1541076779006038046)

<details>
<summary>Details</summary>

> that warning is a red herring i think.

jackdaw_runtime has no prefab support at all i just saw. scenes on disk keep their IsA nodes, and the editor expands them at load time with code that lives only in the editor crate. so a prefab instance reaches your game as an entity with none of its inherited subtree - which i suspect is the issue you are seeing

the good news is the resolver is very portable. resolver_bsn.l imports only jackdaw_bsn and bevy ecs/platform  and std and jackdaw_runtime already depends on jackdaw_bsn. so:

1. move resolver_bsn into jackdaw_bsn as-is. leave a re-export in src/prefab/ and update/refactor in the dependent calls

2. resolve in the asset loader, not at spawn. JackdawSceneLoader::load has a LoadContext, and load_context.read_asset_bytes gives you each prefab's bytes through the asset system - parse those, build the PrefabLookup, call resolve_scene, and store the *resolved* text in JackdawScene.bsn. spawn_loaded_scenes then needs no changes at all. bonus: read_asset_bytes registers a load dependency, so prefab edits hot-reload the scene for free.

   the editor's version of this is src/scene_io/load.rs if you want a reference. I’d copy this approach for warning logs

3. after expansion the instance root still carries the IsA patch (resolve_scene only filters it when inheriting root components, it doesn't strip it from the instance). so either register the prefab types in the runtime, or strip IsA and PrefabEntityId from the resolved doc on the runtime path. the editor needs them for round-tripping, the runtime shouldn’t.

</details>

LLM usage discolure: the code was entirely written by me, but an LLM was used to help me understand the provided instructions and to answer my questions about the steps needed to accomplish the taks.

