### PR TITLE
Resolve runtime GltfSource paths from the assets root

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -5326,6 +5326,7 @@ name = "jackdaw_scene_types"
 version = "0.19.0"
 dependencies = [
  "bevy",
+ "dunce",
  "glam 0.32.1",
  "jackdaw_geometry",
  "rand 0.9.5",

--- a/crates/jackdaw_runtime/src/lib.rs
+++ b/crates/jackdaw_runtime/src/lib.rs
@@ -198,6 +198,14 @@ impl Plugin for JackdawPlugin {
         #[cfg(feature = "render")]
         app.add_plugins(MaterialTextureFormatPlugin);
 
+        // Game code may add a model to an entity long after the scene it lives
+        // in was loaded, and such a source resolves exactly as an authored one.
+        #[cfg(feature = "render")]
+        app.add_systems(
+            Update,
+            attach_inserted_gltf_sources.after(spawn_loaded_scenes),
+        );
+
         #[cfg(feature = "terrain")]
         app.add_plugins(terrain::plugin);
 
@@ -730,26 +738,19 @@ fn spawn_scene_entities(
 
     #[cfg(feature = "render")]
     {
+        let assets_dir = assets_root(world);
         let asset_server = world.resource::<AssetServer>().clone();
-        let gltf_entities: Vec<(Entity, String, usize)> = spawned
+        let gltf_entities: Vec<(Entity, jackdaw_scene_types::GltfSource)> = spawned
             .iter()
             .filter_map(|&e| {
                 world
                     .get::<jackdaw_scene_types::GltfSource>(e)
-                    .map(|gs| (e, gs.path.clone(), gs.scene_index))
+                    .map(|source| (e, source.clone()))
             })
             .collect();
-        for (entity, gltf_path, scene_index) in gltf_entities {
-            let resolved = if Path::new(&gltf_path).is_relative() {
-                parent_path.join(&gltf_path).to_string_lossy().into_owned()
-            } else {
-                gltf_path
-            };
-            let full_path = format!("{resolved}#Scene{scene_index}");
-            let scene_handle: Handle<WorldAsset> = asset_server.load(full_path);
-            world
-                .entity_mut(entity)
-                .insert(WorldAssetRoot(scene_handle));
+        for (entity, source) in gltf_entities {
+            let root = world_asset_root(&asset_server, &source, assets_dir.as_deref());
+            world.entity_mut(entity).insert(root);
         }
     }
     // A terrain's sidecar is named relative to the scene file, whose
@@ -757,10 +758,67 @@ fn spawn_scene_entities(
     #[cfg(feature = "terrain")]
     terrain::attach_sidecars(world, &spawned, parent_path);
 
-    #[cfg(not(feature = "render"))]
+    #[cfg(not(feature = "terrain"))]
     let _ = parent_path;
 
     members
+}
+
+/// The glTF scene an authored [`GltfSource`] names, as the handle the
+/// world-asset spawner instantiates.
+///
+/// The path is read the way the editor reads it, from the assets root rather
+/// than from beside the scene file, so a prefab stored in a subdirectory shows
+/// the same model in a built game that it showed while it was authored.
+///
+/// [`GltfSource`]: jackdaw_scene_types::GltfSource
+#[cfg(feature = "render")]
+fn world_asset_root(
+    asset_server: &AssetServer,
+    source: &jackdaw_scene_types::GltfSource,
+    assets_dir: Option<&Path>,
+) -> WorldAssetRoot {
+    let path = jackdaw_scene_types::to_asset_path(&source.path, assets_dir);
+    let scene: Handle<WorldAsset> =
+        asset_server.load(format!("{path}#Scene{}", source.scene_index));
+    WorldAssetRoot(scene)
+}
+
+/// Give a [`GltfSource`] inserted by game code the same `WorldAssetRoot` a
+/// scene-authored one gets at spawn.
+///
+/// Scene loading attaches the handle as it spawns, so this finds only sources
+/// that arrived some other way; re-inserting an equal handle would make the
+/// world-asset spawner despawn and rebuild the instance, so an entity that
+/// already points at the same glTF scene is left alone.
+///
+/// [`GltfSource`]: jackdaw_scene_types::GltfSource
+#[cfg(feature = "render")]
+fn attach_inserted_gltf_sources(
+    added: Query<
+        (Entity, &jackdaw_scene_types::GltfSource),
+        Added<jackdaw_scene_types::GltfSource>,
+    >,
+    existing: Query<&WorldAssetRoot>,
+    catalog_path: Option<Res<JackdawCatalogPath>>,
+    asset_folder: Option<Res<AssetFolder>>,
+    asset_server: Res<AssetServer>,
+    mut commands: Commands,
+) {
+    if added.is_empty() {
+        return;
+    }
+    let assets_dir = resolve_assets_root(catalog_path.as_deref(), asset_folder.as_deref());
+    for (entity, source) in &added {
+        let root = world_asset_root(&asset_server, source, assets_dir.as_deref());
+        if existing
+            .get(entity)
+            .is_ok_and(|current| current.0 == root.0)
+        {
+            continue;
+        }
+        commands.entity(entity).insert(root);
+    }
 }
 
 /// Spawn one document node and its subtree.
@@ -1370,12 +1428,22 @@ struct AssetFolder(Option<PathBuf>);
 /// directory [`JackdawCatalogPath`] points into when it is set, else the
 /// folder the app's [`AssetPlugin`] reads from.
 pub(crate) fn assets_root(world: &World) -> Option<PathBuf> {
-    if let Some(path) = world.get_resource::<JackdawCatalogPath>() {
+    resolve_assets_root(
+        world.get_resource::<JackdawCatalogPath>(),
+        world.get_resource::<AssetFolder>(),
+    )
+}
+
+/// [`assets_root`] over the two resources it reads, for systems that take them
+/// as parameters rather than reaching into the world.
+fn resolve_assets_root(
+    catalog_path: Option<&JackdawCatalogPath>,
+    asset_folder: Option<&AssetFolder>,
+) -> Option<PathBuf> {
+    if let Some(path) = catalog_path {
         return path.0.parent().map(ToOwned::to_owned);
     }
-    world
-        .get_resource::<AssetFolder>()
-        .and_then(|f| f.0.clone())
+    asset_folder.and_then(|folder| folder.0.clone())
 }
 
 /// Where the app reads assets from: [`AssetPlugin::file_path`] resolved the

--- a/crates/jackdaw_runtime/tests/gltf_source_paths.rs
+++ b/crates/jackdaw_runtime/tests/gltf_source_paths.rs
@@ -1,0 +1,74 @@
+//! An authored `GltfSource` path names a file under the assets root, not one
+//! beside the scene that wrote it, and a source game code inserts later is read
+//! the same way.
+
+use std::path::PathBuf;
+
+use bevy::prelude::*;
+use bevy::world_serialization::WorldAssetRoot;
+use jackdaw_runtime::{JackdawCatalogPath, JackdawPlugin, JackdawScene, JackdawSceneRoot};
+use jackdaw_scene_types::GltfSource;
+
+#[test]
+fn a_prefab_in_a_subdirectory_loads_its_gltf_from_the_assets_root() {
+    let dir = tempfile::tempdir().unwrap();
+    let mut app = runtime_app(dir.path());
+
+    let scene = app
+        .world_mut()
+        .resource_mut::<Assets<JackdawScene>>()
+        .add(JackdawScene::new(
+            "#Fox\n\
+             jackdaw_scene_types::types::GltfSource { path: \"characters/fox.gltf\", scene_index: 0 }\n"
+                .to_owned(),
+            PathBuf::from("prefabs"),
+        ));
+    app.world_mut().spawn(JackdawSceneRoot(scene));
+
+    app.update();
+    app.update();
+
+    assert_eq!(
+        loaded_gltf_path(app.world_mut()).as_deref(),
+        Some("characters/fox.gltf#Scene0"),
+        "the scene's own directory must not be prepended to the authored path"
+    );
+}
+
+#[test]
+fn a_gltf_source_inserted_at_runtime_spawns_its_model() {
+    let dir = tempfile::tempdir().unwrap();
+    let mut app = runtime_app(dir.path());
+
+    app.world_mut().spawn(GltfSource {
+        path: "characters/fox.gltf".to_owned(),
+        scene_index: 2,
+    });
+
+    app.update();
+
+    assert_eq!(
+        loaded_gltf_path(app.world_mut()).as_deref(),
+        Some("characters/fox.gltf#Scene2"),
+        "a source game code inserted gets the same model an authored one gets"
+    );
+}
+
+/// The glTF the one `GltfSource` entity ended up pointing the world-asset
+/// spawner at.
+fn loaded_gltf_path(world: &mut World) -> Option<String> {
+    let mut sources = world.query::<(&GltfSource, &WorldAssetRoot)>();
+    let (_, root) = sources.iter(world).next()?;
+    Some(root.0.path()?.to_string())
+}
+
+fn runtime_app(assets_root: &std::path::Path) -> App {
+    let mut app = App::new();
+    app.add_plugins(MinimalPlugins);
+    app.add_plugins(bevy::transform::TransformPlugin);
+    app.add_plugins(AssetPlugin::default());
+    app.add_plugins(bevy::world_serialization::WorldSerializationPlugin);
+    app.insert_resource(JackdawCatalogPath(assets_root.join("catalog.bsn")));
+    app.add_plugins(JackdawPlugin);
+    app
+}

--- a/crates/jackdaw_scene_types/Cargo.toml
+++ b/crates/jackdaw_scene_types/Cargo.toml
@@ -12,10 +12,14 @@ bevy = { version = "0.19", default-features = false, features = [
     "std",
     "serialize",
     "bevy_color",
+    "bevy_log",
 ] }
 jackdaw_geometry = { version = "0.19.0", path = "../jackdaw_geometry", default-features = false, features = [
     "reflect",
 ] }
+# Absolute authored paths are compared against the assets directory, which on
+# Windows may arrive with a verbatim prefix that no plain prefix test matches.
+dunce = "1.0.5"
 glam.workspace = true
 serde = { workspace = true, features = ["derive"] }
 serde_json.workspace = true

--- a/crates/jackdaw_scene_types/src/asset_path.rs
+++ b/crates/jackdaw_scene_types/src/asset_path.rs
@@ -1,0 +1,72 @@
+//! The one rule for turning an authored file path into a Bevy asset path.
+//!
+//! The editor and the standalone runtime both derive render state from paths a
+//! scene authored, and a path that resolved to two different files depending on
+//! which of them opened the scene would be a scene that renders differently in
+//! the game than it did while it was being made.
+
+use std::path::Path;
+
+use bevy::prelude::*;
+
+/// Resolve an authored path against the assets directory.
+///
+/// Authored paths are relative to the assets root, never to the file that
+/// named them: a prefab stored under `prefabs/` and a scene at the root both
+/// reach the same model by writing `characters/fox.gltf`.
+///
+/// `assets_dir` is the caller's absolute assets directory, when it knows one.
+/// An absolute input -- what scenes authored before paths were normalised
+/// still hold -- has that directory stripped off it, so the load goes through
+/// Bevy's approved-path machinery rather than needing
+/// `UnapprovedPathMode::Allow`. An absolute path outside the assets directory
+/// warns and comes back unchanged; callers should not rely on it loading.
+pub fn to_asset_path(path: &str, assets_dir: Option<&Path>) -> String {
+    let path = dunce::simplified(Path::new(path));
+    if let Some(assets_dir) = assets_dir
+        && let Ok(relative) = path.strip_prefix(dunce::simplified(assets_dir))
+    {
+        return relative.to_string_lossy().into_owned();
+    }
+    if !path.is_absolute() {
+        return path.to_string_lossy().into_owned();
+    }
+    warn!(
+        "Cannot load '{}': file is outside the assets directory. \
+         Move it into your project's assets/ folder.",
+        path.display()
+    );
+    path.to_string_lossy().into_owned()
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn a_relative_path_is_read_from_the_assets_root_whatever_named_it() {
+        assert_eq!(
+            to_asset_path("characters/fox.gltf", Some(Path::new("/project/assets"))),
+            "characters/fox.gltf"
+        );
+    }
+
+    #[test]
+    fn an_absolute_path_inside_the_assets_dir_loses_that_prefix() {
+        assert_eq!(
+            to_asset_path(
+                "/project/assets/characters/fox.gltf",
+                Some(Path::new("/project/assets"))
+            ),
+            "characters/fox.gltf"
+        );
+    }
+
+    #[test]
+    fn a_relative_path_survives_an_unknown_assets_dir() {
+        assert_eq!(
+            to_asset_path("characters/fox.gltf", None),
+            "characters/fox.gltf"
+        );
+    }
+}

--- a/crates/jackdaw_scene_types/src/lib.rs
+++ b/crates/jackdaw_scene_types/src/lib.rs
@@ -17,12 +17,14 @@
 //! `jackdaw_runtime` and `jackdaw` re-export both newtypes
 //! through their preludes.
 
+pub mod asset_path;
 pub mod brush_chunks;
 #[cfg(feature = "render")]
 pub mod mesh_rebuild;
 pub mod node_id;
 pub mod types;
 
+pub use asset_path::to_asset_path;
 pub use brush_chunks::{MeshChunk, build_brush_chunks};
 #[cfg(feature = "render")]
 pub use mesh_rebuild::evaluate_brush_geometry;

--- a/src/entity_ops.rs
+++ b/src/entity_ops.rs
@@ -1727,27 +1727,11 @@ fn hide_all_entities(world: &mut World, scene_entities: &mut SystemState<SceneEn
 /// Bevy's default asset source reads from `<base>/assets/` where `<base>` is
 /// `BEVY_ASSET_ROOT`, `CARGO_MANIFEST_DIR`, or the executable's parent directory.
 ///
-/// Strips the assets-dir prefix when the input is absolute so the load goes
-/// through Bevy's approved-path machinery (no `UnapprovedPathMode::Allow`
-/// needed). Returns the original path on a miss and warns; callers should not
-/// rely on the fallback ever loading successfully under `Forbid`.
+/// The rule itself lives in [`jackdaw_scene_types::to_asset_path`], which the
+/// standalone runtime applies to the same authored paths; this only supplies
+/// the editor's notion of where the assets directory is.
 pub fn to_asset_path(path: &str) -> String {
-    let path = dunce::simplified(Path::new(path));
-    if let Some(assets_dir) = get_assets_base_dir()
-        && let Ok(relative) = path.strip_prefix(dunce::simplified(&assets_dir))
-    {
-        return relative.to_string_lossy().to_string();
-    }
-    // Fallback: if already a simple relative path, use as-is
-    if !path.is_absolute() {
-        return path.to_string_lossy().to_string();
-    }
-    warn!(
-        "Cannot load '{}': file is outside the assets directory. \
-         Move it into your project's assets/ folder.",
-        path.display()
-    );
-    path.to_string_lossy().to_string()
+    jackdaw_scene_types::to_asset_path(path, get_assets_base_dir().as_deref())
 }
 
 /// Get the absolute path of Bevy's assets directory.


### PR DESCRIPTION
A relative GltfSource path was joined onto the scene file's directory at
runtime, so a prefab under prefabs/ looked for prefabs/characters/fox.gltf
and rendered nothing where the editor showed a model. The path rule now
lives once, in jackdaw_scene_types, and both apply it.

A GltfSource inserted by game code also got no WorldAssetRoot at all, since
the conversion only ran during scene spawn; an Added<GltfSource> system now
gives it the same handle an authored one gets.
