### PR TITLE
Play authored animation sets on skeletons loaded from glTF

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -158,6 +158,7 @@ jobs:
         # new dependency cannot silently drop out of the release.
         run: >
           cargo publish --locked
+          -p jackdaw_animation_runtime
           -p jackdaw_api
           -p jackdaw_api_internal
           -p jackdaw_api_macros

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4830,6 +4830,7 @@ dependencies = [
  "image",
  "include_dir",
  "jackdaw_animation",
+ "jackdaw_animation_runtime",
  "jackdaw_api",
  "jackdaw_api_internal",
  "jackdaw_avian_integration",
@@ -4902,6 +4903,14 @@ dependencies = [
  "jackdaw_node_graph",
  "jackdaw_scene_types",
  "lucide-icons",
+ "serde",
+]
+
+[[package]]
+name = "jackdaw_animation_runtime"
+version = "0.19.0"
+dependencies = [
+ "bevy",
  "serde",
 ]
 
@@ -5286,6 +5295,7 @@ version = "0.19.0"
 dependencies = [
  "avian3d",
  "bevy",
+ "jackdaw_animation_runtime",
  "jackdaw_avian_integration",
  "jackdaw_bind",
  "jackdaw_bsn",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -104,6 +104,7 @@ jackdaw_hull.workspace = true
 jackdaw_material.workspace = true
 jackdaw_node_graph.workspace = true
 jackdaw_animation.workspace = true
+jackdaw_animation_runtime.workspace = true
 jackdaw_avian_integration.workspace = true
 # Optional, activated by the default-on `multiplayer` feature. Together
 # these bundle the editor-only networking authoring extension (proxy
@@ -246,6 +247,7 @@ jackdaw_hull = { version = "0.19.0", path = "crates/jackdaw_hull" }
 jackdaw_material = { version = "0.19.0", path = "crates/jackdaw_material" }
 jackdaw_node_graph = { version = "0.19.0", path = "crates/jackdaw_node_graph" }
 jackdaw_animation = { version = "0.19.0", path = "crates/jackdaw_animation" }
+jackdaw_animation_runtime = { version = "0.19.0", path = "crates/jackdaw_animation_runtime" }
 jackdaw_fuzzy = { version = "0.19.0", path = "crates/jackdaw_fuzzy" }
 jackdaw_localization = { version = "0.19.0", path = "crates/jackdaw_localization" }
 glam = { version = "0.32", features = ["serde"] }

--- a/crates/jackdaw_animation_runtime/Cargo.toml
+++ b/crates/jackdaw_animation_runtime/Cargo.toml
@@ -1,0 +1,27 @@
+[package]
+name = "jackdaw_animation_runtime"
+version.workspace = true
+edition = "2024"
+description = "Binds authored animation sets to their glTF skeletons and plays the state they ask for"
+license = "MIT OR Apache-2.0"
+repository = "https://github.com/jbuehler23/jackdaw"
+
+[dependencies]
+bevy = { version = "0.19", default-features = false, features = [
+    "std",
+    "bevy_animation",
+    "bevy_asset",
+    "bevy_log",
+    # `Gltf`, whose named animations are where an authored state finds its
+    # clip. It carries `bevy_mesh` along, which is where `SkinnedMesh` lives,
+    # and `gltf_animation` is what puts the clips on the loaded file at all.
+    "bevy_gltf",
+    "gltf_animation",
+    # The bodies and the clips arrive as spawned scenes, so binding only ever
+    # sees entities `bevy_scene` produced.
+    "bevy_scene",
+] }
+serde = { workspace = true, features = ["derive"] }
+
+[lints]
+workspace = true

--- a/crates/jackdaw_animation_runtime/src/lib.rs
+++ b/crates/jackdaw_animation_runtime/src/lib.rs
@@ -352,15 +352,7 @@ fn merge_part_skeletons(
                 .into_iter()
                 .filter(|&mesh| skins.contains(mesh))
                 .collect();
-            let part_bones = descendants(part, &children)
-                .into_iter()
-                .filter(|&bone| names.contains(bone))
-                .count();
-
-            let remapped = (part_bones == primary_joints.len())
-                .then(|| remap_joints(&part_meshes, &primary_joints, &skins, &names))
-                .flatten();
-            let Some(remapped) = remapped else {
+            let Some(remapped) = remap_joints(&part_meshes, &primary_joints, &skins, &names) else {
                 warn!(
                     "an animated part does not answer to the same bone names as the skeleton it \
                      was placed under, so it keeps its own"

--- a/crates/jackdaw_animation_runtime/src/lib.rs
+++ b/crates/jackdaw_animation_runtime/src/lib.rs
@@ -1,0 +1,611 @@
+//! Playing an authored set of animation states on a skeleton loaded from glTF.
+//!
+//! A rig is rarely one file. The clips are exported once against a reference
+//! armature, and the bodies that play them are exported separately, so the
+//! animation player cannot be built by whatever loaded either half; it has to
+//! be built once both have spawned. This crate holds that binding step, the
+//! small state machine an author writes beside it, and the joint remapping
+//! that lets several parts wear one skeleton.
+//!
+//! Clips address bones by a hash of their name path rather than by entity, so
+//! a clip exported against one armature drives any armature whose bones carry
+//! the same names. [`AnimationRuntimePlugin`] writes those ids itself because
+//! Bevy's glTF loader only writes them for a file that carries animations of
+//! its own, which a body exported without clips does not.
+
+#![deny(missing_docs)]
+
+use std::{
+    collections::{HashMap, HashSet},
+    time::Duration,
+};
+
+use bevy::{
+    animation::{
+        AnimatedBy, AnimationTargetId, RepeatAnimation,
+        graph::{AnimationGraph, AnimationGraphHandle, AnimationNodeIndex},
+        transition::AnimationTransitions,
+    },
+    gltf::Gltf,
+    mesh::skinning::SkinnedMesh,
+    prelude::*,
+};
+use serde::{Deserialize, Serialize};
+
+/// The clips an entity can play and the states that choose between them.
+///
+/// A component equal to its `Default` emits as a bare type path, so changing
+/// this `Default` silently reinterprets every scene already saved that way.
+#[derive(Component, Reflect, Serialize, Deserialize, Debug, Clone, PartialEq)]
+#[reflect(Component, Default)]
+pub struct AnimationSet {
+    /// Assets-relative paths of the glTF files holding the clips. A state
+    /// names one of them by its position in this list.
+    pub sources: Vec<String>,
+    /// Every state this set can be asked for.
+    pub states: Vec<AnimationStateDef>,
+    /// The state played as soon as the set binds. Empty asks for nothing.
+    pub default_state: String,
+    /// Name of the descendant carrying the skeleton the clips drive.
+    pub skeleton_root: String,
+}
+
+impl Default for AnimationSet {
+    fn default() -> Self {
+        Self {
+            sources: Vec::new(),
+            states: Vec::new(),
+            default_state: String::new(),
+            skeleton_root: "Armature".to_string(),
+        }
+    }
+}
+
+/// One state of an [`AnimationSet`]: which clip it plays, and how.
+#[derive(Reflect, Serialize, Deserialize, Debug, Clone, PartialEq)]
+#[reflect(Default)]
+pub struct AnimationStateDef {
+    /// What an [`AnimationState`] names to ask for this state.
+    pub name: String,
+    /// Index into [`AnimationSet::sources`] of the file holding the clip.
+    pub source: usize,
+    /// Name the clip carries in that file.
+    pub clip: String,
+    /// Whether the clip runs forever or once.
+    pub looped: bool,
+    /// Seconds over which the state it replaces fades out.
+    pub transition_secs: f32,
+    /// Playback rate, as a multiple of the clip's authored speed.
+    pub speed: f32,
+    /// State to fall back to once a non-looping clip has run out.
+    pub then: Option<String>,
+}
+
+impl Default for AnimationStateDef {
+    fn default() -> Self {
+        Self {
+            name: String::new(),
+            source: 0,
+            clip: String::new(),
+            looped: true,
+            transition_secs: 0.15,
+            speed: 1.0,
+            then: None,
+        }
+    }
+}
+
+/// The state an [`AnimationSet`] is being asked to play.
+///
+/// Whatever drives the entity writes this: game logic in a running world, the
+/// operator that previews a state in the editor. Empty asks for nothing, so a
+/// set with no default holds whatever pose its skeleton spawned in.
+#[derive(Component, Reflect, Serialize, Deserialize, Debug, Clone, Default, PartialEq, Eq)]
+#[reflect(Component, Default)]
+pub struct AnimationState(
+    /// Name of the wanted [`AnimationStateDef`].
+    pub String,
+);
+
+/// Handles to the glTF files an [`AnimationSet`] draws its clips from.
+///
+/// Held on the entity so the files stay loaded for as long as the graph built
+/// out of them is playing. Inserting it before the set binds skips the load,
+/// which is what an app that already holds the files should do.
+#[derive(Component, Debug, Default)]
+pub struct AnimationSources(
+    /// One handle per entry of [`AnimationSet::sources`], in the same order.
+    pub Vec<Handle<Gltf>>,
+);
+
+/// What an [`AnimationSet`] resolved to once its skeleton and its clips were
+/// both in the world.
+///
+/// Runtime only: it names entities and holds asset handles, so it is neither
+/// reflected nor written to a document.
+#[derive(Component, Debug)]
+pub struct AnimationSetBound {
+    /// The skeleton root, which carries the [`AnimationPlayer`].
+    pub player: Entity,
+    /// The graph node each playable state was added as.
+    pub nodes: HashMap<String, AnimationNodeIndex>,
+    /// The graph every animated root under this set shares.
+    pub graph: Handle<AnimationGraph>,
+    /// Further animated roots: parts whose skeleton could not be folded into
+    /// the primary one and so kept their own.
+    pub parts: Vec<Entity>,
+    /// State names already reported as unknown, so asking again stays quiet.
+    pub warned_states: HashSet<String>,
+}
+
+/// Sent when a non-looping state reaches the end of its clip.
+#[derive(Message, Debug, Clone, PartialEq, Eq)]
+pub struct AnimationStateFinished {
+    /// The entity carrying the [`AnimationSet`].
+    pub entity: Entity,
+    /// The state that ran out.
+    pub state: String,
+}
+
+/// The systems that bind animation sets and play the state they are asked for.
+#[derive(SystemSet, Debug, Clone, Copy, PartialEq, Eq, Hash)]
+pub struct AnimationSetSystems;
+
+/// Binds authored animation sets to their skeletons and plays their states.
+///
+/// Add it wherever scenes carrying an [`AnimationSet`] are spawned. Nothing
+/// here touches an entity without one.
+pub struct AnimationRuntimePlugin;
+
+impl Plugin for AnimationRuntimePlugin {
+    fn build(&self, app: &mut App) {
+        register_animation_set_types(app);
+        app.add_message::<AnimationStateFinished>().add_systems(
+            Update,
+            (
+                bind_animation_sets,
+                merge_part_skeletons,
+                apply_animation_state,
+                report_finished_states,
+            )
+                .chain()
+                .in_set(AnimationSetSystems),
+        );
+    }
+}
+
+/// Registers the authored animation types for reflection.
+///
+/// [`AnimationRuntimePlugin`] calls this; call it directly only to author and
+/// load sets in an app that never plays them, such as one that only writes
+/// documents.
+pub fn register_animation_set_types(app: &mut App) {
+    app.register_type::<AnimationSet>()
+        .register_type::<AnimationStateDef>()
+        .register_type::<AnimationState>();
+}
+
+/// Builds the player, the graph and the bone target ids of every set whose
+/// skeleton and source files have arrived.
+///
+/// Retried each frame rather than run on insertion, because a glTF scene
+/// spawns asynchronously and its skeleton can be several frames behind the
+/// component naming it.
+fn bind_animation_sets(
+    mut commands: Commands,
+    asset_server: Res<AssetServer>,
+    gltfs: Res<Assets<Gltf>>,
+    mut graphs: ResMut<Assets<AnimationGraph>>,
+    unbound: Query<
+        (
+            Entity,
+            &AnimationSet,
+            Option<&AnimationSources>,
+            Option<&AnimationState>,
+        ),
+        Without<AnimationSetBound>,
+    >,
+    children: Query<&Children>,
+    names: Query<&Name>,
+    targets: Query<&AnimationTargetId>,
+) {
+    for (entity, set, sources, state) in &unbound {
+        let Some(sources) = sources else {
+            commands.entity(entity).insert(AnimationSources(
+                set.sources
+                    .iter()
+                    .map(|path| asset_server.load(path))
+                    .collect(),
+            ));
+            continue;
+        };
+        let Some(loaded) = sources
+            .0
+            .iter()
+            .map(|handle| gltfs.get(handle))
+            .collect::<Option<Vec<_>>>()
+        else {
+            continue;
+        };
+        let Some(&root) = descendants_named(entity, &set.skeleton_root, &children, &names).first()
+        else {
+            continue;
+        };
+
+        let mut graph = AnimationGraph::new();
+        let mut nodes = HashMap::new();
+        for def in &set.states {
+            let Some(gltf) = loaded.get(def.source) else {
+                warn!(
+                    "animation state `{}` wants source {} of {}",
+                    def.name,
+                    def.source,
+                    loaded.len()
+                );
+                continue;
+            };
+            let Some(clip) = gltf.named_animations.get(def.clip.as_str()) else {
+                let available: Vec<&str> =
+                    gltf.named_animations.keys().map(|name| &**name).collect();
+                warn!(
+                    "animation state `{}` wants clip `{}`, and its source holds {:?}",
+                    def.name, def.clip, available
+                );
+                continue;
+            };
+            let node = graph.add_clip(clip.clone(), 1.0, graph.root);
+            nodes.insert(def.name.clone(), node);
+        }
+        let graph = graphs.add(graph);
+
+        tag_animation_targets(
+            &mut commands,
+            root,
+            root,
+            &mut Vec::new(),
+            &children,
+            &names,
+            &targets,
+        );
+
+        let wanted = state.map_or(set.default_state.as_str(), |state| state.0.as_str());
+        let mut player = AnimationPlayer::default();
+        let mut transitions = AnimationTransitions::new();
+        let mut warned_states = HashSet::new();
+        match resolve_state(set, &nodes, wanted) {
+            Some((def, node)) => play_state(def, node, &mut player, &mut transitions),
+            None if wanted.is_empty() => {}
+            None => {
+                warn!("animation set has no state named `{wanted}`");
+                warned_states.insert(wanted.to_string());
+            }
+        }
+        commands
+            .entity(root)
+            .insert((player, AnimationGraphHandle(graph.clone()), transitions));
+
+        if state.is_none() {
+            commands
+                .entity(entity)
+                .insert(AnimationState(wanted.to_string()));
+        }
+        commands.entity(entity).insert(AnimationSetBound {
+            player: root,
+            nodes,
+            graph,
+            parts: Vec::new(),
+            warned_states,
+        });
+    }
+}
+
+/// Folds a part exported with its own copy of the skeleton onto the skeleton
+/// already bound, so one player drives the whole body.
+///
+/// A part whose bones do not answer to the same names keeps its own skeleton
+/// and becomes a second animated root on the same graph, which costs a player
+/// but leaves the part visible and in step.
+fn merge_part_skeletons(
+    mut commands: Commands,
+    mut sets: Query<(
+        Entity,
+        &AnimationSet,
+        &mut AnimationSetBound,
+        Option<&AnimationState>,
+    )>,
+    children: Query<&Children>,
+    names: Query<&Name>,
+    child_of: Query<&ChildOf>,
+    targets: Query<&AnimationTargetId>,
+    animated: Query<(), With<AnimationPlayer>>,
+    mut skins: Query<&mut SkinnedMesh>,
+) {
+    for (entity, set, mut bound, state) in &mut sets {
+        let primary = bound.player;
+        let candidates: Vec<Entity> =
+            descendants_named(entity, &set.skeleton_root, &children, &names)
+                .into_iter()
+                .filter(|&part| part != primary && !animated.contains(part))
+                .collect();
+        if candidates.is_empty() {
+            continue;
+        }
+
+        let primary_joints: HashMap<String, Entity> = descendants(primary, &children)
+            .into_iter()
+            .filter_map(|joint| names.get(joint).ok().map(|name| (name.to_string(), joint)))
+            .collect();
+        let primary_parent = child_of
+            .get(primary)
+            .map_or(entity, |&ChildOf(parent)| parent);
+
+        for part in candidates {
+            // A part exported beside its skeleton keeps its meshes as the
+            // skeleton's siblings, so the part is its parent's whole subtree.
+            let part_root = child_of
+                .get(part)
+                .map(|&ChildOf(parent)| parent)
+                .ok()
+                .filter(|&parent| !descendants(parent, &children).contains(&primary))
+                .unwrap_or(part);
+            let part_meshes: Vec<Entity> = descendants(part_root, &children)
+                .into_iter()
+                .filter(|&mesh| skins.contains(mesh))
+                .collect();
+            let part_bones = descendants(part, &children)
+                .into_iter()
+                .filter(|&bone| names.contains(bone))
+                .count();
+
+            let remapped = (part_bones == primary_joints.len())
+                .then(|| remap_joints(&part_meshes, &primary_joints, &skins, &names))
+                .flatten();
+            let Some(remapped) = remapped else {
+                warn!(
+                    "an animated part does not answer to the same bone names as the skeleton it \
+                     was placed under, so it keeps its own"
+                );
+                bind_extra_root(
+                    &mut commands,
+                    part,
+                    &bound,
+                    set,
+                    state,
+                    &children,
+                    &names,
+                    &targets,
+                );
+                bound.parts.push(part);
+                continue;
+            };
+            for (mesh, joints) in remapped {
+                if let Ok(mut skin) = skins.get_mut(mesh) {
+                    skin.joints = joints;
+                }
+                commands.entity(mesh).insert(ChildOf(primary_parent));
+            }
+            commands.entity(part).despawn();
+        }
+    }
+}
+
+/// Plays the state an [`AnimationState`] was changed to.
+fn apply_animation_state(
+    mut sets: Query<
+        (&AnimationSet, &mut AnimationSetBound, &AnimationState),
+        Changed<AnimationState>,
+    >,
+    mut players: Query<(&mut AnimationPlayer, &mut AnimationTransitions)>,
+) {
+    for (set, mut bound, state) in &mut sets {
+        let Some((def, node)) = resolve_state(set, &bound.nodes, &state.0) else {
+            if !state.0.is_empty() && bound.warned_states.insert(state.0.clone()) {
+                warn!("animation set has no state named `{}`", state.0);
+            }
+            continue;
+        };
+        let roots: Vec<Entity> = std::iter::once(bound.player)
+            .chain(bound.parts.iter().copied())
+            .collect();
+        for root in roots {
+            let Ok((mut player, mut transitions)) = players.get_mut(root) else {
+                continue;
+            };
+            play_state(def, node, &mut player, &mut transitions);
+        }
+    }
+}
+
+/// Reports a non-looping state that has run out, and moves on to whatever it
+/// said should follow.
+fn report_finished_states(
+    mut sets: Query<(
+        Entity,
+        &AnimationSet,
+        &AnimationSetBound,
+        &mut AnimationState,
+    )>,
+    players: Query<(&AnimationPlayer, &AnimationTransitions)>,
+    mut finished: MessageWriter<AnimationStateFinished>,
+) {
+    for (entity, set, bound, mut state) in &mut sets {
+        let Some((def, node)) = resolve_state(set, &bound.nodes, &state.0) else {
+            continue;
+        };
+        if def.looped {
+            continue;
+        }
+        let Ok((player, transitions)) = players.get(bound.player) else {
+            continue;
+        };
+        if transitions.get_main_animation() != Some(node) {
+            continue;
+        }
+        // `just_completed` holds for the one frame the clip ran out on, which
+        // is what keeps a state with no `then` from reporting forever.
+        let ran_out = player
+            .animation(node)
+            .is_some_and(|active| active.just_completed() && active.is_finished());
+        if !ran_out {
+            continue;
+        }
+        finished.write(AnimationStateFinished {
+            entity,
+            state: state.0.clone(),
+        });
+        if let Some(next) = &def.then {
+            state.0 = next.clone();
+        }
+    }
+}
+
+/// The state definition and graph node a name asks for, when the set has both.
+fn resolve_state<'a>(
+    set: &'a AnimationSet,
+    nodes: &HashMap<String, AnimationNodeIndex>,
+    wanted: &str,
+) -> Option<(&'a AnimationStateDef, AnimationNodeIndex)> {
+    let def = set.states.iter().find(|def| def.name == wanted)?;
+    let node = *nodes.get(wanted)?;
+    Some((def, node))
+}
+
+/// Starts a state on one animated root, fading out whatever it replaces.
+fn play_state(
+    def: &AnimationStateDef,
+    node: AnimationNodeIndex,
+    player: &mut AnimationPlayer,
+    transitions: &mut AnimationTransitions,
+) {
+    // Asking again for the state already running would restart its fade.
+    if transitions.get_main_animation() == Some(node)
+        && player
+            .animation(node)
+            .is_some_and(|active| !active.is_finished())
+    {
+        return;
+    }
+    let repeat = if def.looped {
+        RepeatAnimation::Forever
+    } else {
+        RepeatAnimation::Never
+    };
+    transitions
+        .play(player, node, Duration::from_secs_f32(def.transition_secs))
+        .set_repeat(repeat)
+        .set_speed(def.speed);
+}
+
+/// Gives a part that kept its own skeleton a player of its own on the shared
+/// graph, so it stays in step with the body it was placed under.
+fn bind_extra_root(
+    commands: &mut Commands,
+    root: Entity,
+    bound: &AnimationSetBound,
+    set: &AnimationSet,
+    state: Option<&AnimationState>,
+    children: &Query<&Children>,
+    names: &Query<&Name>,
+    targets: &Query<&AnimationTargetId>,
+) {
+    tag_animation_targets(
+        commands,
+        root,
+        root,
+        &mut Vec::new(),
+        children,
+        names,
+        targets,
+    );
+    let wanted = state.map_or(set.default_state.as_str(), |state| state.0.as_str());
+    let mut player = AnimationPlayer::default();
+    let mut transitions = AnimationTransitions::new();
+    if let Some((def, node)) = resolve_state(set, &bound.nodes, wanted) {
+        play_state(def, node, &mut player, &mut transitions);
+    }
+    commands.entity(root).insert((
+        player,
+        AnimationGraphHandle(bound.graph.clone()),
+        transitions,
+    ));
+}
+
+/// The joints each of a part's meshes should point at once it wears the
+/// primary skeleton, or `None` when a bone name has no counterpart there.
+fn remap_joints(
+    meshes: &[Entity],
+    primary_joints: &HashMap<String, Entity>,
+    skins: &Query<&mut SkinnedMesh>,
+    names: &Query<&Name>,
+) -> Option<Vec<(Entity, Vec<Entity>)>> {
+    let mut remapped = Vec::with_capacity(meshes.len());
+    for &mesh in meshes {
+        let skin = skins.get(mesh).ok()?;
+        let joints = skin
+            .joints
+            .iter()
+            .map(|&joint| primary_joints.get(names.get(joint).ok()?.as_str()).copied())
+            .collect::<Option<Vec<_>>>()?;
+        remapped.push((mesh, joints));
+    }
+    Some(remapped)
+}
+
+/// Gives every named entity under `root` the target id of its name path, so a
+/// clip authored against a skeleton of the same names drives this one.
+///
+/// An unnamed entity ends the walk: its descendants have no path to hash, and
+/// glTF's own loader passes over them for the same reason.
+fn tag_animation_targets(
+    commands: &mut Commands,
+    root: Entity,
+    entity: Entity,
+    path: &mut Vec<Name>,
+    children: &Query<&Children>,
+    names: &Query<&Name>,
+    targets: &Query<&AnimationTargetId>,
+) {
+    let Ok(name) = names.get(entity) else {
+        return;
+    };
+    path.push(name.clone());
+    if !targets.contains(entity) {
+        commands
+            .entity(entity)
+            .insert((AnimationTargetId::from_names(path.iter()), AnimatedBy(root)));
+    }
+    if let Ok(kids) = children.get(entity) {
+        for child in kids.iter() {
+            tag_animation_targets(commands, root, child, path, children, names, targets);
+        }
+    }
+    path.pop();
+}
+
+/// Every descendant of `root` carrying `wanted` as its name, nearest first.
+fn descendants_named(
+    root: Entity,
+    wanted: &str,
+    children: &Query<&Children>,
+    names: &Query<&Name>,
+) -> Vec<Entity> {
+    descendants(root, children)
+        .into_iter()
+        .skip(1)
+        .filter(|&entity| names.get(entity).is_ok_and(|name| name.as_str() == wanted))
+        .collect()
+}
+
+/// `root` and everything under it, breadth first.
+fn descendants(root: Entity, children: &Query<&Children>) -> Vec<Entity> {
+    let mut found = vec![root];
+    let mut visited = 0;
+    while visited < found.len() {
+        let entity = found[visited];
+        visited += 1;
+        if let Ok(kids) = children.get(entity) {
+            found.extend(kids.iter());
+        }
+    }
+    found
+}

--- a/crates/jackdaw_animation_runtime/src/lib.rs
+++ b/crates/jackdaw_animation_runtime/src/lib.rs
@@ -169,7 +169,12 @@ impl Plugin for AnimationRuntimePlugin {
                 report_finished_states,
             )
                 .chain()
-                .in_set(AnimationSetSystems),
+                .in_set(AnimationSetSystems)
+                .run_if(
+                    resource_exists::<AssetServer>
+                        .and_then(resource_exists::<Assets<Gltf>>)
+                        .and_then(resource_exists::<Assets<AnimationGraph>>),
+                ),
         );
     }
 }

--- a/crates/jackdaw_animation_runtime/tests/animation_sets.rs
+++ b/crates/jackdaw_animation_runtime/tests/animation_sets.rs
@@ -100,6 +100,18 @@ fn spawn_body(
     instance
 }
 
+/// Spawns named nodes under `parent`, the way a glTF file's mesh nodes sit
+/// among the bones of the armature they are skinned to.
+fn spawn_mesh_nodes(app: &mut App, parent: Entity, names: &[&str]) {
+    for name in names {
+        app.world_mut().spawn((
+            Name::new((*name).to_string()),
+            Transform::default(),
+            ChildOf(parent),
+        ));
+    }
+}
+
 /// A clip that slides the bone at `path` one unit along X over a second.
 fn sliding_clip(app: &mut App, path: &[&str]) -> Handle<AnimationClip> {
     let names: Vec<Name> = path
@@ -452,6 +464,85 @@ fn two_parts_sharing_a_rig_are_driven_by_one_skeleton_and_their_joints_move_iden
             .x
             > 0.0,
         "one player moves the bones both meshes are skinned to"
+    );
+}
+
+#[test]
+fn a_part_merges_when_its_joints_match_even_if_mesh_node_counts_differ() {
+    let mut app = animation_app();
+    let clip = sliding_clip(&mut app, &["Armature", "Hips"]);
+    let source = source_holding(&mut app, &[("Walk", clip)]);
+    let set = walking_set(
+        vec!["rig.glb".to_string()],
+        vec![AnimationStateDef {
+            name: "walk".to_string(),
+            clip: "Walk".to_string(),
+            ..AnimationStateDef::default()
+        }],
+        "walk",
+    );
+    let root = spawn_rig(&mut app, set, "Torso", &["Hips"]);
+    app.world_mut()
+        .entity_mut(root)
+        .insert(AnimationSources(vec![source]));
+    let torso = named(&mut app, "Torso");
+    let torso_armature = app.world().get::<Children>(torso).unwrap()[0];
+    let torso_hips = app.world().get::<Children>(torso_armature).unwrap()[0];
+    spawn_mesh_nodes(
+        &mut app,
+        torso_armature,
+        &["TorsoSkin", "TorsoTrim", "TorsoBelt"],
+    );
+    app.world_mut().spawn((
+        Name::new("TorsoMesh"),
+        SkinnedMesh {
+            joints: vec![torso_armature, torso_hips],
+            ..SkinnedMesh::default()
+        },
+        ChildOf(torso),
+    ));
+
+    let legs = spawn_body(&mut app, root, "Legs", "Armature", &["Hips"]);
+    let legs_armature = app.world().get::<Children>(legs).unwrap()[0];
+    let legs_hips = app.world().get::<Children>(legs_armature).unwrap()[0];
+    spawn_mesh_nodes(&mut app, legs_armature, &["LegsSkin"]);
+    let legs_mesh = app
+        .world_mut()
+        .spawn((
+            Name::new("LegsMesh"),
+            SkinnedMesh {
+                joints: vec![legs_armature, legs_hips],
+                ..SkinnedMesh::default()
+            },
+            ChildOf(legs),
+        ))
+        .id();
+
+    for _ in 0..5 {
+        step(&mut app, millis(100));
+    }
+
+    assert_eq!(
+        app.world()
+            .get::<SkinnedMesh>(legs_mesh)
+            .unwrap()
+            .joints
+            .clone(),
+        vec![torso_armature, torso_hips],
+        "the bones a part's mesh names are what decides the merge, not how many mesh nodes each \
+         file carries"
+    );
+    assert!(
+        app.world().get_entity(legs_armature).is_err(),
+        "the part's own copy of the skeleton is gone"
+    );
+    assert!(
+        app.world()
+            .get::<AnimationSetBound>(root)
+            .unwrap()
+            .parts
+            .is_empty(),
+        "and no second player was needed"
     );
 }
 

--- a/crates/jackdaw_animation_runtime/tests/animation_sets.rs
+++ b/crates/jackdaw_animation_runtime/tests/animation_sets.rs
@@ -1,0 +1,585 @@
+//! An authored animation set finds the skeleton spawned under it, drives it
+//! with clips exported against a skeleton of the same bone names, and plays
+//! whichever state it is asked for.
+
+use std::time::Duration;
+
+use bevy::{
+    animation::{
+        AnimatedBy, AnimationClip, AnimationTargetId, animated_field,
+        animation_curves::{AnimatableCurve, AnimatableKeyframeCurve},
+        graph::AnimationNodeIndex,
+        transition::AnimationTransitions,
+    },
+    asset::AssetPlugin,
+    gltf::Gltf,
+    mesh::skinning::SkinnedMesh,
+    platform::collections::HashMap,
+    prelude::*,
+    time::TimeUpdateStrategy,
+};
+use jackdaw_animation_runtime::{
+    AnimationRuntimePlugin, AnimationSet, AnimationSetBound, AnimationSetSystems, AnimationSources,
+    AnimationState, AnimationStateDef, AnimationStateFinished,
+};
+
+/// Every state reported finished so far.
+#[derive(Resource, Default)]
+struct Finished(Vec<String>);
+
+fn animation_app() -> App {
+    let mut app = App::new();
+    app.add_plugins(MinimalPlugins)
+        .add_plugins(AssetPlugin::default())
+        .add_plugins(bevy::transform::TransformPlugin)
+        .add_plugins(bevy::animation::AnimationPlugin)
+        .add_plugins(AnimationRuntimePlugin);
+    app.init_asset::<Gltf>();
+    app.init_resource::<Finished>();
+    app.add_systems(Update, collect_finished.after(AnimationSetSystems));
+    app
+}
+
+fn collect_finished(
+    mut reported: MessageReader<AnimationStateFinished>,
+    mut out: ResMut<Finished>,
+) {
+    out.0
+        .extend(reported.read().map(|finished| finished.state.clone()));
+}
+
+/// Runs one frame of a length the test picks rather than the wall clock's.
+fn step(app: &mut App, delta: Duration) {
+    app.insert_resource(TimeUpdateStrategy::ManualDuration(delta));
+    app.update();
+}
+
+fn millis(ms: u64) -> Duration {
+    Duration::from_millis(ms)
+}
+
+/// Spawns a set on a root, with `bones` hanging off an armature inside a scene
+/// instance of its own, the way a loaded glTF body arrives.
+fn spawn_rig(app: &mut App, set: AnimationSet, instance: &str, bones: &[&str]) -> Entity {
+    let armature_name = set.skeleton_root.clone();
+    let root = app.world_mut().spawn(set).id();
+    spawn_body(app, root, instance, &armature_name, bones);
+    root
+}
+
+/// Spawns one scene instance under `root`: an armature and a chain of bones.
+fn spawn_body(
+    app: &mut App,
+    root: Entity,
+    instance: &str,
+    armature_name: &str,
+    bones: &[&str],
+) -> Entity {
+    let instance = app
+        .world_mut()
+        .spawn((Name::new(instance.to_string()), ChildOf(root)))
+        .id();
+    let mut parent = app
+        .world_mut()
+        .spawn((
+            Name::new(armature_name.to_string()),
+            Transform::default(),
+            ChildOf(instance),
+        ))
+        .id();
+    for bone in bones {
+        parent = app
+            .world_mut()
+            .spawn((
+                Name::new(bone.to_string()),
+                Transform::default(),
+                ChildOf(parent),
+            ))
+            .id();
+    }
+    instance
+}
+
+/// A clip that slides the bone at `path` one unit along X over a second.
+fn sliding_clip(app: &mut App, path: &[&str]) -> Handle<AnimationClip> {
+    let names: Vec<Name> = path
+        .iter()
+        .map(|name| Name::new(name.to_string()))
+        .collect();
+    let curve = AnimatableKeyframeCurve::new([(0.0, Vec3::ZERO), (1.0, Vec3::X)])
+        .expect("two keyframes make a curve");
+    let mut clip = AnimationClip::default();
+    clip.add_curve_to_target(
+        AnimationTargetId::from_names(names.iter()),
+        AnimatableCurve::new(animated_field!(Transform::translation), curve),
+    );
+    app.world_mut()
+        .resource_mut::<Assets<AnimationClip>>()
+        .add(clip)
+}
+
+/// A stand-in for a loaded glTF file that holds nothing but named clips.
+fn source_holding(app: &mut App, clips: &[(&str, Handle<AnimationClip>)]) -> Handle<Gltf> {
+    let gltf = Gltf {
+        scenes: Vec::new(),
+        named_scenes: HashMap::default(),
+        meshes: Vec::new(),
+        named_meshes: HashMap::default(),
+        materials: Vec::new(),
+        named_materials: HashMap::default(),
+        nodes: Vec::new(),
+        named_nodes: HashMap::default(),
+        skins: Vec::new(),
+        named_skins: HashMap::default(),
+        default_scene: None,
+        animations: clips.iter().map(|(_, clip)| clip.clone()).collect(),
+        named_animations: clips
+            .iter()
+            .map(|(name, clip)| ((*name).into(), clip.clone()))
+            .collect(),
+        source: None,
+    };
+    app.world_mut().resource_mut::<Assets<Gltf>>().add(gltf)
+}
+
+fn named(app: &mut App, wanted: &str) -> Entity {
+    let mut names = app.world_mut().query::<(Entity, &Name)>();
+    names
+        .iter(app.world())
+        .find_map(|(entity, name)| (name.as_str() == wanted).then_some(entity))
+        .unwrap_or_else(|| panic!("expected an entity named {wanted}"))
+}
+
+fn target_of(app: &App, entity: Entity) -> AnimationTargetId {
+    *app.world()
+        .get::<AnimationTargetId>(entity)
+        .expect("a bound bone carries a target id")
+}
+
+fn node_for(app: &App, root: Entity, state: &str) -> AnimationNodeIndex {
+    app.world()
+        .get::<AnimationSetBound>(root)
+        .expect("the set is bound")
+        .nodes[state]
+}
+
+fn walking_set(
+    sources: Vec<String>,
+    states: Vec<AnimationStateDef>,
+    default_state: &str,
+) -> AnimationSet {
+    AnimationSet {
+        sources,
+        states,
+        default_state: default_state.to_string(),
+        ..AnimationSet::default()
+    }
+}
+
+#[test]
+fn a_bound_set_gives_every_bone_the_target_id_of_its_name_path() {
+    let mut app = animation_app();
+    spawn_rig(
+        &mut app,
+        AnimationSet::default(),
+        "Body",
+        &["Hips", "Spine"],
+    );
+
+    step(&mut app, Duration::ZERO);
+    step(&mut app, Duration::ZERO);
+
+    let armature = named(&mut app, "Armature");
+    let hips = named(&mut app, "Hips");
+    let spine = named(&mut app, "Spine");
+    let path = |names: &[&str]| {
+        let names: Vec<Name> = names.iter().map(|n| Name::new(n.to_string())).collect();
+        AnimationTargetId::from_names(names.iter())
+    };
+
+    assert_eq!(target_of(&app, armature), path(&["Armature"]));
+    assert_eq!(target_of(&app, hips), path(&["Armature", "Hips"]));
+    assert_eq!(target_of(&app, spine), path(&["Armature", "Hips", "Spine"]));
+    assert_eq!(
+        app.world().get::<AnimatedBy>(spine).map(|by| by.0),
+        Some(armature),
+        "every bone is animated by the skeleton root, not by whatever spawned it"
+    );
+}
+
+#[test]
+fn a_clip_authored_against_one_skeleton_moves_the_same_named_bone_on_another() {
+    let mut app = animation_app();
+    let clip = sliding_clip(&mut app, &["Armature", "Hips"]);
+    let source = source_holding(&mut app, &[("Walk", clip)]);
+    let set = walking_set(
+        vec!["rig.glb".to_string()],
+        vec![AnimationStateDef {
+            name: "walk".to_string(),
+            clip: "Walk".to_string(),
+            ..AnimationStateDef::default()
+        }],
+        "walk",
+    );
+    let root = spawn_rig(&mut app, set, "Body", &["Hips"]);
+    app.world_mut()
+        .entity_mut(root)
+        .insert(AnimationSources(vec![source]));
+
+    for _ in 0..5 {
+        step(&mut app, millis(100));
+    }
+
+    let hips = named(&mut app, "Hips");
+    let moved = app.world().get::<Transform>(hips).unwrap().translation.x;
+    assert!(
+        moved > 0.0,
+        "the clip names bones by path, so it drives a skeleton it was never exported with: {moved}"
+    );
+}
+
+#[test]
+fn setting_a_state_plays_its_clip_and_fades_the_previous_one_over_the_transition() {
+    let mut app = animation_app();
+    let clip = sliding_clip(&mut app, &["Armature", "Hips"]);
+    let source = source_holding(&mut app, &[("Idle", clip.clone()), ("Walk", clip)]);
+    let set = walking_set(
+        vec!["rig.glb".to_string()],
+        vec![
+            AnimationStateDef {
+                name: "idle".to_string(),
+                clip: "Idle".to_string(),
+                ..AnimationStateDef::default()
+            },
+            AnimationStateDef {
+                name: "walk".to_string(),
+                clip: "Walk".to_string(),
+                transition_secs: 0.5,
+                ..AnimationStateDef::default()
+            },
+        ],
+        "idle",
+    );
+    let root = spawn_rig(&mut app, set, "Body", &["Hips"]);
+    app.world_mut()
+        .entity_mut(root)
+        .insert(AnimationSources(vec![source]));
+    step(&mut app, millis(100));
+
+    let armature = named(&mut app, "Armature");
+    let idle = node_for(&app, root, "idle");
+    let walk = node_for(&app, root, "walk");
+    assert_eq!(
+        app.world()
+            .get::<AnimationTransitions>(armature)
+            .unwrap()
+            .get_main_animation(),
+        Some(idle),
+        "the default state is what a freshly bound set plays"
+    );
+
+    app.world_mut()
+        .entity_mut(root)
+        .insert(AnimationState("walk".to_string()));
+    step(&mut app, millis(100));
+
+    assert_eq!(
+        app.world()
+            .get::<AnimationTransitions>(armature)
+            .unwrap()
+            .get_main_animation(),
+        Some(walk),
+    );
+    let fading = app
+        .world()
+        .get::<AnimationPlayer>(armature)
+        .unwrap()
+        .animation(idle)
+        .expect("the state being replaced is still playing while it fades")
+        .weight();
+    assert!(
+        (0.0..1.0).contains(&fading),
+        "a fifth of the way through the transition the old state is part-weight: {fading}"
+    );
+
+    for _ in 0..6 {
+        step(&mut app, millis(100));
+    }
+    assert!(
+        app.world()
+            .get::<AnimationPlayer>(armature)
+            .unwrap()
+            .animation(idle)
+            .is_none(),
+        "once the transition is over the state it replaced has stopped"
+    );
+}
+
+#[test]
+fn a_one_shot_state_reports_finished_and_falls_back_to_its_then_state() {
+    let mut app = animation_app();
+    let clip = sliding_clip(&mut app, &["Armature", "Hips"]);
+    let source = source_holding(&mut app, &[("Attack", clip.clone()), ("Idle", clip)]);
+    let set = walking_set(
+        vec!["rig.glb".to_string()],
+        vec![
+            AnimationStateDef {
+                name: "attack".to_string(),
+                clip: "Attack".to_string(),
+                looped: false,
+                then: Some("idle".to_string()),
+                ..AnimationStateDef::default()
+            },
+            AnimationStateDef {
+                name: "idle".to_string(),
+                clip: "Idle".to_string(),
+                ..AnimationStateDef::default()
+            },
+        ],
+        "attack",
+    );
+    let root = spawn_rig(&mut app, set, "Body", &["Hips"]);
+    app.world_mut()
+        .entity_mut(root)
+        .insert(AnimationSources(vec![source]));
+
+    for _ in 0..10 {
+        step(&mut app, millis(200));
+    }
+
+    assert_eq!(
+        app.world().resource::<Finished>().0,
+        vec!["attack".to_string()],
+        "a one-shot state reports once, on the frame its clip ran out"
+    );
+    assert_eq!(
+        app.world().get::<AnimationState>(root),
+        Some(&AnimationState("idle".to_string())),
+        "and the set moves on to what the state said should follow"
+    );
+    let armature = named(&mut app, "Armature");
+    assert_eq!(
+        app.world()
+            .get::<AnimationTransitions>(armature)
+            .unwrap()
+            .get_main_animation(),
+        Some(node_for(&app, root, "idle")),
+    );
+}
+
+#[test]
+fn two_parts_sharing_a_rig_are_driven_by_one_skeleton_and_their_joints_move_identically() {
+    let mut app = animation_app();
+    let clip = sliding_clip(&mut app, &["Armature", "Hips"]);
+    let source = source_holding(&mut app, &[("Walk", clip)]);
+    let set = walking_set(
+        vec!["rig.glb".to_string()],
+        vec![AnimationStateDef {
+            name: "walk".to_string(),
+            clip: "Walk".to_string(),
+            ..AnimationStateDef::default()
+        }],
+        "walk",
+    );
+    let root = spawn_rig(&mut app, set, "Torso", &["Hips"]);
+    app.world_mut()
+        .entity_mut(root)
+        .insert(AnimationSources(vec![source]));
+    let torso = named(&mut app, "Torso");
+    let torso_armature = named(&mut app, "Armature");
+    let torso_hips = named(&mut app, "Hips");
+    let torso_mesh = app
+        .world_mut()
+        .spawn((
+            Name::new("TorsoMesh"),
+            SkinnedMesh {
+                joints: vec![torso_armature, torso_hips],
+                ..SkinnedMesh::default()
+            },
+            ChildOf(torso),
+        ))
+        .id();
+
+    let legs = spawn_body(&mut app, root, "Legs", "Armature", &["Hips"]);
+    let legs_armature = app.world().get::<Children>(legs).unwrap()[0];
+    let legs_hips = app.world().get::<Children>(legs_armature).unwrap()[0];
+    let legs_mesh = app
+        .world_mut()
+        .spawn((
+            Name::new("LegsMesh"),
+            SkinnedMesh {
+                joints: vec![legs_armature, legs_hips],
+                ..SkinnedMesh::default()
+            },
+            ChildOf(legs),
+        ))
+        .id();
+
+    for _ in 0..5 {
+        step(&mut app, millis(100));
+    }
+
+    let torso_joints = app
+        .world()
+        .get::<SkinnedMesh>(torso_mesh)
+        .unwrap()
+        .joints
+        .clone();
+    let legs_joints = app
+        .world()
+        .get::<SkinnedMesh>(legs_mesh)
+        .unwrap()
+        .joints
+        .clone();
+    assert_eq!(
+        legs_joints, torso_joints,
+        "the part was re-pointed at the bones the other part already uses"
+    );
+    assert!(
+        app.world().get_entity(legs_armature).is_err(),
+        "the part's own copy of the skeleton is gone"
+    );
+    assert_eq!(
+        app.world().get::<ChildOf>(legs_mesh).map(|parent| parent.0),
+        Some(torso),
+        "and its mesh now hangs beside the skeleton driving it"
+    );
+    assert!(
+        app.world()
+            .get::<Transform>(torso_hips)
+            .unwrap()
+            .translation
+            .x
+            > 0.0,
+        "one player moves the bones both meshes are skinned to"
+    );
+}
+
+#[test]
+fn a_part_whose_joints_do_not_match_by_name_keeps_its_own_skeleton_and_warns_once() {
+    let mut app = animation_app();
+    let clip = sliding_clip(&mut app, &["Armature", "Hips"]);
+    let source = source_holding(&mut app, &[("Walk", clip)]);
+    let set = walking_set(
+        vec!["rig.glb".to_string()],
+        vec![AnimationStateDef {
+            name: "walk".to_string(),
+            clip: "Walk".to_string(),
+            ..AnimationStateDef::default()
+        }],
+        "walk",
+    );
+    let root = spawn_rig(&mut app, set, "Torso", &["Hips"]);
+    app.world_mut()
+        .entity_mut(root)
+        .insert(AnimationSources(vec![source]));
+
+    let cloak = spawn_body(&mut app, root, "Cloak", "Armature", &["Tail"]);
+    let cloak_armature = app.world().get::<Children>(cloak).unwrap()[0];
+    let cloak_tail = app.world().get::<Children>(cloak_armature).unwrap()[0];
+    let cloak_mesh = app
+        .world_mut()
+        .spawn((
+            Name::new("CloakMesh"),
+            SkinnedMesh {
+                joints: vec![cloak_armature, cloak_tail],
+                ..SkinnedMesh::default()
+            },
+            ChildOf(cloak),
+        ))
+        .id();
+
+    for _ in 0..5 {
+        step(&mut app, millis(100));
+    }
+
+    let bound = app.world().get::<AnimationSetBound>(root).unwrap();
+    assert_eq!(
+        bound.parts,
+        vec![cloak_armature],
+        "the part is taken up once and then left alone"
+    );
+    assert_eq!(
+        app.world()
+            .get::<SkinnedMesh>(cloak_mesh)
+            .unwrap()
+            .joints
+            .clone(),
+        vec![cloak_armature, cloak_tail],
+        "a part whose bones answer to other names keeps the ones it came with"
+    );
+    assert!(
+        app.world().get::<AnimationPlayer>(cloak_armature).is_some(),
+        "and gets a player of its own so it still plays the set's state"
+    );
+}
+
+#[test]
+fn a_set_whose_skeleton_has_not_spawned_yet_binds_once_it_appears() {
+    let mut app = animation_app();
+    let root = app.world_mut().spawn(AnimationSet::default()).id();
+
+    step(&mut app, Duration::ZERO);
+    step(&mut app, Duration::ZERO);
+    assert!(
+        app.world().get::<AnimationSetBound>(root).is_none(),
+        "nothing binds while the skeleton the set names is still loading"
+    );
+
+    spawn_body(&mut app, root, "Body", "Armature", &["Hips"]);
+    step(&mut app, Duration::ZERO);
+    step(&mut app, Duration::ZERO);
+
+    let armature = named(&mut app, "Armature");
+    assert_eq!(
+        app.world().get::<AnimationSetBound>(root).map(|b| b.player),
+        Some(armature),
+        "the set binds on the frame its skeleton turns up"
+    );
+    assert!(app.world().get::<AnimationPlayer>(armature).is_some());
+}
+
+#[test]
+fn an_unknown_state_name_is_refused_with_one_warning() {
+    let mut app = animation_app();
+    let clip = sliding_clip(&mut app, &["Armature", "Hips"]);
+    let source = source_holding(&mut app, &[("Idle", clip)]);
+    let set = walking_set(
+        vec!["rig.glb".to_string()],
+        vec![AnimationStateDef {
+            name: "idle".to_string(),
+            clip: "Idle".to_string(),
+            ..AnimationStateDef::default()
+        }],
+        "idle",
+    );
+    let root = spawn_rig(&mut app, set, "Body", &["Hips"]);
+    app.world_mut()
+        .entity_mut(root)
+        .insert(AnimationSources(vec![source]));
+    step(&mut app, millis(100));
+    let idle = node_for(&app, root, "idle");
+
+    for _ in 0..2 {
+        app.world_mut()
+            .entity_mut(root)
+            .insert(AnimationState("sprint".to_string()));
+        step(&mut app, millis(100));
+    }
+
+    let bound = app.world().get::<AnimationSetBound>(root).unwrap();
+    assert_eq!(
+        bound.warned_states.iter().collect::<Vec<_>>(),
+        vec!["sprint"],
+        "asking twice for a state the set has never heard of is reported once"
+    );
+    let armature = named(&mut app, "Armature");
+    assert_eq!(
+        app.world()
+            .get::<AnimationTransitions>(armature)
+            .unwrap()
+            .get_main_animation(),
+        Some(idle),
+        "and the state that was playing keeps playing"
+    );
+}

--- a/crates/jackdaw_bind/src/actions.rs
+++ b/crates/jackdaw_bind/src/actions.rs
@@ -12,6 +12,16 @@ use crate::resolve::{
 use crate::{BindError, BindFailures, BindPath, Binding, Bindings};
 
 type ActionFields = Vec<(String, BindPath)>;
+type ActionLiterals = Vec<(String, String)>;
+
+/// One action binding lifted off the widget, carrying the index it sits at so a
+/// failure reaches the same warn-once ledger the evaluator reports through.
+struct QueuedAction {
+    index: usize,
+    event_path: String,
+    fields: ActionFields,
+    literals: ActionLiterals,
+}
 
 /// The only field name an `EntityEvent`'s target can be recognised by.
 ///
@@ -25,14 +35,21 @@ pub fn on_activate(activate: On<Activate>, bindings: Query<&Bindings>, mut comma
     let Ok(found) = bindings.get(target) else {
         return;
     };
-    // The index travels with each action so a failure reaches the same
-    // warn-once ledger the evaluator reports through.
-    let actions: Vec<(usize, String, ActionFields)> = found
+    let actions: Vec<QueuedAction> = found
         .0
         .iter()
         .enumerate()
         .filter_map(|(index, b)| match b {
-            Binding::Action { event, fields } => Some((index, event.clone(), fields.clone())),
+            Binding::Action {
+                event,
+                fields,
+                literals,
+            } => Some(QueuedAction {
+                index,
+                event_path: event.clone(),
+                fields: fields.clone(),
+                literals: literals.clone(),
+            }),
             _ => None,
         })
         .collect();
@@ -40,8 +57,9 @@ pub fn on_activate(activate: On<Activate>, bindings: Query<&Bindings>, mut comma
         return;
     }
     commands.queue(move |world: &mut World| {
-        for (index, event_path, fields) in actions {
-            if let Err(err) = dispatch(world, target, &event_path, &fields) {
+        for action in actions {
+            let index = action.index;
+            if let Err(err) = dispatch(world, target, &action) {
                 match world.get_resource_mut::<BindFailures>() {
                     Some(mut failures) => report(&mut failures, target, index, err),
                     None => warn!("binding {index} on {target}: {err}"),
@@ -184,6 +202,29 @@ fn mismatch(field: &str, type_path: &str, kind: &'static str) -> BindError {
     }
 }
 
+/// Reads a literal's text as the shape the event declares for the field it
+/// fills, so it lands through the same coercion a value read from game state
+/// goes through. Numbers arrive as `f32` and are narrowed there.
+fn literal_value(field: &str, text: &str, type_path: Option<&str>) -> Result<BindValue, BindError> {
+    let Some(type_path) = type_path else {
+        return Err(BindError::UnknownEventField {
+            field: field.to_string(),
+        });
+    };
+    let unreadable = || BindError::UnreadableLiteral {
+        field: field.to_string(),
+        type_path: type_path.to_string(),
+        text: text.to_string(),
+    };
+    if type_path == bool::type_path() {
+        return text.parse().map(BindValue::Bool).map_err(|_| unreadable());
+    }
+    if type_path == String::type_path() {
+        return Ok(BindValue::Str(text.to_string()));
+    }
+    text.parse().map(BindValue::F32).map_err(|_| unreadable())
+}
+
 /// Field types are collected up front so the registry lock is released before
 /// `read_path` runs, which takes the same lock again.
 struct EventShape {
@@ -192,6 +233,8 @@ struct EventShape {
     /// see `dispatch` for why the trigger is not handed the app's.
     registry: TypeRegistry,
     field_types: Vec<Option<String>>,
+    /// The same, for the fields the binding's literals fill.
+    literal_types: Vec<Option<String>>,
     declared_fields: Vec<String>,
     /// Every field the event declares as an `Entity`.
     ///
@@ -208,6 +251,7 @@ fn event_shape(
     world: &World,
     event_path: &str,
     fields: &[(String, BindPath)],
+    literals: &[(String, String)],
 ) -> Result<EventShape, BindError> {
     let registry_arc = world
         .get_resource::<AppTypeRegistry>()
@@ -230,9 +274,14 @@ fn event_shape(
             event_path: event_path.to_string(),
             kind: reg.type_info().kind().to_string(),
         })?;
+    let declared_type = |field: &String| info.field(field).map(|f| f.type_path().to_string());
     let field_types = fields
         .iter()
-        .map(|(field, _)| info.field(field).map(|f| f.type_path().to_string()))
+        .map(|(field, _)| declared_type(field))
+        .collect();
+    let literal_types = literals
+        .iter()
+        .map(|(field, _)| declared_type(field))
         .collect();
     let declared_fields = info.iter().map(|f| f.name().to_string()).collect();
     let entity_fields = info
@@ -248,6 +297,7 @@ fn event_shape(
         reflect_event,
         registry: alone,
         field_types,
+        literal_types,
         declared_fields,
         entity_fields,
         fills_gaps,
@@ -261,9 +311,20 @@ pub(crate) fn check_event(
     world: &World,
     event_path: &str,
     fields: &[(String, BindPath)],
+    literals: &[(String, String)],
 ) -> Result<(), BindError> {
-    let shape = event_shape(world, event_path, fields)?;
-    for ((field, _), declared) in fields.iter().zip(&shape.field_types) {
+    let shape = event_shape(world, event_path, fields, literals)?;
+    let named = fields
+        .iter()
+        .map(|(field, _)| field)
+        .zip(&shape.field_types)
+        .chain(
+            literals
+                .iter()
+                .map(|(field, _)| field)
+                .zip(&shape.literal_types),
+        );
+    for (field, declared) in named {
         if declared.is_none() {
             return Err(BindError::UnknownEventField {
                 field: field.clone(),
@@ -279,17 +340,27 @@ pub(crate) fn check_event(
 /// dispatch, observers included, so it is handed the registry of one that
 /// `event_shape` built rather than the app's, leaving an observer free to ask
 /// for the app's without deadlocking.
-fn dispatch(
-    world: &mut World,
-    widget: Entity,
-    event_path: &str,
-    fields: &[(String, BindPath)],
-) -> Result<(), BindError> {
-    let shape = event_shape(world, event_path, fields)?;
+fn dispatch(world: &mut World, widget: Entity, action: &QueuedAction) -> Result<(), BindError> {
+    let QueuedAction {
+        event_path,
+        fields,
+        literals,
+        ..
+    } = action;
+    let shape = event_shape(world, event_path, fields, literals)?;
     let context = resolve_context(world, widget);
     let mut dynamic = DynamicStruct::default();
     for ((field, path), field_type) in fields.iter().zip(&shape.field_types) {
         let value = read_path(world, context, path)?;
+        insert_coerced(&mut dynamic, field, value, field_type.as_deref())?;
+    }
+    // The bound value wins: a field named on both sides is one the author moved
+    // off its constant and onto game state.
+    for ((field, text), field_type) in literals.iter().zip(&shape.literal_types) {
+        if dynamic.field(field).is_some() {
+            continue;
+        }
+        let value = literal_value(field, text, field_type.as_deref())?;
         insert_coerced(&mut dynamic, field, value, field_type.as_deref())?;
     }
     // A widget with no context resolved has no entity to send, and the event's
@@ -366,6 +437,7 @@ mod tests {
             &world,
             "Fired",
             &[("0".into(), BindPath::new("Slot.index"))],
+            &[],
         )
         .unwrap_err();
         assert!(
@@ -377,7 +449,7 @@ mod tests {
     #[test]
     fn an_enum_event_is_refused_when_the_binding_is_resolved() {
         let world = world_with::<Mode>();
-        let err = check_event(&world, "Mode", &[]).unwrap_err();
+        let err = check_event(&world, "Mode", &[], &[]).unwrap_err();
         assert!(
             matches!(err, BindError::EventNotNamedStruct { ref kind, .. } if kind == "enum"),
             "wrong branch: {err}"

--- a/crates/jackdaw_bind/src/error.rs
+++ b/crates/jackdaw_bind/src/error.rs
@@ -329,6 +329,18 @@ pub enum BindError {
         value: f32,
     },
 
+    /// A constant an `Action` binding carries does not read as the type of the
+    /// field it fills: "two" in a `u8`, or "yes" in a `bool`.
+    #[error("field '{field}' is '{type_path}' and does not read from \"{text}\"")]
+    UnreadableLiteral {
+        /// The event field the constant fills.
+        field: String,
+        /// The type that field is declared as.
+        type_path: String,
+        /// The constant as it was written.
+        text: String,
+    },
+
     /// An `Action` binding leaves an event field unmapped, and the event has
     /// no default to fill the gap with.
     #[error("'{event_path}' leaves field '{field}' unmapped and has no #[reflect(Default)]")]
@@ -658,6 +670,14 @@ mod tests {
                     value: 300.0,
                 },
                 owned("field 'slot' is 'u8' and cannot take 300"),
+            ),
+            (
+                BindError::UnreadableLiteral {
+                    field: owned("slot"),
+                    type_path: owned("u8"),
+                    text: owned("two"),
+                },
+                owned("field 'slot' is 'u8' and does not read from \"two\""),
             ),
             (
                 BindError::UnfillableEvent {

--- a/crates/jackdaw_bind/src/evaluate.rs
+++ b/crates/jackdaw_bind/src/evaluate.rs
@@ -521,8 +521,12 @@ fn resolve_one(
         Binding::Value { .. } => ResolvedTarget::Value {
             text: resolve_text_target(world),
         },
-        Binding::Action { event, fields } => {
-            crate::actions::check_event(world, event, fields)?;
+        Binding::Action {
+            event,
+            fields,
+            literals,
+        } => {
+            crate::actions::check_event(world, event, fields, literals)?;
             ResolvedTarget::Action
         }
     };

--- a/crates/jackdaw_bind/src/lib.rs
+++ b/crates/jackdaw_bind/src/lib.rs
@@ -58,8 +58,11 @@
 //!
 //! # What an action binding can send
 //!
-//! An `Action` binding fills the event's fields from the paths it names. An
-//! `EntityEvent`'s target is the exception: it takes the widget's
+//! An `Action` binding fills the event's fields from the paths it names, and
+//! from the constants it carries: each `literals` entry
+//! names a field and the value it takes, read as the type that field is
+//! declared with. A field named on both sides takes the value read from game
+//! state. An `EntityEvent`'s target is the exception: it takes the widget's
 //! [`BindContext`], and only when the field is named `entity`. A
 //! `#[event_target]` field of another name leaves nothing in the type registry
 //! for reflection to find and is refused with

--- a/crates/jackdaw_bind/src/types.rs
+++ b/crates/jackdaw_bind/src/types.rs
@@ -146,6 +146,14 @@ pub enum Binding {
         /// Which path fills which field of the event. Fields left out take
         /// the event's own default.
         fields: Vec<(String, BindPath)>,
+        /// Constants the binding carries, as (field name, the value written
+        /// out). Each is read as the type the event declares for the field it
+        /// fills; a field `fields` also names takes the value read from game
+        /// state instead.
+        // Documents written before literals existed leave this out, so it
+        // takes its default rather than costing them the whole binding.
+        #[reflect(default)]
+        literals: Vec<(String, String)>,
     },
 }
 

--- a/crates/jackdaw_bind/tests/action_bindings.rs
+++ b/crates/jackdaw_bind/tests/action_bindings.rs
@@ -180,6 +180,7 @@ fn button_with(app: &mut App, subject: Entity, event: &str, field: &str, path: &
             Bindings(vec![Binding::Action {
                 event: event.into(),
                 fields: vec![(field.into(), BindPath::new(path))],
+                literals: Vec::new(),
             }]),
         ))
         .id()
@@ -197,6 +198,7 @@ fn activate_triggers_mapped_game_event() {
             Bindings(vec![Binding::Action {
                 event: "CastAbility".into(),
                 fields: vec![("slot".into(), BindPath::new("AbilitySlot.index"))],
+                literals: Vec::new(),
             }]),
         ))
         .id();
@@ -232,6 +234,7 @@ fn unfillable_event_warns_instead_of_panicking() {
             Bindings(vec![Binding::Action {
                 event: "Undefaultable".into(),
                 fields: vec![("slot".into(), BindPath::new("AbilitySlot.index"))],
+                literals: Vec::new(),
             }]),
         ))
         .id();
@@ -261,6 +264,7 @@ fn string_and_bool_fields_dispatch_when_the_types_line_up() {
                     ("name".into(), BindPath::new("Caption.name")),
                     ("ready".into(), BindPath::new("Caption.ready")),
                 ],
+                literals: Vec::new(),
             }]),
         ))
         .id();
@@ -336,6 +340,7 @@ fn an_action_with_no_resolved_context_sends_nothing() {
             Bindings(vec![Binding::Action {
                 event: "CastAbility".into(),
                 fields: vec![],
+                literals: Vec::new(),
             }]),
         ))
         .id();
@@ -361,6 +366,7 @@ fn an_action_with_a_resolved_context_still_sends() {
             Bindings(vec![Binding::Action {
                 event: "CastAbility".into(),
                 fields: vec![],
+                literals: Vec::new(),
             }]),
         ))
         .id();
@@ -399,6 +405,7 @@ fn unknown_event_type_warns_instead_of_panicking() {
             Bindings(vec![Binding::Action {
                 event: "NotAnEvent".into(),
                 fields: vec![],
+                literals: Vec::new(),
             }]),
         ))
         .id();
@@ -422,6 +429,7 @@ fn a_tuple_struct_event_is_refused_instead_of_panicking() {
             Bindings(vec![Binding::Action {
                 event: "Fired".into(),
                 fields: vec![],
+                literals: Vec::new(),
             }]),
         ))
         .id();
@@ -443,6 +451,7 @@ fn an_enum_event_is_refused_instead_of_panicking() {
             Bindings(vec![Binding::Action {
                 event: "Mode".into(),
                 fields: vec![],
+                literals: Vec::new(),
             }]),
         ))
         .id();
@@ -494,4 +503,102 @@ fn a_nan_is_refused_rather_than_sent_as_zero() {
     app.world_mut().trigger(Activate { entity: button });
     app.update();
     assert!(app.world().resource::<Casts>().0.is_empty());
+}
+
+/// A button that fires `event` with `literals` and nothing read from state.
+fn button_with_literals(
+    app: &mut App,
+    subject: Entity,
+    event: &str,
+    literals: &[(&str, &str)],
+) -> Entity {
+    app.world_mut()
+        .spawn((
+            Node::default(),
+            BindContext(subject),
+            Bindings(vec![Binding::Action {
+                event: event.into(),
+                fields: vec![],
+                literals: literals
+                    .iter()
+                    .map(|(field, text)| ((*field).to_string(), (*text).to_string()))
+                    .collect(),
+            }]),
+        ))
+        .id()
+}
+
+/// A slot number the author typed rather than read reaches the event as the
+/// `u8` the field is declared with.
+#[test]
+fn an_action_sends_the_constant_its_binding_carries() {
+    let mut app = app();
+    let subject = app.world_mut().spawn(AbilitySlot { index: 3 }).id();
+    let button = button_with_literals(&mut app, subject, "CastAbility", &[("slot", "2")]);
+    app.update();
+    app.world_mut().trigger(Activate { entity: button });
+    app.update();
+    assert_eq!(app.world().resource::<Casts>().0, vec![(subject, 2)]);
+}
+
+/// A field the author has since bound to game state is no longer the constant
+/// it started as.
+#[test]
+fn a_bound_field_wins_over_a_literal_naming_the_same_field() {
+    let mut app = app();
+    let subject = app.world_mut().spawn(AbilitySlot { index: 3 }).id();
+    let button = app
+        .world_mut()
+        .spawn((
+            Node::default(),
+            BindContext(subject),
+            Bindings(vec![Binding::Action {
+                event: "CastAbility".into(),
+                fields: vec![("slot".into(), BindPath::new("AbilitySlot.index"))],
+                literals: vec![("slot".into(), "9".into())],
+            }]),
+        ))
+        .id();
+    app.update();
+    app.world_mut().trigger(Activate { entity: button });
+    app.update();
+    assert_eq!(
+        app.world().resource::<Casts>().0,
+        vec![(subject, 3)],
+        "the read path filled the field, not the constant beside it",
+    );
+}
+
+/// A constant that does not read as its field's type is an authored mistake,
+/// so it warns through the ledger once and sends nothing.
+#[test]
+fn a_literal_that_cannot_coerce_is_refused_with_one_warning() {
+    let mut app = app();
+    let subject = app.world_mut().spawn(AbilitySlot { index: 3 }).id();
+    let button = button_with_literals(&mut app, subject, "CastAbility", &[("slot", "two")]);
+    app.update();
+    for _ in 0..2 {
+        app.world_mut().trigger(Activate { entity: button });
+        app.update();
+    }
+    assert!(app.world().resource::<Casts>().0.is_empty());
+    let failures = &app.world().resource::<BindFailures>().0;
+    assert!(failures.contains(&(button, 0)));
+    assert_eq!(failures.len(), 1, "the second click warns nothing new");
+}
+
+/// A constant naming a field the event does not declare is caught when the
+/// binding is resolved, the same as a read path that names one.
+#[test]
+fn a_literal_naming_no_field_of_the_event_is_reported_before_the_first_click() {
+    let mut app = app();
+    let subject = app.world_mut().spawn(AbilitySlot { index: 3 }).id();
+    let button = button_with_literals(&mut app, subject, "CastAbility", &[("nope", "2")]);
+    app.update();
+    assert!(
+        app.world()
+            .resource::<BindFailures>()
+            .0
+            .contains(&(button, 0))
+    );
 }

--- a/crates/jackdaw_bind/tests/hud_scenario.rs
+++ b/crates/jackdaw_bind/tests/hud_scenario.rs
@@ -111,6 +111,7 @@ fn hud_binds_fill_text_veil_and_button() {
             Bindings(vec![Binding::Action {
                 event: "OpenSettingsMenu".into(),
                 fields: vec![],
+                literals: Vec::new(),
             }]),
         ))
         .id();

--- a/crates/jackdaw_bsn/src/apply.rs
+++ b/crates/jackdaw_bsn/src/apply.rs
@@ -1046,6 +1046,8 @@ fn enum_variant_value_to_reflect(
     // `field_len` on the dynamic forms is the trait's, not inherent.
     use bevy::reflect::tuple::Tuple;
 
+    // Why a struct variant came up short, when it did.
+    let mut elided: Option<String> = None;
     let (variant_name, dynamic_variant) = match value {
         BsnValue::Type(type_path) => {
             let name = variant_name_of(type_path);
@@ -1116,24 +1118,33 @@ fn enum_variant_value_to_reflect(
                 };
                 dynamic_struct.insert_boxed(&field.name, reflected);
             }
-            if dynamic_struct.field_len() != struct_var.field_len() {
-                return refused_variant(
-                    enum_info,
-                    name,
-                    &format!(
-                        "it gives {} of the variant's {} fields",
-                        dynamic_struct.field_len(),
-                        struct_var.field_len(),
-                    ),
-                );
-            }
+            elided = (dynamic_struct.field_len() != struct_var.field_len()).then(|| {
+                format!(
+                    "it gives {} of the variant's {} fields",
+                    dynamic_struct.field_len(),
+                    struct_var.field_len(),
+                )
+            });
             (name.to_string(), DynamicVariant::Struct(dynamic_struct))
         }
         _ => return None,
     };
 
-    let mut dynamic_enum = DynamicEnum::new(variant_name, dynamic_variant);
+    let mut dynamic_enum = DynamicEnum::new(variant_name.clone(), dynamic_variant);
     dynamic_enum.set_represented_type(Some(enum_registration.type_info()));
+    // A variant that names fewer fields than the variant declares is a document
+    // written against an older shape. `FromReflect` fills a field the type marks
+    // `#[reflect(default)]` and refuses the rest, so it decides rather than the
+    // count alone.
+    if let Some(short) = elided {
+        let Some(concrete) = enum_registration
+            .data::<ReflectFromReflect>()
+            .and_then(|from_reflect| from_reflect.from_reflect(&dynamic_enum))
+        else {
+            return refused_variant(enum_info, &variant_name, &short);
+        };
+        return Some(concrete.into_partial_reflect());
+    }
     Some(Box::new(dynamic_enum))
 }
 

--- a/crates/jackdaw_bsn/tests/bindings_round_trip.rs
+++ b/crates/jackdaw_bsn/tests/bindings_round_trip.rs
@@ -39,6 +39,7 @@ fn authored_value() -> Bindings {
         Binding::Action {
             event: "game::hud::RetryPressed".to_string(),
             fields: vec![("slot".to_string(), BindPath::new("game::hud::Save.slot"))],
+            literals: Vec::new(),
         },
     ])
 }
@@ -95,5 +96,28 @@ fn saving_what_loaded_reproduces_the_document() {
         serialize_to_bsn(&reloaded),
         saved,
         "and saving it again is a fixpoint",
+    );
+}
+
+/// The document as it was written before an action could carry constants. The
+/// field it leaves out is one the value takes a default for, so the whole
+/// binding still arrives.
+const BEFORE_LITERALS: &str = r#"#Bar
+jackdaw_bind::types::Bindings([
+    jackdaw_bind::types::Binding::Action { event: "game::hud::RetryPressed", fields: [["slot", jackdaw_bind::types::BindPath { raw: "game::hud::Save.slot" }]] },
+])
+"#;
+
+#[test]
+fn an_action_saved_without_literals_still_loads() {
+    let mut world = load(BEFORE_LITERALS);
+    assert_eq!(
+        bindings_of(&mut world, "Bar"),
+        Bindings(vec![Binding::Action {
+            event: "game::hud::RetryPressed".to_string(),
+            fields: vec![("slot".to_string(), BindPath::new("game::hud::Save.slot"))],
+            literals: Vec::new(),
+        }]),
+        "an older document keeps its mapping and takes no constants",
     );
 }

--- a/crates/jackdaw_runtime/Cargo.toml
+++ b/crates/jackdaw_runtime/Cargo.toml
@@ -54,6 +54,9 @@ avian3d = { workspace = true, optional = true }
 # the editor. Default features off, so a `navmesh`-only build takes the data
 # half alone and `terrain` asks for the rendering half by name.
 jackdaw_terrain = { version = "0.19.0", path = "../jackdaw_terrain", optional = true, default-features = false }
+# Authored animation sets: the state machine a rig plays and the binding step
+# that gives a body loaded from one file the clips exported in another.
+jackdaw_animation_runtime = { version = "0.19.0", path = "../jackdaw_animation_runtime", optional = true }
 serde.workspace = true
 serde_json.workspace = true
 thiserror = "2"
@@ -100,6 +103,16 @@ terrain = ["render", "navmesh", "jackdaw_terrain/render"]
 # root. Decoding only: nothing is meshed and nothing is drawn, so a server that
 # validates moves takes this without `terrain`.
 navmesh = ["dep:jackdaw_terrain"]
+# Play the animation sets a scene authored. Bevy's own animation and glTF
+# support come with it, since a set's clips are named animations in a glTF
+# file and `gltf_animation` is what puts them on the loaded file at all. Off by
+# default: a game with no rigs links neither.
+animation = [
+    "dep:jackdaw_animation_runtime",
+    "bevy/bevy_animation",
+    "bevy/bevy_gltf",
+    "bevy/gltf_animation",
+]
 
 [lints]
 workspace = true
@@ -114,3 +127,6 @@ avian3d = { workspace = true }
 # Terrain tests build a sidecar to load back. Optional for the library, so the
 # test targets name it themselves.
 jackdaw_terrain = { version = "0.19.0", path = "../jackdaw_terrain" }
+# The animation test reads the components a loaded set spawned with. Optional
+# for the library, so the test target names it itself.
+jackdaw_animation_runtime = { version = "0.19.0", path = "../jackdaw_animation_runtime" }

--- a/crates/jackdaw_runtime/src/lib.rs
+++ b/crates/jackdaw_runtime/src/lib.rs
@@ -56,6 +56,9 @@
 //!   components. The game adds `PhysicsPlugins` itself to simulate them. With
 //!   `terrain` as well, the authored ground gets a heightfield collider built
 //!   from the heights it is drawn from.
+//! - `animation`: play the animation sets a scene authored, binding each to
+//!   the skeleton spawned under it. Off by default: a game with no rigs links
+//!   neither Bevy's animation support nor its glTF loader.
 //! - `pie`: play-in-editor, streaming this world to a running editor.
 
 use std::any::TypeId;
@@ -197,6 +200,11 @@ impl Plugin for JackdawPlugin {
 
         #[cfg(feature = "terrain")]
         app.add_plugins(terrain::plugin);
+
+        // Registers the authored animation types as well as playing them, so
+        // a set survives a load in the same build that runs it.
+        #[cfg(feature = "animation")]
+        app.add_plugins(jackdaw_animation_runtime::AnimationRuntimePlugin);
 
         // Build avian colliders from authored `AvianCollider` components so
         // brushes collide at runtime. Add `PhysicsPlugins` in your app to run

--- a/crates/jackdaw_runtime/tests/animation_scene_load.rs
+++ b/crates/jackdaw_runtime/tests/animation_scene_load.rs
@@ -1,0 +1,145 @@
+#![cfg(feature = "animation")]
+//! A game runtime plays the animation set its scenes were authored with.
+//!
+//! The set names its clips by file and its skeleton by bone name, so the only
+//! thing the document carries is text; everything else is resolved after the
+//! scene has spawned.
+
+use bevy::{
+    animation::{
+        AnimationClip, AnimationTargetId, animated_field,
+        animation_curves::{AnimatableCurve, AnimatableKeyframeCurve},
+        transition::AnimationTransitions,
+    },
+    gltf::Gltf,
+    platform::collections::HashMap,
+    prelude::*,
+};
+use jackdaw_animation_runtime::{AnimationSet, AnimationSetBound};
+use jackdaw_runtime::{JackdawPlugin, JackdawScene, JackdawSceneRoot};
+
+/// Holds the stand-in source, which is dropped from the asset store the moment
+/// nothing points at it.
+#[derive(Resource)]
+struct SourceHandle(
+    #[expect(dead_code, reason = "held only to keep the asset alive")] Handle<Gltf>,
+);
+
+const SCENE: &str = r#"
+bevy_ecs::hierarchy::Children [
+    #Rig
+    jackdaw_animation_runtime::AnimationSet {
+        sources: ["rig.glb"],
+        states: [
+            jackdaw_animation_runtime::AnimationStateDef {
+                name: "idle",
+                source: 0,
+                clip: "Idle",
+                looped: true,
+                transition_secs: 0.15,
+                speed: 1.0,
+                then: None,
+            },
+        ],
+        default_state: "idle",
+        skeleton_root: "Armature",
+    }
+    bevy_ecs::hierarchy::Children [
+        #Armature
+        bevy_transform::components::transform::Transform
+    ]
+]
+"#;
+
+#[test]
+fn a_loaded_scene_plays_its_default_state() {
+    let mut app = runtime_app();
+    stand_in_for_source(&mut app, "rig.glb", "Idle");
+    let scene = app
+        .world_mut()
+        .resource_mut::<Assets<JackdawScene>>()
+        .add(JackdawScene::new(SCENE.into(), ".".into()));
+    app.world_mut().spawn(JackdawSceneRoot(scene));
+
+    for _ in 0..4 {
+        app.update();
+    }
+
+    let rig = named_entity(app.world_mut(), "Rig");
+    let armature = named_entity(app.world_mut(), "Armature");
+    assert!(
+        app.world().get::<AnimationSet>(rig).is_some(),
+        "the authored set loaded"
+    );
+    let bound = app
+        .world()
+        .get::<AnimationSetBound>(rig)
+        .expect("the set found the skeleton the scene spawned under it");
+    assert_eq!(bound.player, armature);
+    assert_eq!(
+        app.world()
+            .get::<AnimationTransitions>(armature)
+            .and_then(AnimationTransitions::get_main_animation),
+        Some(bound.nodes["idle"]),
+        "a game plays the set's default state with nothing else asking it to"
+    );
+}
+
+/// Puts a file holding one named clip where the asset server would find it,
+/// so the test needs no glTF on disk.
+fn stand_in_for_source(app: &mut App, path: &'static str, clip_name: &str) {
+    let curve = AnimatableKeyframeCurve::new([(0.0, Vec3::ZERO), (1.0, Vec3::X)])
+        .expect("two keyframes make a curve");
+    let mut clip = AnimationClip::default();
+    let names = [Name::new("Armature")];
+    clip.add_curve_to_target(
+        AnimationTargetId::from_names(names.iter()),
+        AnimatableCurve::new(animated_field!(Transform::translation), curve),
+    );
+    let clip = app
+        .world_mut()
+        .resource_mut::<Assets<AnimationClip>>()
+        .add(clip);
+    let gltf = Gltf {
+        scenes: Vec::new(),
+        named_scenes: HashMap::default(),
+        meshes: Vec::new(),
+        named_meshes: HashMap::default(),
+        materials: Vec::new(),
+        named_materials: HashMap::default(),
+        nodes: Vec::new(),
+        named_nodes: HashMap::default(),
+        skins: Vec::new(),
+        named_skins: HashMap::default(),
+        default_scene: None,
+        animations: vec![clip.clone()],
+        named_animations: [(clip_name.into(), clip)].into_iter().collect(),
+        source: None,
+    };
+    let handle: Handle<Gltf> = app.world().resource::<AssetServer>().load(path);
+    app.world_mut()
+        .resource_mut::<Assets<Gltf>>()
+        .insert(handle.id(), gltf)
+        .expect("the stand-in source is the only thing written at that id");
+    app.insert_resource(SourceHandle(handle));
+}
+
+fn runtime_app() -> App {
+    let mut app = App::new();
+    app.add_plugins(MinimalPlugins);
+    app.add_plugins(bevy::transform::TransformPlugin);
+    app.add_plugins(AssetPlugin::default());
+    app.add_plugins(bevy::world_serialization::WorldSerializationPlugin);
+    app.add_plugins(bevy::animation::AnimationPlugin);
+    app.add_plugins(JackdawPlugin);
+    app.init_asset::<Gltf>();
+    app
+}
+
+fn named_entity(world: &mut World, target: &str) -> Entity {
+    let mut names = world.query::<(Entity, &Name)>();
+    names
+        .iter(world)
+        .find_map(|(entity, name)| (name.as_str() == target).then_some(entity))
+        .unwrap_or_else(|| panic!("expected entity named {target}"))
+}

--- a/crates/jackdaw_sdk/Cargo.toml
+++ b/crates/jackdaw_sdk/Cargo.toml
@@ -40,6 +40,7 @@ jackdaw_runtime = { workspace = true, features = [
     "pie",
     "terrain",
     "navmesh",
+    "animation",
 ] }
 # The version `bevy_math` uses, with the generator features a project's own
 # `rand` dependency enables, so the SDK build already carries them.

--- a/src/boot_ops.rs
+++ b/src/boot_ops.rs
@@ -208,6 +208,7 @@ fn declared_params(world: &mut World, id: &str) -> Vec<&'static ParamSpec> {
 /// entity it means, since a guessed target can write to a file or reparent a
 /// node the author never pointed at.
 pub const SELECTION_FALLBACK_OPS: &[&str] = &[
+    "animation.set_state",
     "animation.toggle_keyframe",
     "binding.add",
     "binding.set",

--- a/src/entity_ops.rs
+++ b/src/entity_ops.rs
@@ -1823,6 +1823,7 @@ pub(crate) fn add_to_extension(ctx: &mut ExtensionContext) {
         .register_operator::<EntityAddConeOp>()
         .register_operator::<EntityAddPyramidOp>()
         .register_operator::<EntityAddAnimationPlayerOp>()
+        .register_operator::<AnimationSetStateOp>()
         .register_operator::<EntityAddAudioSourceOp>()
         .register_operator::<EntityAddFogVolumeOp>()
         .register_operator::<EntityAddReflectionProbeOp>()
@@ -2473,6 +2474,36 @@ pub(crate) fn entity_add_terrain(
 #[operator(id = "entity.add.prefab", label = "Prefab")]
 pub fn entity_add_prefab(_: In<OperatorParameters>, mut commands: Commands) -> OperatorResult {
     commands.queue(crate::prefab::operators::open_prefab_picker);
+    OperatorResult::Finished
+}
+
+// -- Animation ---------------------------------------------------
+
+/// Ask an entity's animation set for one of the states it declares, so an
+/// authored set previews in the viewport the way it plays in the game.
+#[operator(
+    id = "animation.set_state",
+    label = "Set Animation State",
+    description = "Play one of the states an entity's animation set declares.",
+    params(
+        entity(
+            Entity,
+            doc = "Entity carrying the animation set. Defaults to the selection."
+        ),
+        state(String, doc = "Name of the state to play."),
+    )
+)]
+pub(crate) fn animation_set_state(
+    params: In<OperatorParameters>,
+    mut commands: Commands,
+) -> OperatorResult {
+    let entity = params.as_entity("entity")?;
+    let state = params.as_str("state").map(str::to_string)?;
+    commands.queue(move |world: &mut World| {
+        if let Ok(mut entity) = world.get_entity_mut(entity) {
+            entity.insert(jackdaw_animation_runtime::AnimationState(state));
+        }
+    });
     OperatorResult::Finished
 }
 

--- a/src/inspector/bindings_card.rs
+++ b/src/inspector/bindings_card.rs
@@ -152,6 +152,7 @@ impl BindKind {
             BindKind::Action => Binding::Action {
                 event: String::new(),
                 fields: Vec::new(),
+                literals: Vec::new(),
             },
         }
     }
@@ -187,6 +188,8 @@ pub enum BindControl {
     AsPercent,
     TwoWay,
     Event,
+    /// The constant one event field takes when no path fills it.
+    Literal,
     AddRead,
     RemoveRead(usize),
     MoveUp,
@@ -289,6 +292,32 @@ fn set_path(binding: &mut Binding, slot: PathSlot, event_field: &str, raw: Strin
             }
         }
         _ => {}
+    }
+}
+
+/// The constant on `field`, or empty when the binding carries none.
+fn literal_at<'a>(binding: &'a Binding, field: &str) -> &'a str {
+    let Binding::Action { literals, .. } = binding else {
+        return "";
+    };
+    literals
+        .iter()
+        .find(|(name, _)| name == field)
+        .map_or("", |(_, text)| text.as_str())
+}
+
+/// Put `text` on `field`. Empty text takes the constant off, the way an empty
+/// path takes a mapping off.
+fn set_literal(binding: &mut Binding, field: &str, text: String) {
+    let Binding::Action { literals, .. } = binding else {
+        return;
+    };
+    if text.is_empty() {
+        literals.retain(|(name, _)| name != field);
+    } else if let Some((_, value)) = literals.iter_mut().find(|(name, _)| name == field) {
+        *value = text;
+    } else {
+        literals.push((field.to_string(), text));
     }
 }
 
@@ -854,7 +883,12 @@ impl SchemaCtx {
 
     /// The first thing wrong with a binding, in reading order.
     fn binding_error(&self, binding: &Binding) -> Option<BindError> {
-        if let Binding::Action { event, fields } = binding {
+        if let Binding::Action {
+            event,
+            fields,
+            literals,
+        } = binding
+        {
             if !event.is_empty() && self.schema_known && self.event(event).is_none() {
                 return Some(BindError::UnknownType {
                     noun: "event type",
@@ -862,9 +896,11 @@ impl SchemaCtx {
                 });
             }
             if let Some(schema) = self.event(event)
-                && let Some((name, _)) = fields
+                && let Some(name) = fields
                     .iter()
-                    .find(|(name, _)| !schema.fields.iter().any(|field| field == name))
+                    .map(|(name, _)| name)
+                    .chain(literals.iter().map(|(name, _)| name))
+                    .find(|name| !schema.fields.iter().any(|field| field == *name))
             {
                 return Some(BindError::UnknownEventField {
                     field: name.clone(),
@@ -892,11 +928,19 @@ impl SchemaCtx {
     /// The complaint for one unmapped field of an event that cannot fill its own
     /// gaps, the one unfinished binding known to fail at dispatch.
     fn gap_warning(&self, binding: &Binding, field: &str) -> Option<BindError> {
-        let Binding::Action { event, fields } = binding else {
+        let Binding::Action {
+            event,
+            fields,
+            literals,
+        } = binding
+        else {
             return None;
         };
         let schema = self.event(event)?;
-        if schema.fills_gaps || fields.iter().any(|(mapped, _)| mapped == field) {
+        if schema.fills_gaps
+            || fields.iter().any(|(mapped, _)| mapped == field)
+            || literals.iter().any(|(mapped, _)| mapped == field)
+        {
             return None;
         }
         Some(BindError::UnfillableEvent {
@@ -984,7 +1028,7 @@ fn summary(binding: &Binding) -> String {
             let arrow = if *two_way { "<->" } else { "<-" };
             format!("value {arrow} {}", display_path(&with.raw))
         }
-        Binding::Action { event, fields } => {
+        Binding::Action { event, fields, .. } => {
             let event = if event.is_empty() {
                 "...".to_string()
             } else {
@@ -1172,13 +1216,27 @@ fn spawn_binding_row(
                 *two_way,
             );
         }
-        Binding::Action { event, fields } => {
+        Binding::Action {
+            event,
+            fields,
+            literals,
+        } => {
             spawn_event_picker(commands, row, source, index, event, ctx);
-            // Without a schema the rows fall back to whatever is already
-            // mapped: a mapping the card does not draw cannot be taken back.
+            // Without a schema the rows fall back to whatever the binding
+            // already names: a field the card does not draw cannot be taken
+            // back.
             let names: Vec<String> = match ctx.event(event) {
                 Some(schema) => schema.fields.clone(),
-                None => fields.iter().map(|(name, _)| name.clone()).collect(),
+                None => {
+                    let mut named: Vec<String> =
+                        fields.iter().map(|(name, _)| name.clone()).collect();
+                    for (name, _) in literals {
+                        if !named.contains(name) {
+                            named.push(name.clone());
+                        }
+                    }
+                    named
+                }
             };
             for name in names {
                 spawn_path_row(
@@ -1189,12 +1247,13 @@ fn spawn_binding_row(
                         index,
                         slot: PathSlot::EventField,
                         label: name.clone(),
-                        event_field: name,
+                        event_field: name.clone(),
                         removable: false,
                     },
                     binding,
                     ctx,
                 );
+                spawn_literal_input(commands, row, source, index, &name, binding);
             }
         }
     }
@@ -1658,6 +1717,29 @@ fn spawn_text_input(
     ));
 }
 
+/// The constant one event field takes when no path fills it. Empty text clears
+/// it, the way an empty path clears a mapping.
+fn spawn_literal_input(
+    commands: &mut Commands,
+    parent: Entity,
+    source: Entity,
+    index: usize,
+    field: &str,
+    binding: &Binding,
+) {
+    let row = spawn_field_row(commands, parent, FieldRowProps::new(format!("{field} =")));
+    commands.spawn((
+        text_edit(
+            TextEditProps::default()
+                .with_placeholder("constant")
+                .with_default_value(literal_at(binding, field))
+                .allow_empty(),
+        ),
+        BindingControl::for_event_field(source, index, BindControl::Literal, field),
+        ChildOf(row.control),
+    ));
+}
+
 fn spawn_add_read(
     commands: &mut Commands,
     parent: Entity,
@@ -1776,6 +1858,7 @@ struct BindingEdit {
     two_way: Option<bool>,
     event: Option<String>,
     map: Option<Vec<(String, BindPath)>>,
+    literals: Option<Vec<(String, String)>>,
 }
 
 impl BindingEdit {
@@ -1810,6 +1893,13 @@ impl BindingEdit {
                     .map(|(field, path)| (field.to_string(), BindPath::new(path)))
                     .collect()
             }),
+            literals: params.as_str("literals").map(|raw| {
+                raw.split(',')
+                    .filter(|part| !part.is_empty())
+                    .filter_map(|pair| pair.split_once('='))
+                    .map(|(field, text)| (field.to_string(), text.to_string()))
+                    .collect()
+            }),
         }
     }
 
@@ -1826,6 +1916,7 @@ impl BindingEdit {
             two_way,
             event,
             map,
+            literals,
         } = self;
         match binding {
             Binding::Field {
@@ -1851,6 +1942,7 @@ impl BindingEdit {
                     ("two_way", two_way.is_some()),
                     ("event", event.is_some()),
                     ("map", map.is_some()),
+                    ("literals", literals.is_some()),
                 ]));
             }
             Binding::Text {
@@ -1870,6 +1962,7 @@ impl BindingEdit {
                     ("two_way", two_way.is_some()),
                     ("event", event.is_some()),
                     ("map", map.is_some()),
+                    ("literals", literals.is_some()),
                 ]));
             }
             Binding::Visible {
@@ -1889,6 +1982,7 @@ impl BindingEdit {
                     ("two_way", two_way.is_some()),
                     ("event", event.is_some()),
                     ("map", map.is_some()),
+                    ("literals", literals.is_some()),
                 ]));
             }
             Binding::Value {
@@ -1908,22 +2002,28 @@ impl BindingEdit {
                     ("format", format.is_some()),
                     ("event", event.is_some()),
                     ("map", map.is_some()),
+                    ("literals", literals.is_some()),
                 ]));
             }
             Binding::Action {
                 event: event_slot,
                 fields,
+                literals: literals_slot,
             } => {
                 // A mapping belongs to the event it was made against, so a new
-                // event clears it before the clause's own map lands.
+                // event clears it before the clause's own values land.
                 if let Some(event) = event
                     && *event_slot != event
                 {
                     *event_slot = event;
                     fields.clear();
+                    literals_slot.clear();
                 }
                 if let Some(map) = map {
                     *fields = map;
+                }
+                if let Some(literals) = literals {
+                    *literals_slot = literals;
                 }
                 ignored.extend(named_keys(&[
                     ("read", read.is_some()),
@@ -1983,6 +2083,10 @@ fn named_keys(present: &[(&'static str, bool)]) -> Vec<&'static str> {
         two_way(bool, doc = "Let a Value binding write the author's edits back."),
         event(String, doc = "An Action binding's event type path."),
         map(String, doc = "Action field mapping, as comma-separated field:path pairs."),
+        literals(
+            String,
+            doc = "Action constants, as comma-separated field=value pairs, e.g. \"slot=2\"."
+        ),
     ),
 )]
 pub(crate) fn binding_add(
@@ -2044,6 +2148,10 @@ pub(crate) fn binding_add(
         two_way(bool, doc = "Let a Value binding write the author's edits back."),
         event(String, doc = "An Action binding's event type path."),
         map(String, doc = "Action field mapping, as comma-separated field:path pairs."),
+        literals(
+            String,
+            doc = "Action constants, as comma-separated field=value pairs, e.g. \"slot=2\"."
+        ),
     ),
 )]
 pub(crate) fn binding_set(
@@ -2331,12 +2439,17 @@ pub(crate) fn on_binding_combobox_change(
         BindControl::Event => {
             let picked = picked.unwrap_or_default();
             apply_to(&mut commands, source, index, move |binding| {
-                if let Binding::Action { event, fields } = binding
+                if let Binding::Action {
+                    event,
+                    fields,
+                    literals,
+                } = binding
                     && *event != picked
                 {
                     // A mapping belongs to the event it was made against.
                     *event = picked;
                     fields.clear();
+                    literals.clear();
                 }
             });
         }
@@ -2468,6 +2581,7 @@ pub(crate) fn on_binding_text_commit(
     }
     let text = event.text.clone();
     let control_kind = control.control;
+    let event_field = control.event_field.clone();
     apply_to(
         &mut commands,
         control.source,
@@ -2478,6 +2592,7 @@ pub(crate) fn on_binding_text_commit(
             | (Binding::Visible { via, .. }, BindControl::ViaText) => {
                 *via = (!text.is_empty()).then_some(text);
             }
+            (binding, BindControl::Literal) => set_literal(binding, &event_field, text),
             _ => {}
         },
     );
@@ -2674,6 +2789,7 @@ mod tests {
         let mut binding = Binding::Action {
             event: "demo::Fired".to_string(),
             fields: Vec::new(),
+            literals: Vec::new(),
         };
         set_path(
             &mut binding,

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -465,6 +465,7 @@ impl Plugin for EditorCorePlugin {
         .add_plugins(operator_tooltip::OperatorTooltipPlugin)
         .add_plugins(jackdaw_node_graph::NodeGraphPlugin)
         .add_plugins(jackdaw_animation::AnimationPlugin)
+        .add_plugins(jackdaw_animation_runtime::AnimationRuntimePlugin)
         .add_plugins(windowing::WindowingPlugin)
         .add_plugins(jackdaw_panels::DockPlugin)
         .add_plugins(input_contexts::InputContextsPlugin)

--- a/tests/inspector/bindings_card.rs
+++ b/tests/inspector/bindings_card.rs
@@ -17,6 +17,7 @@ use jackdaw_bsn::{BsnValue, SceneBsnAst};
 use jackdaw_commands::CommandHistory;
 use jackdaw_feathers::button::ButtonClickEvent;
 use jackdaw_feathers::combobox::{ComboBoxChangeEvent, EditorComboBox};
+use jackdaw_feathers::text_edit::TextEditCommitEvent;
 use jackdaw_feathers::tokens;
 use jackdaw_feathers::tooltip::Tooltip;
 use jackdaw_feathers::variant_edit::VariantEditConfig;
@@ -257,6 +258,15 @@ fn pick(app: &mut App, combo: Entity, selected: usize, label: &str, value: Optio
     app.update();
 }
 
+fn commit_text(app: &mut App, input: Entity, text: &str) {
+    app.world_mut().trigger(TextEditCommitEvent {
+        entity: input,
+        text: text.to_string(),
+    });
+    app.update();
+    app.update();
+}
+
 fn click(app: &mut App, button: Entity) {
     app.world_mut().trigger(ButtonClickEvent { entity: button });
     app.update();
@@ -451,6 +461,7 @@ fn every_binding_kind_renders_its_own_controls() {
         Binding::Action {
             event: "demo_game::Fired".to_string(),
             fields: Vec::new(),
+            literals: Vec::new(),
         },
     ]));
 
@@ -1034,6 +1045,7 @@ fn the_event_picker_offers_only_struct_events() {
     let (mut app, _) = app_with_bindings(Bindings(vec![Binding::Action {
         event: String::new(),
         fields: Vec::new(),
+        literals: Vec::new(),
     }]));
 
     let event = control(&mut app, 0, BindControl::Event);
@@ -1055,6 +1067,7 @@ fn an_event_that_cannot_fill_gaps_warns_while_fields_are_unmapped() {
     let (mut app, entity) = app_with_bindings(Bindings(vec![Binding::Action {
         event: "demo_game::Strict".to_string(),
         fields: Vec::new(),
+        literals: Vec::new(),
     }]));
 
     let body = card_body(&mut app);
@@ -1072,7 +1085,7 @@ fn an_event_that_cannot_fill_gaps_warns_while_fields_are_unmapped() {
     // Map it, and the warning goes.
     let combo = control(&mut app, 0, BindControl::PathType(PathSlot::EventField));
     pick(&mut app, combo, 0, "Health", Some("demo_game::Health"));
-    let Binding::Action { event, fields } = live(&app, entity).0[0].clone() else {
+    let Binding::Action { event, fields, .. } = live(&app, entity).0[0].clone() else {
         panic!("the binding is still an Action");
     };
     assert_eq!(event, "demo_game::Strict");
@@ -1114,6 +1127,45 @@ fn an_event_that_cannot_fill_gaps_warns_while_fields_are_unmapped() {
         !still_warning,
         "once every field is mapped there is nothing to warn about",
     );
+}
+
+/// A field with nothing worth reading can still be filled by hand: the constant
+/// lands on the row for the field it names, and clearing the text takes it off.
+#[test]
+fn a_constant_typed_on_an_action_row_fills_the_field_it_names() {
+    let (mut app, entity) = app_with_bindings(Bindings(vec![Binding::Action {
+        event: "demo_game::Strict".to_string(),
+        fields: Vec::new(),
+        literals: Vec::new(),
+    }]));
+
+    let input = control(&mut app, 0, BindControl::Literal);
+    commit_text(&mut app, input, "3");
+
+    let Binding::Action { literals, .. } = live(&app, entity).0[0].clone() else {
+        panic!("the binding is still an Action");
+    };
+    assert_eq!(literals, vec![("amount".to_string(), "3".to_string())]);
+
+    let body = card_body(&mut app);
+    let still_warning = descendants(app.world_mut(), body)
+        .into_iter()
+        .any(|entity| {
+            app.world()
+                .get::<Tooltip>(entity)
+                .is_some_and(|tip| tip.title.contains("leaves field 'amount' unmapped"))
+        });
+    assert!(
+        !still_warning,
+        "a field the binding carries a constant for is not an unmapped one",
+    );
+
+    let input = control(&mut app, 0, BindControl::Literal);
+    commit_text(&mut app, input, "");
+    let Binding::Action { literals, .. } = live(&app, entity).0[0].clone() else {
+        panic!("the binding is still an Action");
+    };
+    assert!(literals.is_empty(), "empty text takes the constant off");
 }
 
 /// A `Field` binding writes fields of the widget's own components, so the write
@@ -1287,6 +1339,7 @@ fn an_action_keeps_its_mappings_when_the_event_is_unknown() {
             "amount".to_string(),
             BindPath::new("demo_game::Health.current"),
         )],
+        literals: Vec::new(),
     }]));
 
     let combo = control(&mut app, 0, BindControl::PathField(PathSlot::EventField));
@@ -1396,6 +1449,7 @@ fn a_saved_binding_comes_back_off_disk_unchanged() {
         Binding::Action {
             event: "game::hud::RetryPressed".to_string(),
             fields: vec![("slot".to_string(), BindPath::new("game::hud::Save.slot"))],
+            literals: Vec::new(),
         },
     ]);
     let (mut app, _) = app_with_bindings(authored.clone());

--- a/tests/operators/authoring_ops.rs
+++ b/tests/operators/authoring_ops.rs
@@ -1052,7 +1052,7 @@ fn every_binding_shape_the_card_offers_is_reachable_from_a_clause() {
     run_finished(
         &mut app,
         "binding.add entity=Button kind=action event=operators::authoring_ops::Hit \
-         map=amount:operators::authoring_ops::AuthoringHealth.current",
+         map=amount:operators::authoring_ops::AuthoringHealth.current literals=slot=2",
     );
 
     assert_eq!(
@@ -1090,6 +1090,7 @@ fn every_binding_shape_the_card_offers_is_reachable_from_a_clause() {
                     "amount".to_string(),
                     BindPath::new("operators::authoring_ops::AuthoringHealth.current"),
                 )],
+                literals: vec![("slot".to_string(), "2".to_string())],
             },
         ],
         "a clause authored a shape the card would not have"

--- a/tests/operators/authoring_ops.rs
+++ b/tests/operators/authoring_ops.rs
@@ -524,6 +524,7 @@ fn a_number_where_an_entity_belongs_is_refused_on_the_boot_path_too() {
 /// fill it from the selection. Each is classified explicitly: left to a default,
 /// the prefab family would inherit one that writes files.
 const ENTITY_PARAM_OPS: &[(&str, &[&str], bool)] = &[
+    ("animation.set_state", &["entity"], true),
     ("animation.toggle_keyframe", &["entity"], true),
     ("binding.add", &["entity"], true),
     ("binding.set", &["entity"], true),


### PR DESCRIPTION

An Action binding could only fill event fields from bind paths. It now carries literals too: field name and value as text, coerced through the same path bound values take, with a bound field winning over a literal naming it. `binding.add`/`binding.set` take `literals=field=value` pairs and the bindings card edits them. Loading a struct enum variant now lets FromReflect fill fields the document leaves out, so documents saved before the new field existed still load.
