### PR TITLE
Take a prefab's fingerprint when it is read so the watch starting is not an edit

### DIFF
--- a/src/prefab/cache.rs
+++ b/src/prefab/cache.rs
@@ -6,10 +6,10 @@ use std::path::Path;
 use crate::prefab::canonical_path::{CanonicalPrefabPath, canonical_prefab_path};
 
 /// Snapshot of a prefab file's identity at the moment the editor
-/// wrote it. The watcher compares the current on-disk fingerprint
-/// against this entry to recognise its own echoed write event and
-/// skip the reload that would otherwise clobber in-memory edits
-/// landing between the save and the watcher firing.
+/// wrote or read it. The watcher compares the current on-disk
+/// fingerprint against this entry to recognise its own echoed write,
+/// or the first look it takes when a watch starts, and skip the reload
+/// that would otherwise clobber in-memory edits.
 #[derive(Clone, Debug, PartialEq)]
 pub struct SavedFingerprint {
     pub mtime: std::time::SystemTime,

--- a/src/prefab/save_load.rs
+++ b/src/prefab/save_load.rs
@@ -40,7 +40,14 @@ fn cache_prefab_tree_inner(path: &Path, cache: &mut PrefabAstCache, depth: usize
     }
     if cache.get(path).is_none() {
         match read_prefab_ast(path) {
-            Ok(prefab_ast) => cache.insert(path, prefab_ast),
+            Ok(prefab_ast) => {
+                cache.insert(path, prefab_ast);
+                // The file as read is the watcher's baseline: the first look
+                // it takes when the watch starts must not read as an edit.
+                if let Ok(fingerprint) = crate::prefab::cache::compute_file_fingerprint(path) {
+                    cache.record_saved_fingerprint(path, fingerprint);
+                }
+            }
             Err(_) => return,
         }
     }

--- a/src/prefab/watcher.rs
+++ b/src/prefab/watcher.rs
@@ -219,9 +219,11 @@ fn drain_changes(world: &mut World) {
 
         match crate::prefab::save_load::read_prefab_ast(&path) {
             Ok(new_ast) => {
-                world
-                    .resource_mut::<PrefabAstCache>()
-                    .insert(cache_key.clone(), new_ast);
+                let mut cache = world.resource_mut::<PrefabAstCache>();
+                cache.insert(cache_key.clone(), new_ast);
+                if let Ok(fingerprint) = crate::prefab::cache::compute_file_fingerprint(&path) {
+                    cache.record_saved_fingerprint(&path, fingerprint);
+                }
             }
             Err(e) => {
                 // Keep the last copy that parsed: without a baseline to

--- a/tests/prefabs/prefab_lifecycle.rs
+++ b/tests/prefabs/prefab_lifecycle.rs
@@ -718,6 +718,42 @@ fn prefab_file_change_triggers_reload() {
 }
 
 #[test]
+fn a_prefab_is_not_reloaded_when_its_watch_starts() {
+    let tmp = tempfile::tempdir().unwrap();
+    let prefab_path = tmp.path().join("p.bsn");
+    let scene_path = tmp.path().join("s.jsn");
+
+    let mut app = make_app_for_prefab_tests();
+    app.add_plugins(jackdaw::prefab::watcher::PrefabWatcherPlugin);
+    write_bsn_prefab(&mut app, &prefab_path, &prefab_with_name("v1"));
+    std::fs::write(&scene_path, scene_referencing(&prefab_path)).unwrap();
+
+    jackdaw::scene_io::load_scene_from_file(app.world_mut(), &scene_path);
+    app.update();
+
+    let entity_named = |app: &mut App| {
+        let mut names = app.world_mut().query::<(Entity, &Name)>();
+        names
+            .iter(app.world())
+            .find(|(_, name)| name.as_str() == "v1")
+            .map(|(entity, _)| entity)
+    };
+    let before = entity_named(&mut app).expect("the instance spawned");
+
+    let deadline = std::time::Instant::now() + std::time::Duration::from_millis(800);
+    while std::time::Instant::now() < deadline {
+        app.update();
+        std::thread::sleep(std::time::Duration::from_millis(25));
+    }
+
+    assert_eq!(
+        entity_named(&mut app),
+        Some(before),
+        "the watch starting is not a change; the instance keeps its entity"
+    );
+}
+
+#[test]
 fn spawn_instance_caches_and_spawns_inherited_entity() {
     let tmp = tempfile::tempdir().unwrap();
     let prefab_path = tmp.path().join("rock.bsn");


### PR DESCRIPTION
The prefab watcher queues every newly watched file as a change, and its own-write check only knew fingerprints the editor had written. A file it had merely read therefore reloaded once, about 150 ms after its watch began, respawning every instance and dropping the selection. On a loaded runner that reload landed between two clicks of the outliner tests.

The cache now records a file's fingerprint when it reads it, so the first look the watch takes is not an edit, while a real edit made before the watch started still reloads.
