### PR TITLE
Write clip playheads from bound sets and graphs so authored clip events fire

### DIFF
--- a/crates/jackdaw_animation_runtime/src/events.rs
+++ b/crates/jackdaw_animation_runtime/src/events.rs
@@ -22,35 +22,48 @@ pub struct ClipEvent {
     pub name: String,
 }
 
-/// How far through its clip playback has come, written by whatever plays it.
-///
-/// Runtime only: the pair of times is a per-frame reading, not something a
-/// document holds.
+/// How far through its clip playback has come, written each frame by
+/// whatever plays it; never saved.
 #[derive(Component, Debug, Clone, Copy, Default)]
 pub struct ClipPlayhead {
     /// Where playback stood when events last fired.
     pub last: f32,
     /// Where it stands now.
     pub now: f32,
+    /// How playback travelled from one to the other.
+    pub pass: ClipPass,
+}
+
+/// The way playback moved through a clip between two readings.
+#[derive(Debug, Clone, Copy, Default, PartialEq, Eq)]
+pub enum ClipPass {
+    /// Onwards through the clip.
+    #[default]
+    Forward,
+    /// Onwards, off the end of the clip and on again from the start.
+    ForwardWrapped,
+    /// Back through the clip.
+    Backward,
+    /// Back off the start of the clip and on again from the end.
+    BackwardWrapped,
 }
 
 impl ClipPlayhead {
     /// Move the playhead to `now`, keeping where it came from.
-    pub fn advance_to(&mut self, now: f32) {
+    pub fn advance_to(&mut self, now: f32, pass: ClipPass) {
         self.last = self.now;
         self.now = now;
+        self.pass = pass;
     }
 
-    /// Whether the span since the last reading covers `time`.
-    ///
-    /// The span is half open on the left so a playhead parked on a key does
-    /// not fire it again next tick. A span that runs backwards is a clip that
-    /// wrapped, so it covers the tail of the clip and the head of it both.
+    /// Whether the span since the last reading covers `time`: closed at the end
+    /// playback moves towards, open at the one it left, both ends on a wrap.
     fn covers(&self, time: f32) -> bool {
-        if self.now >= self.last {
-            time > self.last && time <= self.now
-        } else {
-            time > self.last || time <= self.now
+        match self.pass {
+            ClipPass::Forward => time >= self.last && time < self.now,
+            ClipPass::ForwardWrapped => time >= self.last || time < self.now,
+            ClipPass::Backward => time >= self.now && time < self.last,
+            ClipPass::BackwardWrapped => time >= self.now || time < self.last,
         }
     }
 }
@@ -87,6 +100,7 @@ pub fn fire_clip_events(
             }
         }
         playhead.last = playhead.now;
+        playhead.pass = ClipPass::Forward;
     }
 }
 
@@ -120,10 +134,20 @@ mod tests {
         clip: Entity,
         now: f32,
     ) -> Vec<AnimationEvent> {
+        moved_to(app, cursor, clip, now, ClipPass::Forward)
+    }
+
+    fn moved_to(
+        app: &mut App,
+        cursor: &mut bevy::ecs::message::MessageCursor<AnimationEvent>,
+        clip: Entity,
+        now: f32,
+        pass: ClipPass,
+    ) -> Vec<AnimationEvent> {
         app.world_mut()
             .get_mut::<ClipPlayhead>(clip)
             .expect("the clip carries a playhead")
-            .now = now;
+            .advance_to(now, pass);
         app.update();
         cursor
             .read(app.world().resource::<Messages<AnimationEvent>>())
@@ -166,12 +190,43 @@ mod tests {
         let mut seen = cursor(&app);
         events_after(&mut app, &mut seen, clip, 0.9);
 
-        let fired = events_after(&mut app, &mut seen, clip, 0.2);
+        let fired = moved_to(&mut app, &mut seen, clip, 0.2, ClipPass::ForwardWrapped);
 
         assert_eq!(
             fired.len(),
             1,
             "wrapping past the key should send it: {fired:?}"
+        );
+    }
+
+    #[test]
+    fn a_key_on_the_first_frame_of_a_clip_fires_as_playback_leaves_it() {
+        let (mut app, _, clip) = world_with_an_event_at(0.0);
+        let mut seen = cursor(&app);
+
+        let fired = events_after(&mut app, &mut seen, clip, 0.1);
+
+        assert_eq!(
+            fired.len(),
+            1,
+            "a key at the very start of the clip should send once the first \
+             span leaves it: {fired:?}"
+        );
+    }
+
+    #[test]
+    fn a_wrap_that_lands_where_it_started_fires_the_whole_clip() {
+        let (mut app, _, clip) = world_with_an_event_at(0.6);
+        let mut seen = cursor(&app);
+        events_after(&mut app, &mut seen, clip, 0.2);
+
+        let fired = moved_to(&mut app, &mut seen, clip, 0.2, ClipPass::ForwardWrapped);
+
+        assert_eq!(
+            fired.len(),
+            1,
+            "a clip shorter than the frame that ran it comes back to the same \
+             time having passed every key: {fired:?}"
         );
     }
 }

--- a/crates/jackdaw_animation_runtime/src/graph.rs
+++ b/crates/jackdaw_animation_runtime/src/graph.rs
@@ -353,6 +353,10 @@ struct BoundClip {
     threshold: f32,
     /// Seconds the clip runs for, which an exit time is read against.
     duration: f32,
+    /// Assets-relative path of the file the clip came out of.
+    source: String,
+    /// Name the clip carries in that file.
+    clip: String,
 }
 
 /// One compiled state of a graph.
@@ -393,6 +397,18 @@ pub struct AnimationGraphBound {
 }
 
 impl AnimationGraphBound {
+    /// The source, name and player node of the clip a state leads with, which
+    /// for a blend is whichever of its clips currently carries the most weight.
+    pub(crate) fn leading_clip_of(
+        &self,
+        player: &AnimationPlayer,
+        state: &str,
+    ) -> Option<(&str, &str, AnimationNodeIndex)> {
+        let bound = self.states.get(*self.by_name.get(state)?)?;
+        let clip = leading_clip(player, bound)?;
+        Some((clip.source.as_str(), clip.clip.as_str(), clip.node))
+    }
+
     /// The node a state plays, when the state compiled.
     pub fn node(&self, state: &str) -> Option<AnimationNodeIndex> {
         self.by_name
@@ -892,6 +908,8 @@ fn compile_state(
                     node,
                     threshold: 0.0,
                     duration,
+                    source: clip_ref.source.clone(),
+                    clip: clip_ref.clip.clone(),
                 }],
             })
         }
@@ -905,6 +923,8 @@ fn compile_state(
                         node: graph.add_clip(handle, 1.0, blend),
                         threshold: point.threshold,
                         duration,
+                        source: point.clip.source.clone(),
+                        clip: point.clip.clip.clone(),
                     })
                 })
                 .collect();

--- a/crates/jackdaw_animation_runtime/src/lib.rs
+++ b/crates/jackdaw_animation_runtime/src/lib.rs
@@ -22,7 +22,7 @@ use std::{
 
 use bevy::{
     animation::{
-        AnimatedBy, AnimationTargetId, RepeatAnimation,
+        ActiveAnimation, AnimatedBy, AnimationTargetId, RepeatAnimation,
         graph::{AnimationGraph, AnimationGraphHandle, AnimationNodeIndex},
         transition::AnimationTransitions,
     },
@@ -36,7 +36,7 @@ use serde::{Deserialize, Serialize};
 pub mod events;
 pub mod graph;
 
-pub use events::{AnimationEvent, ClipEvent, ClipPlayhead, fire_clip_events};
+pub use events::{AnimationEvent, ClipEvent, ClipPass, ClipPlayhead, fire_clip_events};
 pub use graph::{
     AnimationBlendPoint, AnimationClipRef, AnimationCondition, AnimationConditionOp,
     AnimationGraphAsset, AnimationGraphBound, AnimationGraphDef, AnimationGraphLoadError,
@@ -187,7 +187,6 @@ impl Plugin for AnimationRuntimePlugin {
         }
         app.add_message::<AnimationStateFinished>()
             .add_message::<AnimationEvent>()
-            .add_systems(Update, fire_clip_events)
             .add_systems(
                 Update,
                 (
@@ -219,6 +218,18 @@ impl Plugin for AnimationRuntimePlugin {
                             .and_then(resource_exists::<Assets<AnimationGraph>>)
                             .and_then(resource_exists::<Assets<AnimationGraphAsset>>),
                     ),
+            )
+            .add_systems(
+                Update,
+                (write_clip_playheads, fire_clip_events)
+                    .chain()
+                    .in_set(AnimationSetSystems)
+                    .after(apply_animation_state)
+                    .after(graph::advance_animation_graphs)
+                    // Before a `then` writes the state it moves on to, so
+                    // the keys at the tail of the clip that ran out are still
+                    // read against that clip.
+                    .before(report_finished_states),
             );
     }
 }
@@ -446,6 +457,135 @@ fn apply_animation_state(
             };
             play_state(def, node, &mut player, &mut transitions);
         }
+    }
+}
+
+/// What an entity is playing, and where its playhead stands.
+#[derive(Clone, Copy)]
+struct PlayingClip<'a> {
+    /// The file the clip came out of, as the set or graph names it.
+    source: &'a str,
+    /// The clip's name in that file.
+    clip: &'a str,
+    /// Seconds into the clip, as of the last tick.
+    seek: f32,
+    /// The way that tick moved through the clip.
+    pass: ClipPass,
+}
+
+impl<'a> PlayingClip<'a> {
+    /// Reads a clip's playhead and how it travelled off the animation playing
+    /// it; a finished run reads as past the end, not as a wrap.
+    fn read(source: &'a str, clip: &'a str, active: &ActiveAnimation) -> Self {
+        let wrapped = active.just_completed() && !active.is_finished();
+        Self {
+            source,
+            clip,
+            seek: active.seek_time(),
+            pass: match (active.is_playback_reversed(), wrapped) {
+                (false, false) => ClipPass::Forward,
+                (false, true) => ClipPass::ForwardWrapped,
+                (true, false) => ClipPass::Backward,
+                (true, true) => ClipPass::BackwardWrapped,
+            },
+        }
+    }
+}
+
+/// Writes each bound entity's playhead onto the clip entity that carries
+/// that clip's events; a graph beside a set drives the entity alone.
+fn write_clip_playheads(
+    mut commands: Commands,
+    sets: Query<
+        (Entity, &AnimationSet, &AnimationSetBound, &AnimationState),
+        Without<AnimationGraphBound>,
+    >,
+    graphs: Query<(Entity, &AnimationGraphBound, &graph::AnimationGraphPlayback)>,
+    players: Query<&AnimationPlayer>,
+    children: Query<&Children>,
+    names: Query<&Name>,
+    marked: Query<(), With<ClipEvent>>,
+    mut playheads: Query<&mut ClipPlayhead>,
+) {
+    for (owner, set, bound, state) in &sets {
+        let playing = resolve_state(set, &bound.nodes, &state.0).and_then(|(def, node)| {
+            let active = players.get(bound.player).ok()?.animation(node)?;
+            let source = set.sources.get(def.source).map_or("", String::as_str);
+            Some(PlayingClip::read(source, def.clip.as_str(), active))
+        });
+        write_playheads_under(
+            owner,
+            playing,
+            &mut commands,
+            &children,
+            &names,
+            &marked,
+            &mut playheads,
+        );
+    }
+    for (owner, bound, playback) in &graphs {
+        let playing = players.get(bound.player).ok().and_then(|player| {
+            let (source, clip, node) = bound.leading_clip_of(player, &playback.state)?;
+            Some(PlayingClip::read(source, clip, player.animation(node)?))
+        });
+        write_playheads_under(
+            owner,
+            playing,
+            &mut commands,
+            &children,
+            &names,
+            &marked,
+            &mut playheads,
+        );
+    }
+}
+
+/// Moves the playhead of the clip entity directly under `owner` that stands
+/// for the playing clip, seeds one that just started, and clears the rest.
+fn write_playheads_under(
+    owner: Entity,
+    playing: Option<PlayingClip<'_>>,
+    commands: &mut Commands,
+    children: &Query<&Children>,
+    names: &Query<&Name>,
+    marked: &Query<(), With<ClipEvent>>,
+    playheads: &mut Query<&mut ClipPlayhead>,
+) {
+    let Ok(kids) = children.get(owner) else {
+        return;
+    };
+    for row in kids.iter() {
+        let holds_events = children
+            .get(row)
+            .is_ok_and(|keys| keys.iter().any(|key| marked.contains(key)));
+        if !holds_events {
+            continue;
+        }
+        let name = names.get(row).map_or("", Name::as_str);
+        let played = playing.filter(|clip| stands_for_clip(name, clip.source, clip.clip));
+        match (playheads.get_mut(row), played) {
+            (Ok(mut playhead), Some(clip)) => playhead.advance_to(clip.seek, clip.pass),
+            (Ok(_), None) => {
+                commands.entity(row).remove::<ClipPlayhead>();
+            }
+            (Err(_), Some(clip)) => {
+                commands.entity(row).insert(ClipPlayhead {
+                    last: clip.seek,
+                    now: clip.seek,
+                    pass: ClipPass::Forward,
+                });
+            }
+            (Err(_), None) => {}
+        }
+    }
+}
+
+/// Whether a clip entity name stands for `clip` out of `source`: a bare
+/// clip name, or `<file>#<clip>` when the file matters.
+fn stands_for_clip(name: &str, source: &str, clip: &str) -> bool {
+    match name.split_once('#') {
+        Some((file, named)) => file == source && named == clip,
+        None => name == clip,
     }
 }
 

--- a/crates/jackdaw_animation_runtime/tests/animation_graphs.rs
+++ b/crates/jackdaw_animation_runtime/tests/animation_graphs.rs
@@ -18,12 +18,16 @@ use bevy::{
 };
 use jackdaw_animation_runtime::{
     AnimationBlendPoint, AnimationClipRef, AnimationCondition, AnimationConditionOp,
-    AnimationGraphAsset, AnimationGraphBound, AnimationGraphDef, AnimationGraphPlayback,
-    AnimationGraphRef, AnimationGraphSource, AnimationGraphState, AnimationMotion,
-    AnimationParameterDef, AnimationParameterKind, AnimationParams, AnimationRuntimePlugin,
-    AnimationSet, AnimationSetBound, AnimationSources, AnimationState, AnimationStateDef,
-    AnimationTransitionDef,
+    AnimationEvent, AnimationGraphAsset, AnimationGraphBound, AnimationGraphDef,
+    AnimationGraphPlayback, AnimationGraphRef, AnimationGraphSource, AnimationGraphState,
+    AnimationMotion, AnimationParameterDef, AnimationParameterKind, AnimationParams,
+    AnimationRuntimePlugin, AnimationSet, AnimationSetBound, AnimationSetSystems, AnimationSources,
+    AnimationState, AnimationStateDef, AnimationTransitionDef, ClipEvent,
 };
+
+/// Every clip event sent so far.
+#[derive(Resource, Default)]
+struct Fired(Vec<String>);
 
 fn animation_app() -> App {
     let mut app = App::new();
@@ -33,7 +37,29 @@ fn animation_app() -> App {
         .add_plugins(bevy::animation::AnimationPlugin)
         .add_plugins(AnimationRuntimePlugin);
     app.init_asset::<Gltf>();
+    app.init_resource::<Fired>();
+    app.add_systems(Update, collect_fired.after(AnimationSetSystems));
     app
+}
+
+fn collect_fired(mut sent: MessageReader<AnimationEvent>, mut out: ResMut<Fired>) {
+    out.0.extend(sent.read().map(|event| event.name.clone()));
+}
+
+/// Puts a named moment on a clip row under `owner`: a child named for the clip
+/// the events belong to, carrying one event.
+fn clip_marker(app: &mut App, owner: Entity, clip: &str, time: f32, name: &str) {
+    let row = app
+        .world_mut()
+        .spawn((Name::new(clip.to_string()), ChildOf(owner)))
+        .id();
+    app.world_mut().spawn((
+        ClipEvent {
+            time,
+            name: name.to_string(),
+        },
+        ChildOf(row),
+    ));
 }
 
 /// Runs one frame of a length the test picks rather than the wall clock's.
@@ -855,5 +881,101 @@ fn a_graph_reference_naming_no_file_leaves_the_set_beside_it_to_play() {
             .animation(node)
             .is_some(),
         "and its default state is playing on the skeleton"
+    );
+}
+
+#[test]
+fn a_blend_state_fires_the_markers_of_the_clip_it_leads_with() {
+    let mut app = animation_app();
+    let idle = sliding_clip(&mut app, &["Armature", "Hips"]);
+    let walk = sliding_clip(&mut app, &["Armature", "Hips"]);
+    let source = source_holding(&mut app, &[("Idle", idle), ("Walk", walk)]);
+    let def = AnimationGraphDef {
+        parameters: vec![AnimationParameterDef {
+            name: "speed".to_string(),
+            kind: AnimationParameterKind::Float,
+            default: 0.0,
+        }],
+        states: vec![AnimationGraphState {
+            name: "locomotion".to_string(),
+            motion: AnimationMotion::Blend1d {
+                parameter: "speed".to_string(),
+                points: vec![blend_point(0.0, "Idle"), blend_point(1.5, "Walk")],
+            },
+            ..AnimationGraphState::default()
+        }],
+        transitions: Vec::new(),
+        entry: "locomotion".to_string(),
+    };
+    let root = spawn_graphed_rig(&mut app, def, source);
+    clip_marker(&mut app, root, "Idle", 0.4, "breath");
+    clip_marker(&mut app, root, "Walk", 0.4, "footfall");
+
+    step(&mut app, Duration::ZERO);
+    step(&mut app, Duration::ZERO);
+    params(&mut app, root).set_float("speed", 1.5);
+    for _ in 0..8 {
+        step(&mut app, millis(100));
+    }
+
+    assert_eq!(
+        app.world().resource::<Fired>().0,
+        vec!["footfall".to_string()],
+        "the clip carrying the blend sends its markers, and the one at no \
+         weight sends none"
+    );
+}
+
+#[test]
+fn a_clip_that_takes_the_blend_partway_through_sends_no_marker_behind_it() {
+    let mut app = animation_app();
+    let idle = sliding_clip(&mut app, &["Armature", "Hips"]);
+    let walk = sliding_clip(&mut app, &["Armature", "Hips"]);
+    let source = source_holding(&mut app, &[("Idle", idle), ("Walk", walk)]);
+    let def = AnimationGraphDef {
+        parameters: vec![AnimationParameterDef {
+            name: "speed".to_string(),
+            kind: AnimationParameterKind::Float,
+            default: 0.0,
+        }],
+        states: vec![AnimationGraphState {
+            name: "locomotion".to_string(),
+            motion: AnimationMotion::Blend1d {
+                parameter: "speed".to_string(),
+                points: vec![blend_point(0.0, "Idle"), blend_point(1.5, "Walk")],
+            },
+            ..AnimationGraphState::default()
+        }],
+        transitions: Vec::new(),
+        entry: "locomotion".to_string(),
+    };
+    let root = spawn_graphed_rig(&mut app, def, source);
+    clip_marker(&mut app, root, "Walk", 0.2, "footfall");
+
+    step(&mut app, Duration::ZERO);
+    step(&mut app, Duration::ZERO);
+    for _ in 0..6 {
+        step(&mut app, millis(100));
+    }
+    params(&mut app, root).set_float("speed", 1.5);
+    for _ in 0..3 {
+        step(&mut app, millis(100));
+    }
+
+    assert!(
+        app.world().resource::<Fired>().0.is_empty(),
+        "a clip taking the lead at 0.6s starts from where it stands, rather \
+         than sending every marker below it at once: {:?}",
+        app.world().resource::<Fired>().0
+    );
+
+    for _ in 0..6 {
+        step(&mut app, millis(100));
+    }
+
+    assert_eq!(
+        app.world().resource::<Fired>().0,
+        vec!["footfall".to_string()],
+        "and it sends the marker on the pass that reaches it"
     );
 }

--- a/crates/jackdaw_animation_runtime/tests/animation_sets.rs
+++ b/crates/jackdaw_animation_runtime/tests/animation_sets.rs
@@ -19,13 +19,17 @@ use bevy::{
     time::TimeUpdateStrategy,
 };
 use jackdaw_animation_runtime::{
-    AnimationRuntimePlugin, AnimationSet, AnimationSetBound, AnimationSetSystems, AnimationSources,
-    AnimationState, AnimationStateDef, AnimationStateFinished,
+    AnimationEvent, AnimationRuntimePlugin, AnimationSet, AnimationSetBound, AnimationSetSystems,
+    AnimationSources, AnimationState, AnimationStateDef, AnimationStateFinished, ClipEvent,
 };
 
 /// Every state reported finished so far.
 #[derive(Resource, Default)]
 struct Finished(Vec<String>);
+
+/// Every clip event sent so far, with the entity it named.
+#[derive(Resource, Default)]
+struct Fired(Vec<(Entity, String)>);
 
 fn animation_app() -> App {
     let mut app = App::new();
@@ -36,8 +40,42 @@ fn animation_app() -> App {
         .add_plugins(AnimationRuntimePlugin);
     app.init_asset::<Gltf>();
     app.init_resource::<Finished>();
-    app.add_systems(Update, collect_finished.after(AnimationSetSystems));
+    app.init_resource::<Fired>();
+    app.add_systems(
+        Update,
+        (collect_finished, collect_fired).after(AnimationSetSystems),
+    );
     app
+}
+
+fn collect_fired(mut sent: MessageReader<AnimationEvent>, mut out: ResMut<Fired>) {
+    out.0
+        .extend(sent.read().map(|event| (event.entity, event.name.clone())));
+}
+
+/// Puts a named moment on a clip row under `owner`: a child named for the clip
+/// the events belong to, carrying one event.
+fn clip_marker(app: &mut App, owner: Entity, clip: &str, time: f32, name: &str) {
+    let row = app
+        .world_mut()
+        .spawn((Name::new(clip.to_string()), ChildOf(owner)))
+        .id();
+    app.world_mut().spawn((
+        ClipEvent {
+            time,
+            name: name.to_string(),
+        },
+        ChildOf(row),
+    ));
+}
+
+fn fired_names(app: &App) -> Vec<String> {
+    app.world()
+        .resource::<Fired>()
+        .0
+        .iter()
+        .map(|(_, name)| name.clone())
+        .collect()
 }
 
 fn collect_finished(
@@ -114,11 +152,16 @@ fn spawn_mesh_nodes(app: &mut App, parent: Entity, names: &[&str]) {
 
 /// A clip that slides the bone at `path` one unit along X over a second.
 fn sliding_clip(app: &mut App, path: &[&str]) -> Handle<AnimationClip> {
+    sliding_clip_lasting(app, path, 1.0)
+}
+
+/// The same slide over a length the test picks.
+fn sliding_clip_lasting(app: &mut App, path: &[&str], seconds: f32) -> Handle<AnimationClip> {
     let names: Vec<Name> = path
         .iter()
         .map(|name| Name::new(name.to_string()))
         .collect();
-    let curve = AnimatableKeyframeCurve::new([(0.0, Vec3::ZERO), (1.0, Vec3::X)])
+    let curve = AnimatableKeyframeCurve::new([(0.0, Vec3::ZERO), (seconds, Vec3::X)])
         .expect("two keyframes make a curve");
     let mut clip = AnimationClip::default();
     clip.add_curve_to_target(
@@ -672,5 +715,322 @@ fn an_unknown_state_name_is_refused_with_one_warning() {
             .get_main_animation(),
         Some(idle),
         "and the state that was playing keeps playing"
+    );
+}
+
+#[test]
+fn a_marker_fires_once_on_every_pass_of_a_looping_clip() {
+    let mut app = animation_app();
+    let clip = sliding_clip(&mut app, &["Armature", "Hips"]);
+    let source = source_holding(&mut app, &[("Walk", clip)]);
+    let set = walking_set(
+        vec!["rig.glb".to_string()],
+        vec![AnimationStateDef {
+            name: "walk".to_string(),
+            clip: "Walk".to_string(),
+            ..AnimationStateDef::default()
+        }],
+        "walk",
+    );
+    let root = spawn_rig(&mut app, set, "Body", &["Hips"]);
+    app.world_mut()
+        .entity_mut(root)
+        .insert(AnimationSources(vec![source]));
+    clip_marker(&mut app, root, "Walk", 0.4, "step");
+
+    step(&mut app, Duration::ZERO);
+    step(&mut app, Duration::ZERO);
+    for _ in 0..30 {
+        step(&mut app, millis(100));
+    }
+
+    assert_eq!(
+        app.world().resource::<Fired>().0,
+        vec![(root, "step".to_string()); 3],
+        "a second-long clip run for three seconds should send its 0.4s marker \
+         once on each pass, named against the entity the clip animates"
+    );
+}
+
+#[test]
+fn a_one_shot_state_fires_its_marker_once_and_says_nothing_after_it_ends() {
+    let mut app = animation_app();
+    let clip = sliding_clip(&mut app, &["Armature", "Hips"]);
+    let source = source_holding(&mut app, &[("Hit", clip)]);
+    let set = walking_set(
+        vec!["rig.glb".to_string()],
+        vec![AnimationStateDef {
+            name: "hit".to_string(),
+            clip: "Hit".to_string(),
+            looped: false,
+            ..AnimationStateDef::default()
+        }],
+        "hit",
+    );
+    let root = spawn_rig(&mut app, set, "Body", &["Hips"]);
+    app.world_mut()
+        .entity_mut(root)
+        .insert(AnimationSources(vec![source]));
+    clip_marker(&mut app, root, "Hit", 0.4, "impact");
+
+    step(&mut app, Duration::ZERO);
+    step(&mut app, Duration::ZERO);
+    for _ in 0..25 {
+        step(&mut app, millis(100));
+    }
+
+    assert_eq!(
+        fired_names(&app),
+        vec!["impact".to_string()],
+        "a clip that runs once holds its last frame, and a marker already \
+         passed must not send again while it sits there"
+    );
+}
+
+#[test]
+fn a_state_left_before_its_marker_never_fires_it() {
+    let mut app = animation_app();
+    let clip = sliding_clip(&mut app, &["Armature", "Hips"]);
+    let source = source_holding(&mut app, &[("Idle", clip.clone()), ("Walk", clip)]);
+    let set = walking_set(
+        vec!["rig.glb".to_string()],
+        vec![
+            AnimationStateDef {
+                name: "idle".to_string(),
+                clip: "Idle".to_string(),
+                ..AnimationStateDef::default()
+            },
+            AnimationStateDef {
+                name: "walk".to_string(),
+                clip: "Walk".to_string(),
+                ..AnimationStateDef::default()
+            },
+        ],
+        "idle",
+    );
+    let root = spawn_rig(&mut app, set, "Body", &["Hips"]);
+    app.world_mut()
+        .entity_mut(root)
+        .insert(AnimationSources(vec![source]));
+    clip_marker(&mut app, root, "Idle", 0.4, "blink");
+    clip_marker(&mut app, root, "Walk", 0.4, "stride");
+
+    step(&mut app, Duration::ZERO);
+    step(&mut app, Duration::ZERO);
+    for _ in 0..4 {
+        step(&mut app, millis(100));
+    }
+    app.world_mut()
+        .entity_mut(root)
+        .insert(AnimationState("walk".to_string()));
+    for _ in 0..8 {
+        step(&mut app, millis(100));
+    }
+
+    assert_eq!(
+        fired_names(&app),
+        vec!["stride".to_string()],
+        "leaving idle at 0.3s drops its 0.4s marker rather than sending it \
+         late, while the state moved to sends its own"
+    );
+}
+
+#[test]
+fn a_marker_at_the_head_of_a_clip_fires_on_every_pass_of_it() {
+    let mut app = animation_app();
+    let clip = sliding_clip(&mut app, &["Armature", "Hips"]);
+    let source = source_holding(&mut app, &[("Walk", clip)]);
+    let set = walking_set(
+        vec!["rig.glb".to_string()],
+        vec![AnimationStateDef {
+            name: "walk".to_string(),
+            clip: "Walk".to_string(),
+            ..AnimationStateDef::default()
+        }],
+        "walk",
+    );
+    let root = spawn_rig(&mut app, set, "Body", &["Hips"]);
+    app.world_mut()
+        .entity_mut(root)
+        .insert(AnimationSources(vec![source]));
+    clip_marker(&mut app, root, "Walk", 0.0, "plant");
+
+    step(&mut app, Duration::ZERO);
+    step(&mut app, Duration::ZERO);
+    for _ in 0..25 {
+        step(&mut app, millis(100));
+    }
+
+    assert_eq!(
+        fired_names(&app),
+        vec!["plant".to_string(); 3],
+        "a marker sitting on the first frame is passed once on the way out of \
+         it and once on every pass after"
+    );
+}
+
+#[test]
+fn a_state_played_backwards_sends_each_marker_once_a_pass() {
+    let mut app = animation_app();
+    let clip = sliding_clip(&mut app, &["Armature", "Hips"]);
+    let source = source_holding(&mut app, &[("Walk", clip)]);
+    let set = walking_set(
+        vec!["rig.glb".to_string()],
+        vec![AnimationStateDef {
+            name: "walk".to_string(),
+            clip: "Walk".to_string(),
+            speed: -1.0,
+            ..AnimationStateDef::default()
+        }],
+        "walk",
+    );
+    let root = spawn_rig(&mut app, set, "Body", &["Hips"]);
+    app.world_mut()
+        .entity_mut(root)
+        .insert(AnimationSources(vec![source]));
+    clip_marker(&mut app, root, "Walk", 0.4, "step");
+    clip_marker(&mut app, root, "Walk", 0.7, "land");
+
+    step(&mut app, Duration::ZERO);
+    step(&mut app, Duration::ZERO);
+    for _ in 0..25 {
+        step(&mut app, millis(100));
+    }
+
+    assert_eq!(
+        fired_names(&app),
+        ["land", "step", "land", "step", "land"].map(str::to_string),
+        "a clip walked backwards passes each marker once a lap, in the order \
+         it meets them, rather than a whole clip of them at the wrap"
+    );
+}
+
+#[test]
+fn a_clip_shorter_than_the_frame_running_it_still_fires_its_marker() {
+    let mut app = animation_app();
+    let clip = sliding_clip_lasting(&mut app, &["Armature", "Hips"], 0.1);
+    let source = source_holding(&mut app, &[("Flash", clip)]);
+    let set = walking_set(
+        vec!["rig.glb".to_string()],
+        vec![AnimationStateDef {
+            name: "flash".to_string(),
+            clip: "Flash".to_string(),
+            ..AnimationStateDef::default()
+        }],
+        "flash",
+    );
+    let root = spawn_rig(&mut app, set, "Body", &["Hips"]);
+    app.world_mut()
+        .entity_mut(root)
+        .insert(AnimationSources(vec![source]));
+    clip_marker(&mut app, root, "Flash", 0.08, "tick");
+
+    step(&mut app, Duration::ZERO);
+    step(&mut app, Duration::ZERO);
+    for _ in 0..6 {
+        step(&mut app, millis(200));
+    }
+
+    let fired = fired_names(&app);
+    assert_eq!(
+        fired,
+        vec!["tick".to_string(); 5],
+        "a frame that laps a clip more than once leaves the playhead where it \
+         found it, and the marker it swept past must still send: {fired:?}"
+    );
+}
+
+#[test]
+fn a_paused_player_sends_nothing_until_it_is_let_go() {
+    let mut app = animation_app();
+    let clip = sliding_clip(&mut app, &["Armature", "Hips"]);
+    let source = source_holding(&mut app, &[("Walk", clip)]);
+    let set = walking_set(
+        vec!["rig.glb".to_string()],
+        vec![AnimationStateDef {
+            name: "walk".to_string(),
+            clip: "Walk".to_string(),
+            ..AnimationStateDef::default()
+        }],
+        "walk",
+    );
+    let root = spawn_rig(&mut app, set, "Body", &["Hips"]);
+    app.world_mut()
+        .entity_mut(root)
+        .insert(AnimationSources(vec![source]));
+    clip_marker(&mut app, root, "Walk", 0.4, "step");
+
+    step(&mut app, Duration::ZERO);
+    step(&mut app, Duration::ZERO);
+    let node = node_for(&app, root, "walk");
+    let armature = named(&mut app, "Armature");
+    app.world_mut()
+        .get_mut::<AnimationPlayer>(armature)
+        .expect("the skeleton carries a player")
+        .animation_mut(node)
+        .expect("the state is playing")
+        .pause();
+    for _ in 0..20 {
+        step(&mut app, millis(100));
+    }
+
+    assert!(
+        fired_names(&app).is_empty(),
+        "a playhead that is not moving passes nothing: {:?}",
+        fired_names(&app)
+    );
+
+    app.world_mut()
+        .get_mut::<AnimationPlayer>(armature)
+        .expect("the skeleton carries a player")
+        .animation_mut(node)
+        .expect("the state is playing")
+        .resume();
+    for _ in 0..6 {
+        step(&mut app, millis(100));
+    }
+
+    assert_eq!(
+        fired_names(&app),
+        vec!["step".to_string()],
+        "and it sends again once playback moves on"
+    );
+}
+
+#[test]
+fn a_marker_row_naming_its_source_file_fires_only_for_that_source() {
+    let mut app = animation_app();
+    let first = sliding_clip(&mut app, &["Armature", "Hips"]);
+    let second = sliding_clip(&mut app, &["Armature", "Hips"]);
+    let one = source_holding(&mut app, &[("Walk", first)]);
+    let two = source_holding(&mut app, &[("Walk", second)]);
+    let set = walking_set(
+        vec!["one.glb".to_string(), "two.glb".to_string()],
+        vec![AnimationStateDef {
+            name: "walk".to_string(),
+            source: 1,
+            clip: "Walk".to_string(),
+            ..AnimationStateDef::default()
+        }],
+        "walk",
+    );
+    let root = spawn_rig(&mut app, set, "Body", &["Hips"]);
+    app.world_mut()
+        .entity_mut(root)
+        .insert(AnimationSources(vec![one, two]));
+    clip_marker(&mut app, root, "one.glb#Walk", 0.4, "wrong file");
+    clip_marker(&mut app, root, "two.glb#Walk", 0.4, "right file");
+
+    step(&mut app, Duration::ZERO);
+    step(&mut app, Duration::ZERO);
+    for _ in 0..8 {
+        step(&mut app, millis(100));
+    }
+
+    assert_eq!(
+        fired_names(&app),
+        vec!["right file".to_string()],
+        "two files holding a clip of the same name are told apart by a row \
+         named `<file>#<clip>`"
     );
 }


### PR DESCRIPTION
Clip events authored on a clip entity fire at runtime. A system after the
set and graph advance writes ClipPlayhead onto the clip entity, a named
child of the animated entity, from the playing animation's seek and how it
travelled since the last frame: forward, wrapped, backward, or finished.
Keys fire once per pass, a key at 0.0 fires on the first pass, a clip
lapped more than once in a frame still fires each pass, reverse playback
fires keys in playback order, and a clip that stops playing loses its
playhead so nothing fires late. A row named <file>#<clip> tells two files
holding the same clip name apart. For a blend state the leading clip's
rows are written.