### PR TITLE
Redirect an edge only when the SDK built the features it needs

### DIFF
--- a/crates/jackdaw_cli/src/package.rs
+++ b/crates/jackdaw_cli/src/package.rs
@@ -407,8 +407,9 @@ fn package(workspace: &Path, out: &Path) -> Result<String, String> {
     let mut shipped_manifest = String::new();
     let mut rlibs = 0usize;
     for line in manifest_text.lines() {
-        let mut parts = line.splitn(3, ' ');
-        let (Some(name), Some(version), Some(abspath)) = (parts.next(), parts.next(), parts.next())
+        let mut parts = line.splitn(4, ' ');
+        let (Some(name), Some(version), Some(enabled), Some(abspath)) =
+            (parts.next(), parts.next(), parts.next(), parts.next())
         else {
             return Err(format!("malformed SDK manifest line: {line}"));
         };
@@ -417,7 +418,10 @@ fn package(workspace: &Path, out: &Path) -> Result<String, String> {
             .file_name()
             .ok_or_else(|| format!("manifest artifact has no filename: {abspath}"))?;
         copy(src, &deps_out.join(base))?;
-        shipped_manifest.push_str(&format!("{name} {version} {}\n", base.to_string_lossy()));
+        shipped_manifest.push_str(&format!(
+            "{name} {version} {enabled} {}\n",
+            base.to_string_lossy()
+        ));
         rlibs += 1;
     }
     write(&sdk_out.join("manifest.txt"), &shipped_manifest)?;

--- a/crates/jackdaw_project_build/src/plan.rs
+++ b/crates/jackdaw_project_build/src/plan.rs
@@ -29,6 +29,18 @@ use jackdaw_env::rust_env_command;
 
 use crate::sdk_paths::SdkPaths;
 
+const NO_FEATURES: &str = "-";
+
+fn parse_feature_list(list: &str) -> BTreeSet<String> {
+    if list == NO_FEATURES {
+        return BTreeSet::new();
+    }
+    list.split(',')
+        .filter(|f| !f.is_empty())
+        .map(str::to_string)
+        .collect()
+}
+
 #[derive(Debug)]
 pub enum PlanError {
     Io(std::io::Error),
@@ -63,6 +75,7 @@ impl From<std::io::Error> for PlanError {
 /// workspace build in dev.
 pub struct SdkManifest {
     artifacts: BTreeMap<(String, String), String>,
+    features: BTreeMap<(String, String), BTreeSet<String>>,
 }
 
 impl SdkManifest {
@@ -70,19 +83,22 @@ impl SdkManifest {
     pub fn load(path: &Path) -> Result<Self, PlanError> {
         let contents = std::fs::read_to_string(path)?;
         let mut artifacts = BTreeMap::new();
+        let mut features = BTreeMap::new();
         for line in contents.lines() {
-            let mut parts = line.splitn(3, ' ');
-            let (Some(name), Some(version), Some(artifact)) =
-                (parts.next(), parts.next(), parts.next())
+            let mut parts = line.splitn(4, ' ');
+            let (Some(name), Some(version), Some(enabled), Some(artifact)) =
+                (parts.next(), parts.next(), parts.next(), parts.next())
             else {
                 return Err(PlanError::Parse(format!("bad manifest line: {line}")));
             };
-            artifacts.insert(
-                (name.to_string(), version.to_string()),
-                artifact.to_string(),
-            );
+            let key = (name.to_string(), version.to_string());
+            features.insert(key.clone(), parse_feature_list(enabled));
+            artifacts.insert(key, artifact.to_string());
         }
-        Ok(Self { artifacts })
+        Ok(Self {
+            artifacts,
+            features,
+        })
     }
 
     /// Generate the manifest from a dev workspace: the SDK's runtime
@@ -157,6 +173,7 @@ impl SdkManifest {
         };
         let roots = build_private_roots(sdk);
         let mut artifacts = BTreeMap::new();
+        let mut features: BTreeMap<(String, String), BTreeSet<String>> = BTreeMap::new();
         let mut link_paths: BTreeSet<String> = BTreeSet::new();
         let mut host_deps: BTreeSet<String> = BTreeSet::new();
         for line in String::from_utf8_lossy(&output.stdout).lines() {
@@ -258,6 +275,14 @@ impl SdkManifest {
                         .find(|f| f.ends_with(".rmeta"))
                 });
             if let Some(artifact) = artifact {
+                let enabled = msg["features"]
+                    .as_array()
+                    .into_iter()
+                    .flatten()
+                    .filter_map(|f| f.as_str())
+                    .map(str::to_string)
+                    .collect();
+                features.insert((name.clone(), version.to_string()), enabled);
                 artifacts.insert((name, version.to_string()), artifact.to_string());
             }
         }
@@ -290,7 +315,10 @@ impl SdkManifest {
 
         write_link_paths(&link_paths_path(&sdk.manifest), &link_paths)?;
         write_lines(&host_deps_path(&sdk.manifest), &host_deps)?;
-        let manifest = Self { artifacts };
+        let manifest = Self {
+            artifacts,
+            features,
+        };
         manifest.write(&sdk.manifest)?;
         Ok(manifest)
     }
@@ -298,7 +326,13 @@ impl SdkManifest {
     pub fn write(&self, path: &Path) -> Result<(), PlanError> {
         let mut file = std::fs::File::create(path)?;
         for ((name, version), artifact) in &self.artifacts {
-            writeln!(file, "{name} {version} {artifact}")?;
+            let enabled = self
+                .features
+                .get(&(name.clone(), version.clone()))
+                .map(|set| set.iter().cloned().collect::<Vec<_>>().join(","))
+                .filter(|list| !list.is_empty())
+                .unwrap_or_else(|| NO_FEATURES.to_string());
+            writeln!(file, "{name} {version} {enabled} {artifact}")?;
         }
         Ok(())
     }
@@ -330,6 +364,12 @@ impl SdkManifest {
             .take(limit)
             .map(|((name, version), _)| format!("{name} {version}"))
             .collect()
+    }
+
+    pub fn covers(&self, name: &str, version: &str, wanted: &BTreeSet<String>) -> bool {
+        self.features
+            .get(&(name.to_string(), version.to_string()))
+            .is_some_and(|enabled| wanted.is_subset(enabled))
     }
 
     pub fn artifact(&self, name: &str, version: &str) -> Option<&str> {
@@ -422,6 +462,22 @@ fn plan_contents(
     let mut edges = 0;
     let mut absent: BTreeSet<String> = BTreeSet::new();
     let empty = Vec::new();
+    let no_features = BTreeSet::new();
+    let mut wanted: BTreeMap<String, BTreeSet<String>> = BTreeMap::new();
+    for node in metadata["resolve"]["nodes"].as_array().unwrap_or(&empty) {
+        if let Some(id) = node["id"].as_str() {
+            wanted.insert(
+                id.to_string(),
+                node["features"]
+                    .as_array()
+                    .into_iter()
+                    .flatten()
+                    .filter_map(|f| f.as_str())
+                    .map(str::to_string)
+                    .collect(),
+            );
+        }
+    }
     for node in metadata["resolve"]["nodes"].as_array().unwrap_or(&empty) {
         let Some(consumer_id) = node["id"].as_str() else {
             continue;
@@ -445,6 +501,13 @@ fn plan_contents(
                 continue;
             };
             if let Some(artifact) = manifest.artifact(&dep_name, dep_version) {
+                if !manifest.covers(
+                    &dep_name,
+                    dep_version,
+                    wanted.get(pkg_id).unwrap_or(&no_features),
+                ) {
+                    continue;
+                }
                 // Key the edge on the consumer's exact version: a graph
                 // can hold two versions of one crate (two `rand`s), each
                 // wanting a different version of the same dependency, so
@@ -706,13 +769,23 @@ mod tests {
             ("glam".to_string(), "0.32.1".to_string()),
             "/sdk/deps/libglam-abc.rlib".to_string(),
         );
-        let manifest = SdkManifest { artifacts };
+        let mut features = BTreeMap::new();
+        features.insert(
+            ("glam".to_string(), "0.32.1".to_string()),
+            BTreeSet::from(["std".to_string()]),
+        );
+        let manifest = SdkManifest {
+            artifacts,
+            features,
+        };
         manifest.write(&path).unwrap();
         let back = SdkManifest::load(&path).unwrap();
         assert_eq!(
             back.artifact("glam", "0.32.1"),
             Some("/sdk/deps/libglam-abc.rlib")
         );
+        assert!(back.covers("glam", "0.32.1", &BTreeSet::from(["std".to_string()])));
+        assert!(!back.covers("glam", "0.32.1", &BTreeSet::from(["serde".to_string()])));
     }
 
     #[test]
@@ -778,17 +851,43 @@ mod tests {
     }
 
     fn sdk_manifest(entries: &[&str]) -> SdkManifest {
-        let artifacts = entries
-            .iter()
-            .map(|spec| {
-                let (name, version) = spec.split_once('@').expect("name@version");
-                (
-                    (name.to_string(), version.to_string()),
-                    format!("lib{name}-abc.rlib"),
-                )
-            })
-            .collect();
-        SdkManifest { artifacts }
+        sdk_manifest_built_with(
+            &entries
+                .iter()
+                .map(|spec| (*spec, &[][..]))
+                .collect::<Vec<_>>(),
+        )
+    }
+
+    fn sdk_manifest_built_with(entries: &[(&str, &[&str])]) -> SdkManifest {
+        let mut artifacts = BTreeMap::new();
+        let mut features = BTreeMap::new();
+        for (spec, enabled) in entries {
+            let (name, version) = spec.split_once('@').expect("name@version");
+            let key = (name.to_string(), version.to_string());
+            artifacts.insert(key.clone(), format!("lib{name}-abc.rlib"));
+            features.insert(
+                key,
+                enabled
+                    .iter()
+                    .map(|f| (*f).to_string())
+                    .collect::<BTreeSet<_>>(),
+            );
+        }
+        SdkManifest {
+            artifacts,
+            features,
+        }
+    }
+
+    fn resolving(mut graph: serde_json::Value, spec: &str, features: &[&str]) -> serde_json::Value {
+        let id = package_id(spec);
+        for node in graph["resolve"]["nodes"].as_array_mut().expect("nodes") {
+            if node["id"] == serde_json::Value::String(id.clone()) {
+                node["features"] = serde_json::json!(features);
+            }
+        }
+        graph
     }
 
     fn shadows(metadata: &serde_json::Value, manifest: &SdkManifest) -> Vec<String> {
@@ -918,6 +1017,39 @@ mod tests {
         ]);
         let manifest = sdk_manifest(&["serde@1.0.228"]);
         assert_eq!(shadows(&graph, &manifest), ["serde"]);
+    }
+
+    #[test]
+    fn an_edge_the_sdk_did_not_build_the_features_for_is_not_redirected() {
+        let deps_dir = std::env::temp_dir().join(format!("jackdaw_cover_{}", std::process::id()));
+        std::fs::create_dir_all(&deps_dir).unwrap();
+        std::fs::write(deps_dir.join("librand-abc.rlib"), b"rlib").unwrap();
+
+        let graph = resolving(
+            metadata(
+                &[
+                    ("shim@0.0.0", &["my-game@0.1.0"]),
+                    ("my-game@0.1.0", &["rand@0.10.1"]),
+                    ("rand@0.10.1", &[]),
+                ],
+                &[],
+            ),
+            "rand@0.10.1",
+            &["std", "std_rng"],
+        );
+
+        let narrow = sdk_manifest_built_with(&[("rand@0.10.1", &["std"])]);
+        let (contents, edges) = plan_contents(&graph, &narrow, &deps_dir).unwrap();
+        let contents = String::from_utf8(contents).unwrap();
+        assert_eq!(edges, 0, "{contents}");
+        assert!(!contents.contains("my_game@0.1.0:rand="), "{contents}");
+
+        let wide = sdk_manifest_built_with(&[("rand@0.10.1", &["std", "std_rng"])]);
+        let (contents, edges) = plan_contents(&graph, &wide, &deps_dir).unwrap();
+        let contents = String::from_utf8(contents).unwrap();
+        assert_eq!(edges, 1, "{contents}");
+
+        let _ = std::fs::remove_dir_all(&deps_dir);
     }
 
     /// Both halves of the plan, over one graph: an edge line per covered


### PR DESCRIPTION
Fixes #376.

`plan_contents` decides a redirect on `(name, version)` alone:

```rust
if let Some(artifact) = manifest.artifact(&dep_name, dep_version) {
```

Features are never compared. Where the SDK built a crate with fewer features than the project
resolves, the consumer is handed an artifact missing the items it compiles against — and rustc
reports it against whichever crate happened to hold the edge, nowhere near the SDK.

`rand` is the case that surfaced it. It reaches the SDK closure only through `bevy_math`, which takes
it with `default-features = false`, so the SDK's build has no `std_rng`:

```
$ rustc -Zls=all sdk/x86_64-unknown-linux-gnu/deps/librand-2bcf3937eed4e3fa.rlib
=External Dependencies=
1..19  core, alloc, compiler_builtins, std, libc, … panic_unwind
20 rand_core-4b9079fcaee34cd4 hash 48f517bb6e379c77d77211541fe85022 kind Unconditional public
```

`lightyear_link` and `lightyear_netcode` 0.29 call `rand::rng()` / `rand::random()`, redirect onto
that build, and fail.

## The change

`manifest.txt` gains a field — the feature set each artifact was built with — and an edge whose
resolved features the SDK does not cover is left out of the plan. The crate then builds locally,
inside the shadow set that already holds it.

Both halves of the data already exist: the project side is `resolve.nodes[].features` from the
`cargo metadata` document `plan.rs` already parses (no extra cargo run), and the SDK side is the
`features` array on the `compiler-artifact` messages `generate` already reads.

New test `an_edge_the_sdk_did_not_build_the_features_for_is_not_redirected` pins it — same graph,
narrow SDK manifest yields 0 edges, wide manifest yields 1. Mutation-checked: deleting the `covers`
guard fails it (`left: 1, right: 0`). Full `jackdaw_project_build` suite passes (91), clippy clean.

## What this does and does not fix, on main

Worth separating, because #376 was filed against rc.7 and main already moved:

- The reported `can't find crate for chacha20` is **already fixed on main** by #329's downward-closed
  shadow set — `chacha20` becomes a shadow, so it compiles against the project's `rand_core` rather
  than the SDK's. Checked against the reporting project's real `cargo metadata`.
- What remains on main is the featureless-`rand` redirect above: `lightyear_link` is not a shadow, so
  its `rand` edge still points at the SDK build, and it would fail on `cannot find function rng in
  crate rand`. That is what this PR fixes.

## Tradeoff, stated plainly

Declining an edge grows the shadow side, and `shadow_names`' own comment is explicit that neither
direction is free. Here it trades a hard failure for a possible **redirected-consumer straddle**: the
SDK's `bevy_math` was built against the SDK's `rand`, so a consumer that uses `bevy_math` APIs whose
signatures mention `rand` types could now see two `rand`s and get a trait mismatch instead. Nothing
plan-side can remove that — only the SDK building `rand` with the features projects ask for can.

So if you want the narrow, zero-straddle fix for the release and this for later, adding
`rand = "0.10"` to `crates/jackdaw_sdk/Cargo.toml` does it in one line: the SDK's resolution becomes
a superset (the rule that manifest already states for extension features), `chacha20` enters the
closure, and every consumer keeps redirecting consistently. That was this PR's first version; happy
to restore it instead, or ship both.

## Compatibility

The manifest format changes, so an SDK packaged by an older jackdaw fails `SdkManifest::load` with
`bad manifest line` until regenerated. `jackdaw_cli`'s packager carries the new field through.
