### PR TITLE
Paint detail layers on terrain: instanced meshes with wind, bend and pressers

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -5385,6 +5385,8 @@ version = "0.19.0"
 dependencies = [
  "bevy",
  "bevy_math",
+ "bytemuck",
+ "jackdaw_scene_types",
  "noise",
  "path-slash",
  "rand 0.10.2",

--- a/crates/jackdaw_runtime/src/lib.rs
+++ b/crates/jackdaw_runtime/src/lib.rs
@@ -83,9 +83,9 @@ use jackdaw_bsn::{
 };
 
 pub use jackdaw_scene_types::{
-    Brush, BrushFaceData, CustomProperties, EditorCategory, EditorDescription, EditorHidden,
-    EditorPreview, GltfSource, NAVMESH_EXCLUDE_TYPE_PATH, NavmeshExclude, PropertyValue,
-    ScatterGroup, ScatterInstance, SkipSerialization,
+    Brush, BrushFaceData, CustomProperties, DetailPresser, EditorCategory, EditorDescription,
+    EditorHidden, EditorPreview, GltfSource, NAVMESH_EXCLUDE_TYPE_PATH, NavmeshExclude,
+    PropertyValue, ScatterGroup, ScatterInstance, SkipSerialization,
 };
 
 #[cfg(feature = "pie")]
@@ -99,6 +99,8 @@ pub use pie_windowless::{maybe_windowless, windowless_requested};
 
 #[cfg(feature = "terrain")]
 mod terrain;
+#[cfg(feature = "terrain")]
+pub use jackdaw_terrain::render::{DetailPressers, DetailSettings};
 #[cfg(feature = "terrain")]
 pub use terrain::TerrainViewer;
 
@@ -116,13 +118,13 @@ pub use schema_cli::{
 pub mod prelude {
     #[cfg(feature = "navmesh")]
     pub use crate::JackdawNavmesh;
-    #[cfg(feature = "terrain")]
-    pub use crate::TerrainViewer;
     pub use crate::{
-        EditorCategory, EditorDescription, EditorHidden, EditorPreview, JackdawCatalog,
-        JackdawCatalogPath, JackdawPlugin, JackdawSceneMember, JackdawSceneRoot, SceneRefused,
-        SkipSerialization,
+        DetailPresser, EditorCategory, EditorDescription, EditorHidden, EditorPreview,
+        JackdawCatalog, JackdawCatalogPath, JackdawPlugin, JackdawSceneMember, JackdawSceneRoot,
+        SceneRefused, SkipSerialization,
     };
+    #[cfg(feature = "terrain")]
+    pub use crate::{DetailPressers, DetailSettings, TerrainViewer};
 }
 
 pub struct JackdawPlugin;

--- a/crates/jackdaw_runtime/src/terrain.rs
+++ b/crates/jackdaw_runtime/src/terrain.rs
@@ -43,6 +43,8 @@ use avian3d::prelude::{Collider, RigidBody};
 /// would upload as linear 0.214 and draw more than twice as dark.
 const UNTEXTURED: Color = Color::linear_rgb(0.5, 0.5, 0.5);
 
+/// Loads terrain sidecars and keeps ground surfaces in step with them, writing
+/// the scatter and detail projections before their renderers rebuild.
 pub(crate) fn plugin(app: &mut App) {
     app.add_plugins((TerrainRenderPlugin, ScatterRenderPlugin, DetailRenderPlugin))
         .add_systems(
@@ -56,8 +58,6 @@ pub(crate) fn plugin(app: &mut App) {
             )
                 .chain()
                 .after(crate::spawn_loaded_scenes)
-                // The scatter and detail a sidecar carries are written here and
-                // drawn by the rebuilds, so they land before the rebuilds read them.
                 .before(ScatterSystems::Rebuild)
                 .before(DetailSystems::Rebuild),
         );

--- a/crates/jackdaw_runtime/src/terrain.rs
+++ b/crates/jackdaw_runtime/src/terrain.rs
@@ -21,9 +21,10 @@ use bevy::mesh::{Indices, PrimitiveTopology};
 use bevy::prelude::*;
 use jackdaw_scene_types::Terrain;
 use jackdaw_terrain::render::{
-    ScatterDirty, ScatterRenderPlugin, ScatterSystems, SplatArrayHandles, SplatBuildError,
-    TerrainRenderPlugin, TerrainScatter, TerrainSplatMaterial, TextureSetImages,
-    control_image_from_bytes, resolve_with, slope_image, splat_images, tint_image,
+    DetailDirty, DetailRenderPlugin, DetailSystems, ScatterDirty, ScatterRenderPlugin,
+    ScatterSystems, SplatArrayHandles, SplatBuildError, TerrainDetailSource, TerrainRenderPlugin,
+    TerrainScatter, TerrainSplatMaterial, TextureSetImages, control_image_from_bytes, resolve_with,
+    slope_image, splat_images, tint_image,
 };
 use jackdaw_terrain::sidecar::{self, TerrainMaterialSlot};
 use jackdaw_terrain::splat::ControlTexels;
@@ -43,7 +44,7 @@ use avian3d::prelude::{Collider, RigidBody};
 const UNTEXTURED: Color = Color::linear_rgb(0.5, 0.5, 0.5);
 
 pub(crate) fn plugin(app: &mut App) {
-    app.add_plugins((TerrainRenderPlugin, ScatterRenderPlugin))
+    app.add_plugins((TerrainRenderPlugin, ScatterRenderPlugin, DetailRenderPlugin))
         .add_systems(
             Update,
             (
@@ -55,10 +56,10 @@ pub(crate) fn plugin(app: &mut App) {
             )
                 .chain()
                 .after(crate::spawn_loaded_scenes)
-                // The scatter a sidecar carries is written here and drawn
-                // by the rebuild, so it is written before the rebuild
-                // reads it rather than a frame behind it.
-                .before(ScatterSystems::Rebuild),
+                // The scatter and detail a sidecar carries are written here and
+                // drawn by the rebuilds, so they land before the rebuilds read them.
+                .before(ScatterSystems::Rebuild)
+                .before(DetailSystems::Rebuild),
         );
     #[cfg(feature = "physics")]
     app.add_systems(Update, build_ground_colliders.after(refresh_heightmaps));
@@ -208,6 +209,11 @@ fn load_sidecars(
             None => RegionTerrainData::default(),
         };
 
+        if let Some(detail) = TerrainDetailSource::from_document(&data, terrain) {
+            commands
+                .entity(entity)
+                .insert((detail, DetailDirty::default()));
+        }
         commands.entity(entity).insert((
             TerrainScatter::from_document(&data),
             ScatterDirty::all(),

--- a/crates/jackdaw_scene_types/src/lib.rs
+++ b/crates/jackdaw_scene_types/src/lib.rs
@@ -30,10 +30,11 @@ pub use brush_chunks::{MeshChunk, build_brush_chunks};
 pub use mesh_rebuild::evaluate_brush_geometry;
 pub use node_id::{SCENE_NODE_ID_TYPE_PATH, SPARSE_MIN, SceneNodeId};
 pub use types::{
-    Brush, BrushFaceData, BrushPlane, BrushTopology, CustomProperties, DerivedFaceMesh, GltfSource,
-    NAVMESH_EXCLUDE_TYPE_PATH, NavmeshExclude, PrefabBaseline, PropertyValue, ScatterGroup,
-    ScatterInstance, SceneRootTag, Terrain, TerrainChannel, TerrainChannelElement, TerrainNavmesh,
-    TerrainPaletteEntry, TerrainQuantization,
+    Brush, BrushFaceData, BrushPlane, BrushTopology, CustomProperties, DerivedFaceMesh,
+    DetailLayer, DetailMesh, DetailPresser, GltfSource, NAVMESH_EXCLUDE_TYPE_PATH, NavmeshExclude,
+    PrefabBaseline, PropertyValue, ScatterGroup, ScatterInstance, SceneRootTag, Terrain,
+    TerrainChannel, TerrainChannelElement, TerrainNavmesh, TerrainPaletteEntry,
+    TerrainQuantization,
 };
 
 use bevy::prelude::*;
@@ -82,6 +83,9 @@ impl Plugin for SceneTypesPlugin {
             .register_type::<TerrainChannel>()
             .register_type::<TerrainChannelElement>()
             .register_type::<TerrainNavmesh>()
+            .register_type::<DetailLayer>()
+            .register_type::<DetailMesh>()
+            .register_type::<DetailPresser>()
             .register_type::<NavmeshExclude>()
             .register_type::<ScatterGroup>()
             .register_type::<ScatterInstance>()

--- a/crates/jackdaw_scene_types/src/types.rs
+++ b/crates/jackdaw_scene_types/src/types.rs
@@ -900,6 +900,10 @@ pub struct Terrain {
     pub quantization: TerrainQuantization,
     /// What this terrain's navigation mesh is baked for.
     pub navmesh: TerrainNavmesh,
+    /// The ground detail this terrain scatters, one entry per layer. Each grows
+    /// from the channel of [`Terrain::channels`] its `density_channel` names.
+    #[reflect(default)]
+    pub detail: Vec<DetailLayer>,
 }
 
 /// These values are a persisted contract: BSN elides a field equal to its
@@ -923,6 +927,7 @@ impl Default for Terrain {
             heights: Vec::new(),
             quantization: TerrainQuantization::default(),
             navmesh: TerrainNavmesh::default(),
+            detail: Vec::new(),
         }
     }
 }
@@ -931,6 +936,109 @@ impl Terrain {
     /// Cell count this terrain's per-cell arrays must have.
     pub fn cell_count(&self) -> usize {
         (self.resolution as usize) * (self.resolution as usize)
+    }
+}
+
+/// One layer of ground detail: what it draws, where it grows and how it moves.
+/// The `Default` is the grass look, and a persisted contract: BSN elides it.
+#[derive(Reflect, Clone, Debug, PartialEq)]
+#[reflect(Default)]
+pub struct DetailLayer {
+    /// What this layer is called in the editor.
+    pub name: String,
+    /// Name of the [`TerrainChannel`] holding per-cell density. A cell reading
+    /// zero grows nothing; the channel's ceiling is full density.
+    pub density_channel: String,
+    /// What one instance draws.
+    pub mesh: DetailMesh,
+    /// Shortest and tallest an instance stands, in world units. Each takes a
+    /// height between the two from the placement noise.
+    pub height: [f32; 2],
+    /// Narrowest and widest an instance is drawn, as a multiple of the mesh's
+    /// own width.
+    pub width: [f32; 2],
+    /// Linear colour at the foot of an instance.
+    pub color_base: [f32; 3],
+    /// Linear colour at the top of an instance.
+    pub color_tip: [f32; 3],
+    /// How fast the wind pattern travels across the terrain, in tiles per
+    /// second.
+    pub wind_speed: f32,
+    /// How far the wind leans a tip sideways, in world units.
+    pub wind_strength: f32,
+    /// How far the wind bobs a tip vertically, in world units. Weaker than
+    /// [`Self::wind_strength`].
+    pub wind_vertical_strength: f32,
+    /// Direction the wind pattern travels in, on the XZ plane.
+    pub wind_direction: [f32; 2],
+    /// World units one tile of the wind pattern spans.
+    pub wind_tile_size: f32,
+    /// How far a tip leans from its own facing, in world units, before any
+    /// wind. The foot stays where it is planted.
+    pub bend: f32,
+    /// How far a presser shoves a tip away from itself, in world units.
+    pub push_strength: f32,
+    /// How close a presser has to be to bend an instance at all, in world
+    /// units.
+    pub push_radius: f32,
+    /// Instances per square metre at full density.
+    pub density_per_m2: f32,
+    /// How far from the viewer this layer draws, in world units.
+    pub cull_distance: f32,
+    /// Whether an instance stands along the ground normal rather than
+    /// straight up.
+    pub align_to_normal: bool,
+}
+
+/// What one instance of a detail layer draws.
+#[derive(Reflect, Clone, Debug, PartialEq, Default)]
+#[reflect(Default)]
+pub enum DetailMesh {
+    /// The built-in blade card.
+    #[default]
+    Card,
+    /// A glTF below the assets directory, flattened into one mesh.
+    Asset(String),
+}
+
+impl Default for DetailLayer {
+    fn default() -> Self {
+        Self {
+            name: "grass".to_string(),
+            density_channel: "grass".to_string(),
+            mesh: DetailMesh::Card,
+            height: [0.35, 0.7],
+            width: [0.03, 0.05],
+            color_base: [0.05, 0.14, 0.04],
+            color_tip: [0.36, 0.56, 0.16],
+            wind_speed: 0.15,
+            wind_strength: 0.12,
+            wind_vertical_strength: 0.04,
+            wind_direction: [1.0, 0.35],
+            wind_tile_size: 12.0,
+            bend: 0.22,
+            push_strength: 0.8,
+            push_radius: 1.2,
+            density_per_m2: 24.0,
+            cull_distance: 45.0,
+            align_to_normal: false,
+        }
+    }
+}
+
+/// Something ground detail bends away from. Only the few nearest the viewer
+/// reach the shader each frame.
+#[derive(Component, Reflect, Clone, Copy, Debug, PartialEq)]
+#[reflect(Component, Default, @crate::EditorCategory::new("Terrain"))]
+pub struct DetailPresser {
+    /// How wide this presser flattens detail, in world units. Multiplied into
+    /// each layer's own [`DetailLayer::push_radius`].
+    pub radius: f32,
+}
+
+impl Default for DetailPresser {
+    fn default() -> Self {
+        Self { radius: 0.5 }
     }
 }
 

--- a/crates/jackdaw_terrain/Cargo.toml
+++ b/crates/jackdaw_terrain/Cargo.toml
@@ -10,11 +10,13 @@ repository = "https://github.com/jbuehler23/jackdaw"
 noise = { workspace = true, optional = true }
 rand = { workspace = true, optional = true }
 bevy_math = "0.19"
+bytemuck = { version = "1", features = ["derive"], optional = true }
 bevy = { version = "0.19", default-features = false, optional = true, features = [
     "std",
     "bevy_asset",
 ] }
 path-slash = { workspace = true, optional = true }
+jackdaw_scene_types = { version = "0.19.0", path = "../jackdaw_scene_types", default-features = false, optional = true }
 
 [features]
 default = ["render", "procgen"]
@@ -31,6 +33,9 @@ procgen = ["dep:noise", "dep:rand"]
 render = [
     "dep:bevy",
     "dep:path-slash",
+    "dep:bytemuck",
+    "dep:jackdaw_scene_types",
+    "jackdaw_scene_types/render",
     "bevy/bevy_pbr",
     "bevy/bevy_render",
     "bevy/bevy_image",

--- a/crates/jackdaw_terrain/src/channel.rs
+++ b/crates/jackdaw_terrain/src/channel.rs
@@ -220,10 +220,12 @@ pub fn apply_density_brush(
             let Some(before) = values.get(idx).copied() else {
                 continue;
             };
-            // A value past the ceiling, from a channel narrowed after it was
-            // painted, is pulled down to it.
-            let before = before.min(element.max_value());
-            let after = step_toward(before, target, (opacity * weight * dt).clamp(0.0, 1.0));
+            let before_within_ceiling = before.min(element.max_value());
+            let after = step_toward(
+                before_within_ceiling,
+                target,
+                (opacity * weight * dt).clamp(0.0, 1.0),
+            );
             if after != values[idx] {
                 values[idx] = after;
                 changed += 1;
@@ -504,15 +506,19 @@ mod tests {
         );
         let centre = values[20 * 40 + 20];
         assert!(centre > 0);
-        // The plateau reaches 6 cells out; the ring beyond it has fallen off.
-        for offset in 1..=5 {
+        let outermost_plateau_cell = 5;
+        for offset in 1..=outermost_plateau_cell {
             assert_eq!(
                 values[20 * 40 + 20 + offset],
                 centre,
                 "cell {offset} inside the plateau matches the centre"
             );
         }
-        assert!(values[20 * 40 + 20 + 9] < centre);
+        let beyond_the_plateau = outermost_plateau_cell + 4;
+        assert!(
+            values[20 * 40 + 20 + beyond_the_plateau] < centre,
+            "the ring beyond the plateau has not fallen off"
+        );
     }
 
     #[test]

--- a/crates/jackdaw_terrain/src/channel.rs
+++ b/crates/jackdaw_terrain/src/channel.rs
@@ -7,6 +7,7 @@
 use bevy_math::Vec2;
 
 use crate::brush::compute_falloff;
+use crate::tint::brush_weight;
 
 /// Storage width a channel's values are written with on disk.
 ///
@@ -171,6 +172,89 @@ pub fn apply_channel_brush(
     changed
 }
 
+/// Ease cells under a circular brush toward the channel's ceiling, or toward
+/// zero when `erase` is set; returns the number of cells changed.
+#[expect(
+    clippy::too_many_arguments,
+    reason = "mirrors apply_color_brush's flat parameter list"
+)]
+pub fn apply_density_brush(
+    values: &mut [u16],
+    resolution: u32,
+    element: ChannelElement,
+    center: Vec2,
+    radius: f32,
+    hardness: f32,
+    falloff: f32,
+    opacity: f32,
+    dt: f32,
+    erase: bool,
+) -> usize {
+    if resolution == 0
+        || !radius.is_finite()
+        || radius <= 0.0
+        || !opacity.is_finite()
+        || opacity <= 0.0
+        || !dt.is_finite()
+        || dt <= 0.0
+    {
+        return 0;
+    }
+    let target = if erase { 0 } else { element.max_value() };
+    let res = resolution as i32;
+
+    let min_x = ((center.x - radius).floor() as i32).clamp(0, res - 1);
+    let max_x = ((center.x + radius).ceil() as i32).clamp(0, res - 1);
+    let min_z = ((center.y - radius).floor() as i32).clamp(0, res - 1);
+    let max_z = ((center.y + radius).ceil() as i32).clamp(0, res - 1);
+
+    let mut changed = 0;
+    for gz in min_z..=max_z {
+        for gx in min_x..=max_x {
+            let dist = ((gx as f32 - center.x).powi(2) + (gz as f32 - center.y).powi(2)).sqrt();
+            let weight = brush_weight(dist, radius, falloff, hardness);
+            if weight <= 0.0 {
+                continue;
+            }
+            let idx = (gz * res + gx) as usize;
+            let Some(before) = values.get(idx).copied() else {
+                continue;
+            };
+            // A value past the ceiling, from a channel narrowed after it was
+            // painted, is pulled down to it.
+            let before = before.min(element.max_value());
+            let after = step_toward(before, target, (opacity * weight * dt).clamp(0.0, 1.0));
+            if after != values[idx] {
+                values[idx] = after;
+                changed += 1;
+            }
+        }
+    }
+    changed
+}
+
+/// One cell eased `t` of the way from `from` to `to`, never passing it, and
+/// never standing still while `t` is positive.
+fn step_toward(from: u16, to: u16, t: f32) -> u16 {
+    if from == to || !t.is_finite() || t <= 0.0 {
+        return from;
+    }
+    let delta = (f32::from(to) - f32::from(from)) * t;
+    let step = if delta > 0.0 {
+        delta.max(1.0)
+    } else {
+        delta.min(-1.0)
+    };
+    let next = (f32::from(from) + step)
+        .round()
+        .clamp(0.0, f32::from(u16::MAX)) as u16;
+    if to > from {
+        next.min(to)
+    } else {
+        next.max(to)
+    }
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;
@@ -329,5 +413,124 @@ mod tests {
         );
         assert!(narrow < wide, "narrow {narrow} should be under wide {wide}");
         assert!(narrow > 0);
+    }
+
+    #[test]
+    fn a_density_stamp_accumulates_toward_the_channel_ceiling() {
+        let mut values = vec![0u16; 100];
+        let mut last = 0;
+        for _ in 0..4 {
+            apply_density_brush(
+                &mut values,
+                10,
+                ChannelElement::U8,
+                Vec2::new(5.0, 5.0),
+                3.0,
+                0.5,
+                1.0,
+                2.0,
+                1.0 / 60.0,
+                false,
+            );
+            let now = values[5 * 10 + 5];
+            assert!(now > last, "density {now} should rise above {last}");
+            last = now;
+        }
+        for _ in 0..2000 {
+            apply_density_brush(
+                &mut values,
+                10,
+                ChannelElement::U8,
+                Vec2::new(5.0, 5.0),
+                3.0,
+                0.5,
+                1.0,
+                2.0,
+                1.0 / 60.0,
+                false,
+            );
+        }
+        assert_eq!(values[5 * 10 + 5], ChannelElement::U8.max_value());
+        assert_eq!(values[0], 0, "a cell outside the radius is untouched");
+    }
+
+    #[test]
+    fn erasing_density_takes_a_cell_back_to_nothing() {
+        let mut values = vec![200u16; 100];
+        apply_density_brush(
+            &mut values,
+            10,
+            ChannelElement::U8,
+            Vec2::new(5.0, 5.0),
+            3.0,
+            0.5,
+            1.0,
+            2.0,
+            1.0 / 60.0,
+            true,
+        );
+        assert!(values[5 * 10 + 5] < 200);
+        for _ in 0..2000 {
+            apply_density_brush(
+                &mut values,
+                10,
+                ChannelElement::U8,
+                Vec2::new(5.0, 5.0),
+                3.0,
+                0.5,
+                1.0,
+                2.0,
+                1.0 / 60.0,
+                true,
+            );
+        }
+        assert_eq!(values[5 * 10 + 5], 0);
+    }
+
+    #[test]
+    fn the_density_hardness_plateau_paints_flat() {
+        let mut values = vec![0u16; 1600];
+        apply_density_brush(
+            &mut values,
+            40,
+            ChannelElement::U16,
+            Vec2::new(20.0, 20.0),
+            10.0,
+            0.6,
+            1.0,
+            0.5,
+            1.0 / 60.0,
+            false,
+        );
+        let centre = values[20 * 40 + 20];
+        assert!(centre > 0);
+        // The plateau reaches 6 cells out; the ring beyond it has fallen off.
+        for offset in 1..=5 {
+            assert_eq!(
+                values[20 * 40 + 20 + offset],
+                centre,
+                "cell {offset} inside the plateau matches the centre"
+            );
+        }
+        assert!(values[20 * 40 + 20 + 9] < centre);
+    }
+
+    #[test]
+    fn a_density_brush_outside_the_terrain_changes_nothing() {
+        let mut values = vec![0u16; 25];
+        let changed = apply_density_brush(
+            &mut values,
+            5,
+            ChannelElement::U8,
+            Vec2::new(50.0, 50.0),
+            2.0,
+            0.5,
+            1.0,
+            1.0,
+            1.0 / 60.0,
+            false,
+        );
+        assert_eq!(changed, 0);
+        assert!(values.iter().all(|v| *v == 0));
     }
 }

--- a/crates/jackdaw_terrain/src/detail.rs
+++ b/crates/jackdaw_terrain/src/detail.rs
@@ -1,0 +1,626 @@
+//! Instance placement for a terrain's detail layers over their density channels.
+//! Placement is a pure function of `(seed, layer, cell, index)`.
+
+use bevy_math::{IVec2, Vec2, Vec3};
+use bytemuck::{Pod, Zeroable};
+use jackdaw_scene_types::DetailLayer;
+
+use crate::heightmap::Heightmap;
+
+/// Steepest ground detail grows on, in radians. A steeper cell is bare.
+const MAX_SLOPE: f32 = 40.0 * std::f32::consts::PI / 180.0;
+
+/// World units one tile of the height and tint variation spans.
+const VARIATION_TILE: f32 = 9.0;
+
+/// Share of an instance's height that is its own rather than its patch's, in `0..1`.
+const HEIGHT_JITTER: f32 = 0.25;
+
+/// Share of an instance's tint that is its own rather than its patch's, in `0..1`.
+const TINT_JITTER: f32 = 0.3;
+
+/// Lattice cells before the variation field repeats.
+const VARIATION_PERIOD: f32 = 4096.0;
+
+/// One instance, as the vertex buffer holds it. The four variation bytes are
+/// normalized; the shader maps each into the range the layer declares.
+#[repr(C)]
+#[derive(Clone, Copy, Debug, Default, PartialEq, Pod, Zeroable)]
+pub struct DetailInstance {
+    /// Terrain-local position of the instance's foot.
+    pub position: Vec3,
+    /// Height, width, yaw and tint, one byte each from the low byte up.
+    pub packed: u32,
+    /// X and Z of the ground normal the instance stands along, or zero for one
+    /// standing straight up.
+    pub tilt: Vec2,
+}
+
+impl DetailInstance {
+    /// Pack the four variation bytes into one word.
+    pub fn pack(height: u8, width: u8, yaw: u8, tint: u8) -> u32 {
+        u32::from(height) | u32::from(width) << 8 | u32::from(yaw) << 16 | u32::from(tint) << 24
+    }
+
+    /// The four variation bytes, in the order [`Self::pack`] took them.
+    pub fn unpack(self) -> [u8; 4] {
+        self.packed.to_le_bytes()
+    }
+}
+
+/// How finely one tile of detail is seeded. A far tile's instances are a
+/// subset of a near tile's.
+#[derive(Clone, Copy, Debug, PartialEq, Eq, Hash)]
+pub enum DetailLod {
+    Near,
+    Far,
+}
+
+impl DetailLod {
+    /// Fraction of full density this level seeds at.
+    pub fn density_scale(self) -> f32 {
+        match self {
+            Self::Near => 1.0,
+            Self::Far => 0.3,
+        }
+    }
+}
+
+/// Half-width of the dead zone either side of the detail boundary, as a
+/// fraction of the near band.
+const LOD_HYSTERESIS: f32 = 0.15;
+
+/// Distance from a viewer to the centre of a tile, in cells.
+pub fn tile_centre_distance(viewer_cell: IVec2, tile: IVec2, tile_cells: u32) -> f32 {
+    let side = tile_cells as f32;
+    let centre = tile.as_vec2() * side + Vec2::splat(side * 0.5);
+    viewer_cell.as_vec2().distance(centre)
+}
+
+/// The detail level a tile whose centre is `centre_distance` cells away takes.
+/// A tile already seeded at `held` keeps it until a margin past the boundary.
+pub fn detail_lod_at(centre_distance: f32, cull_cells: f32, held: Option<DetailLod>) -> DetailLod {
+    let band = cull_cells * 0.5;
+    let margin = band * LOD_HYSTERESIS;
+    let boundary = match held {
+        Some(DetailLod::Near) => band + margin,
+        Some(DetailLod::Far) => band - margin,
+        None => band,
+    };
+    if centre_distance <= boundary {
+        DetailLod::Near
+    } else {
+        DetailLod::Far
+    }
+}
+
+/// The tiles of detail around a viewer with any part inside `cull_cells`,
+/// nearest first, each with the level it takes when not yet seeded.
+pub fn detail_tiles_around(
+    viewer_cell: IVec2,
+    cull_cells: f32,
+    tile_cells: u32,
+) -> Vec<(IVec2, DetailLod)> {
+    if tile_cells == 0 || !cull_cells.is_finite() || cull_cells <= 0.0 {
+        return Vec::new();
+    }
+    let side = tile_cells as f32;
+    let span = (cull_cells / side).ceil() as i32 + 1;
+    let base = IVec2::new(
+        viewer_cell.x.div_euclid(tile_cells as i32),
+        viewer_cell.y.div_euclid(tile_cells as i32),
+    );
+    let viewer = viewer_cell.as_vec2();
+
+    let mut tiles = Vec::new();
+    for tz in -span..=span {
+        for tx in -span..=span {
+            let tile = base + IVec2::new(tx, tz);
+            let min = tile.as_vec2() * side;
+            let max = min + Vec2::splat(side);
+            let nearest = viewer.clamp(min, max);
+            if viewer.distance(nearest) > cull_cells {
+                continue;
+            }
+            let centre_distance = tile_centre_distance(viewer_cell, tile, tile_cells);
+            tiles.push((
+                tile,
+                detail_lod_at(centre_distance, cull_cells, None),
+                centre_distance,
+            ));
+        }
+    }
+    tiles.sort_by(|a, b| {
+        a.2.total_cmp(&b.2)
+            .then_with(|| (a.0.x, a.0.y).cmp(&(b.0.x, b.0.y)))
+    });
+    tiles
+        .into_iter()
+        .map(|(tile, lod, _)| (tile, lod))
+        .collect()
+}
+
+/// Seed one tile of ground with a layer's instances, in terrain-local space.
+/// `density` is row-major at the heightmap's resolution, with `max` its ceiling.
+#[expect(
+    clippy::too_many_arguments,
+    reason = "every argument is one dimension of the field, and none group"
+)]
+pub fn place_detail(
+    density: &[u16],
+    max: u16,
+    heightmap: &Heightmap,
+    layer: &DetailLayer,
+    layer_index: usize,
+    tile: IVec2,
+    tile_cells: u32,
+    cell_size: f32,
+    density_scale: f32,
+    lod_scale: f32,
+    seed: u64,
+) -> Vec<DetailInstance> {
+    let resolution = heightmap.resolution;
+    let density_per_m2 = layer.density_per_m2 * density_scale;
+    if tile_cells == 0
+        || max == 0
+        || resolution == 0
+        || !cell_size.is_finite()
+        || cell_size <= 0.0
+        || !density_per_m2.is_finite()
+        || density_per_m2 <= 0.0
+        || !lod_scale.is_finite()
+        || lod_scale <= 0.0
+        || density.len() != (resolution as usize) * (resolution as usize)
+    {
+        return Vec::new();
+    }
+
+    let per_cell = density_per_m2 * cell_size * cell_size * lod_scale;
+    let origin = tile * tile_cells as i32;
+    let layer_seed = seed ^ mix64(layer_index as u64);
+    let mut placed = Vec::new();
+
+    for lz in 0..tile_cells as i32 {
+        for lx in 0..tile_cells as i32 {
+            let gx = origin.x + lx;
+            let gz = origin.y + lz;
+            if gx < 0 || gz < 0 || gx >= resolution as i32 || gz >= resolution as i32 {
+                continue;
+            }
+            let coverage = f32::from(density[gz as usize * resolution as usize + gx as usize])
+                / f32::from(max);
+            if coverage <= 0.0 {
+                continue;
+            }
+            let gradient = cell_gradient(heightmap, gx, gz, cell_size);
+            if gradient.length().atan() > MAX_SLOPE {
+                continue;
+            }
+            let tilt = match layer.align_to_normal {
+                true => ground_tilt(gradient),
+                false => Vec2::ZERO,
+            };
+
+            let wanted = per_cell * coverage;
+            let cell_seed = mix64(
+                layer_seed ^ mix64(gx as i64 as u64) ^ mix64((gz as i64 as u64).rotate_left(32)),
+            );
+            // Stochastic rounding: the fractional instance is spent by a draw
+            // against the cell's own hash.
+            let count = wanted.floor() as u32 + u32::from(unit(cell_seed) < wanted.fract());
+
+            for k in 0..count {
+                let h = mix64(cell_seed ^ mix64(u64::from(k).wrapping_add(0x9e37_79b9)));
+                let jitter = Vec2::new(unit(h), unit(h.rotate_left(17)));
+                let grid = Vec2::new(gx as f32, gz as f32) + jitter;
+                let local = heightmap.origin + grid * cell_size;
+                let position =
+                    Vec3::new(local.x, heightmap.sample_bilinear(grid.x, grid.y), local.y);
+                let variation = tileable_value_noise(local / VARIATION_TILE, VARIATION_PERIOD);
+                let height = to_byte(blend(variation, unit(h.rotate_left(53)), HEIGHT_JITTER));
+                let width = to_byte(unit(h.rotate_left(41)));
+                let yaw = to_byte(unit(h.rotate_left(5)));
+                let tint = to_byte(blend(variation, unit(h.rotate_left(29)), TINT_JITTER));
+                placed.push(DetailInstance {
+                    position,
+                    packed: DetailInstance::pack(height, width, yaw, tint),
+                    tilt,
+                });
+            }
+        }
+    }
+    placed
+}
+
+/// A patch value and an instance's own, mixed `amount` of the way toward the
+/// instance, in `0..1`.
+fn blend(patch: f32, instance: f32, amount: f32) -> f32 {
+    (patch * (1.0 - amount) + instance * amount).clamp(0.0, 1.0)
+}
+
+/// Height change per world unit along X and Z at one cell.
+fn cell_gradient(heightmap: &Heightmap, gx: i32, gz: i32, cell_size: f32) -> Vec2 {
+    let at = |x: i32, z: i32| {
+        let x = x.clamp(0, heightmap.resolution as i32 - 1) as u32;
+        let z = z.clamp(0, heightmap.resolution as i32 - 1) as u32;
+        heightmap.get_height(x, z)
+    };
+    let dx = (at(gx + 1, gz) - at(gx - 1, gz)) / (2.0 * cell_size);
+    let dz = (at(gx, gz + 1) - at(gx, gz - 1)) / (2.0 * cell_size);
+    Vec2::new(dx, dz)
+}
+
+/// X and Z of the unit ground normal a gradient stands under.
+fn ground_tilt(gradient: Vec2) -> Vec2 {
+    let normal = Vec3::new(-gradient.x, 1.0, -gradient.y).normalize_or(Vec3::Y);
+    Vec2::new(normal.x, normal.z)
+}
+
+/// Value noise on a lattice that wraps every `period` units, in `0..1`.
+pub fn tileable_value_noise(p: Vec2, period: f32) -> f32 {
+    if !period.is_finite() || period <= 0.0 {
+        return 0.5;
+    }
+    let x0 = p.x.floor();
+    let z0 = p.y.floor();
+    let fx = smoothstep(p.x - x0);
+    let fz = smoothstep(p.y - z0);
+    let wrap = |v: f32| v.rem_euclid(period) as i64 as u64;
+    let lattice = |x: f32, z: f32| unit(mix64(wrap(x) ^ mix64(wrap(z).rotate_left(32))));
+
+    let n00 = lattice(x0, z0);
+    let n10 = lattice(x0 + 1.0, z0);
+    let n01 = lattice(x0, z0 + 1.0);
+    let n11 = lattice(x0 + 1.0, z0 + 1.0);
+    let top = n00 + (n10 - n00) * fx;
+    let bottom = n01 + (n11 - n01) * fx;
+    top + (bottom - top) * fz
+}
+
+/// Hermite ease over `0..1`.
+fn smoothstep(t: f32) -> f32 {
+    let t = t.clamp(0.0, 1.0);
+    t * t * (3.0 - 2.0 * t)
+}
+
+/// A `0..1` value as the byte the vertex buffer carries.
+fn to_byte(v: f32) -> u8 {
+    (v.clamp(0.0, 1.0) * 255.0).round() as u8
+}
+
+/// Top 24 bits of a hash as a `0..1` float.
+fn unit(h: u64) -> f32 {
+    (h >> 40) as f32 / 16_777_216.0
+}
+
+/// Integer avalanche hash, identical on every platform.
+fn mix64(mut x: u64) -> u64 {
+    x ^= x >> 33;
+    x = x.wrapping_mul(0xff51_afd7_ed55_8ccd);
+    x ^= x >> 33;
+    x = x.wrapping_mul(0xc4ce_b9fe_1a85_ec53);
+    x ^= x >> 33;
+    x
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn flat(resolution: u32) -> Heightmap {
+        Heightmap::new_at(
+            resolution,
+            Vec2::splat((resolution - 1) as f32),
+            50.0,
+            Vec2::ZERO,
+        )
+    }
+
+    fn full(resolution: u32) -> Vec<u16> {
+        vec![255; (resolution as usize) * (resolution as usize)]
+    }
+
+    fn layer(density_per_m2: f32) -> DetailLayer {
+        DetailLayer {
+            density_per_m2,
+            ..DetailLayer::default()
+        }
+    }
+
+    #[expect(
+        clippy::too_many_arguments,
+        reason = "one call shape for every placement test"
+    )]
+    fn place(
+        density: &[u16],
+        heightmap: &Heightmap,
+        layer: &DetailLayer,
+        layer_index: usize,
+        tile: IVec2,
+        tile_cells: u32,
+        lod_scale: f32,
+        seed: u64,
+    ) -> Vec<DetailInstance> {
+        place_detail(
+            density,
+            255,
+            heightmap,
+            layer,
+            layer_index,
+            tile,
+            tile_cells,
+            1.0,
+            1.0,
+            lod_scale,
+            seed,
+        )
+    }
+
+    #[test]
+    fn the_same_tile_and_seed_place_the_same_instances() {
+        let heightmap = flat(32);
+        let density = full(32);
+        let grown = layer(12.0);
+        let once = place(&density, &heightmap, &grown, 0, IVec2::new(1, 1), 8, 1.0, 7);
+        let twice = place(&density, &heightmap, &grown, 0, IVec2::new(1, 1), 8, 1.0, 7);
+        assert!(!once.is_empty());
+        assert_eq!(once, twice);
+
+        let elsewhere = place(&density, &heightmap, &grown, 0, IVec2::new(1, 1), 8, 1.0, 8);
+        assert_ne!(once, elsewhere, "a different seed places a different field");
+    }
+
+    #[test]
+    fn two_layers_of_one_terrain_place_different_fields() {
+        let heightmap = flat(32);
+        let density = full(32);
+        let grown = layer(12.0);
+        let first = place(&density, &heightmap, &grown, 0, IVec2::ZERO, 8, 1.0, 5);
+        let second = place(&density, &heightmap, &grown, 1, IVec2::ZERO, 8, 1.0, 5);
+        assert!(!first.is_empty());
+        assert_ne!(first, second, "a second layer places different instances");
+    }
+
+    #[test]
+    fn instance_count_scales_with_density_and_detail_level() {
+        let heightmap = flat(32);
+        let density = full(32);
+        let sparse = place(&density, &heightmap, &layer(4.0), 0, IVec2::ZERO, 8, 1.0, 3);
+        let dense = place(
+            &density,
+            &heightmap,
+            &layer(16.0),
+            0,
+            IVec2::ZERO,
+            8,
+            1.0,
+            3,
+        );
+        assert!(
+            dense.len() > sparse.len() * 2,
+            "{} instances at four times the density beats {}",
+            dense.len(),
+            sparse.len()
+        );
+
+        let far = place(
+            &density,
+            &heightmap,
+            &layer(16.0),
+            0,
+            IVec2::ZERO,
+            8,
+            DetailLod::Far.density_scale(),
+            3,
+        );
+        assert!(far.len() < dense.len());
+        assert!(!far.is_empty());
+        for instance in &far {
+            assert!(
+                dense.contains(instance),
+                "a far tile keeps instances the near tile also placed"
+            );
+        }
+    }
+
+    #[test]
+    fn a_cell_with_no_density_grows_nothing() {
+        let heightmap = flat(16);
+        let mut density = vec![0u16; 16 * 16];
+        let grown = layer(20.0);
+        assert!(place(&density, &heightmap, &grown, 0, IVec2::ZERO, 8, 1.0, 1).is_empty());
+
+        density[3 * 16 + 3] = 255;
+        let placed = place(&density, &heightmap, &grown, 0, IVec2::ZERO, 8, 1.0, 1);
+        assert!(!placed.is_empty());
+        for instance in &placed {
+            assert!(
+                (3.0..4.0).contains(&instance.position.x)
+                    && (3.0..4.0).contains(&instance.position.z),
+                "every instance stands on the one cell that has density"
+            );
+        }
+    }
+
+    #[test]
+    fn instances_in_one_patch_do_not_stand_level() {
+        let heightmap = flat(16);
+        let density = full(16);
+        let placed = place(
+            &density,
+            &heightmap,
+            &layer(40.0),
+            0,
+            IVec2::ZERO,
+            4,
+            1.0,
+            11,
+        );
+        assert!(placed.len() > 20);
+
+        let heights: Vec<u8> = placed.iter().map(|blade| blade.unpack()[0]).collect();
+        let tints: Vec<u8> = placed.iter().map(|blade| blade.unpack()[3]).collect();
+        let spread = |bytes: &[u8]| {
+            let low = *bytes.iter().min().expect("instances were placed");
+            let high = *bytes.iter().max().expect("instances were placed");
+            high - low
+        };
+        // Four cells fall inside one nine-metre variation tile, so the
+        // spread here is the instances' own.
+        assert!(
+            spread(&heights) > 20,
+            "every instance stands the same height"
+        );
+        assert!(spread(&tints) > 20, "every instance reads the same colour");
+    }
+
+    #[test]
+    fn a_steep_cell_grows_nothing_while_the_flat_ground_beside_it_does() {
+        let mut heightmap = flat(16);
+        for z in 0..16 {
+            for x in 8..16 {
+                heightmap.set_height(x, z, (x - 8) as f32 * 3.0);
+            }
+        }
+        let density = full(16);
+        let placed = place(
+            &density,
+            &heightmap,
+            &layer(20.0),
+            0,
+            IVec2::ZERO,
+            16,
+            1.0,
+            2,
+        );
+        assert!(!placed.is_empty());
+        for instance in &placed {
+            assert!(
+                instance.position.x < 8.0,
+                "no instance stands on the slope, but one is at {}",
+                instance.position.x
+            );
+        }
+        assert!(
+            placed.iter().any(|instance| instance.position.x > 6.0),
+            "the flat ground beside the slope still grows"
+        );
+    }
+
+    #[test]
+    fn a_layer_that_aligns_to_the_normal_leans_on_a_slope() {
+        let mut heightmap = flat(16);
+        for z in 0..16 {
+            for x in 0..16 {
+                heightmap.set_height(x, z, x as f32 * 0.5);
+            }
+        }
+        let density = full(16);
+        let upright = layer(20.0);
+        let aligned = DetailLayer {
+            align_to_normal: true,
+            ..upright.clone()
+        };
+
+        let standing = place(&density, &heightmap, &upright, 0, IVec2::ZERO, 8, 1.0, 4);
+        let leaning = place(&density, &heightmap, &aligned, 0, IVec2::ZERO, 8, 1.0, 4);
+        assert!(!leaning.is_empty());
+        assert!(standing.iter().all(|instance| instance.tilt == Vec2::ZERO));
+        assert!(
+            leaning.iter().all(|instance| instance.tilt.x < -0.1),
+            "every instance leans down the rising X gradient"
+        );
+        assert!(leaning.iter().all(|instance| instance.tilt.y.abs() < 1e-5));
+    }
+
+    #[test]
+    fn tiles_cover_the_cull_radius_and_stop_there() {
+        let tiles = detail_tiles_around(IVec2::new(64, 64), 40.0, 16);
+        assert!(!tiles.is_empty());
+        for (tile, _) in &tiles {
+            let min = tile.as_vec2() * 16.0;
+            let nearest = Vec2::splat(64.0).clamp(min, min + Vec2::splat(16.0));
+            assert!(
+                Vec2::splat(64.0).distance(nearest) <= 40.0,
+                "tile {tile} is inside the cull radius"
+            );
+        }
+        assert!(tiles.iter().any(|(tile, _)| *tile == IVec2::new(4, 4)));
+        assert!(!tiles.iter().any(|(tile, _)| *tile == IVec2::new(9, 9)));
+
+        let wider = detail_tiles_around(IVec2::new(64, 64), 80.0, 16);
+        assert!(wider.len() > tiles.len());
+    }
+
+    #[test]
+    fn tiles_are_listed_nearest_first_and_coarsen_with_distance() {
+        // The middle of tile (4, 4).
+        let tiles = detail_tiles_around(IVec2::new(72, 72), 64.0, 16);
+        assert_eq!(tiles[0].0, IVec2::new(4, 4));
+        assert_eq!(tiles[0].1, DetailLod::Near);
+        assert_eq!(
+            tiles.last().expect("the list is not empty").1,
+            DetailLod::Far
+        );
+        assert!(tiles.iter().any(|(_, lod)| *lod == DetailLod::Near));
+    }
+
+    #[test]
+    fn a_seeded_tile_keeps_its_level_across_the_boundary() {
+        let cull = 64.0;
+        let band = cull * 0.5;
+        assert_eq!(detail_lod_at(band - 0.01, cull, None), DetailLod::Near);
+        assert_eq!(detail_lod_at(band + 0.01, cull, None), DetailLod::Far);
+
+        assert_eq!(
+            detail_lod_at(band + 0.01, cull, Some(DetailLod::Near)),
+            DetailLod::Near,
+            "a near tile nudged past the boundary stays near"
+        );
+        assert_eq!(
+            detail_lod_at(band - 0.01, cull, Some(DetailLod::Far)),
+            DetailLod::Far,
+            "a far tile nudged inside the boundary stays far"
+        );
+
+        let margin = band * LOD_HYSTERESIS;
+        assert_eq!(
+            detail_lod_at(band + margin * 2.0, cull, Some(DetailLod::Near)),
+            DetailLod::Far,
+            "past the margin it does change"
+        );
+        assert_eq!(
+            detail_lod_at(band - margin * 2.0, cull, Some(DetailLod::Far)),
+            DetailLod::Near
+        );
+    }
+
+    #[test]
+    fn a_viewer_with_no_cull_radius_has_no_tiles() {
+        assert!(detail_tiles_around(IVec2::ZERO, 0.0, 16).is_empty());
+        assert!(detail_tiles_around(IVec2::ZERO, 40.0, 0).is_empty());
+    }
+
+    #[test]
+    fn the_variation_bytes_survive_the_packed_word() {
+        let instance = DetailInstance {
+            position: Vec3::new(1.0, 2.0, 3.0),
+            packed: DetailInstance::pack(9, 200, 17, 255),
+            tilt: Vec2::ZERO,
+        };
+        assert_eq!(instance.unpack(), [9, 200, 17, 255]);
+        assert_eq!(size_of::<DetailInstance>(), 24);
+    }
+
+    #[test]
+    fn the_value_noise_wraps_across_its_period() {
+        for at in [0.0, 0.25, 1.5, 3.75] {
+            let inside = tileable_value_noise(Vec2::new(at, at), 8.0);
+            let wrapped = tileable_value_noise(Vec2::new(at + 8.0, at + 8.0), 8.0);
+            assert!(
+                (inside - wrapped).abs() < 1e-5,
+                "{inside} at {at} should repeat as {wrapped}"
+            );
+        }
+    }
+}

--- a/crates/jackdaw_terrain/src/detail.rs
+++ b/crates/jackdaw_terrain/src/detail.rs
@@ -205,9 +205,7 @@ pub fn place_detail(
             let cell_seed = mix64(
                 layer_seed ^ mix64(gx as i64 as u64) ^ mix64((gz as i64 as u64).rotate_left(32)),
             );
-            // Stochastic rounding: the fractional instance is spent by a draw
-            // against the cell's own hash.
-            let count = wanted.floor() as u32 + u32::from(unit(cell_seed) < wanted.fract());
+            let count = stochastic_round(wanted, cell_seed);
 
             for k in 0..count {
                 let h = mix64(cell_seed ^ mix64(u64::from(k).wrapping_add(0x9e37_79b9)));
@@ -286,6 +284,12 @@ fn smoothstep(t: f32) -> f32 {
 /// A `0..1` value as the byte the vertex buffer carries.
 fn to_byte(v: f32) -> u8 {
     (v.clamp(0.0, 1.0) * 255.0).round() as u8
+}
+
+/// `wanted` as a whole count, its fraction spent as a draw against `seed` so
+/// that a field of cells averages out to `wanted`.
+fn stochastic_round(wanted: f32, seed: u64) -> u32 {
+    wanted.floor() as u32 + u32::from(unit(seed) < wanted.fract())
 }
 
 /// Top 24 bits of a hash as a `0..1` float.
@@ -446,13 +450,14 @@ mod tests {
     fn instances_in_one_patch_do_not_stand_level() {
         let heightmap = flat(16);
         let density = full(16);
+        let cells_within_one_variation_tile = 4;
         let placed = place(
             &density,
             &heightmap,
             &layer(40.0),
             0,
             IVec2::ZERO,
-            4,
+            cells_within_one_variation_tile,
             1.0,
             11,
         );
@@ -465,8 +470,6 @@ mod tests {
             let high = *bytes.iter().max().expect("instances were placed");
             high - low
         };
-        // Four cells fall inside one nine-metre variation tile, so the
-        // spread here is the instances' own.
         assert!(
             spread(&heights) > 20,
             "every instance stands the same height"
@@ -554,8 +557,8 @@ mod tests {
 
     #[test]
     fn tiles_are_listed_nearest_first_and_coarsen_with_distance() {
-        // The middle of tile (4, 4).
-        let tiles = detail_tiles_around(IVec2::new(72, 72), 64.0, 16);
+        let middle_of_tile_4_4 = IVec2::new(72, 72);
+        let tiles = detail_tiles_around(middle_of_tile_4_4, 64.0, 16);
         assert_eq!(tiles[0].0, IVec2::new(4, 4));
         assert_eq!(tiles[0].1, DetailLod::Near);
         assert_eq!(

--- a/crates/jackdaw_terrain/src/lib.rs
+++ b/crates/jackdaw_terrain/src/lib.rs
@@ -2,6 +2,8 @@ pub mod brush;
 pub mod channel;
 pub mod clipmap;
 pub mod control;
+#[cfg(feature = "render")]
+pub mod detail;
 #[cfg(feature = "procgen")]
 pub mod erosion;
 #[cfg(feature = "procgen")]
@@ -21,13 +23,20 @@ pub mod texture_set;
 pub mod tint;
 
 pub use brush::{SculptTool, affected_chunks, affected_chunks_at, apply_brush, apply_brush_at};
-pub use channel::{ChannelData, ChannelDescriptor, ChannelElement, apply_channel_brush};
+pub use channel::{
+    ChannelData, ChannelDescriptor, ChannelElement, apply_channel_brush, apply_density_brush,
+};
 pub use clipmap::{
     ClipmapLevel, GridSquare, REBUILD_BUDGET, SurfaceMeshData, build_clipmap_indices,
     build_clipmap_mesh_data, clipmap_levels, flat_shaded, plan_rebuilds,
 };
 pub use control::{
     Control, MANUAL_BIT, MAX_BLEND, MAX_TEXTURE_ID, apply_control_brush, apply_restore_brush,
+};
+#[cfg(feature = "render")]
+pub use detail::{
+    DetailInstance, DetailLod, detail_lod_at, detail_tiles_around, place_detail,
+    tile_centre_distance,
 };
 #[cfg(feature = "procgen")]
 pub use erosion::{ErosionParams, hydraulic_erosion};

--- a/crates/jackdaw_terrain/src/render/detail.rs
+++ b/crates/jackdaw_terrain/src/render/detail.rs
@@ -10,7 +10,7 @@ use bevy::ecs::query::QueryItem;
 use bevy::ecs::system::SystemParamItem;
 use bevy::ecs::system::lifetimeless::{Read, SRes};
 use bevy::image::{ImageAddressMode, ImageSampler, ImageSamplerDescriptor};
-use bevy::math::Affine3A;
+use bevy::math::{Affine3A, Mat3A};
 use bevy::mesh::{
     Indices, MeshVertexAttribute, MeshVertexBufferLayoutRef, PrimitiveTopology, VertexBufferLayout,
 };
@@ -197,10 +197,10 @@ pub struct DetailDirty {
 }
 
 impl DetailDirty {
-    /// Mark the ground a rect covers stale.
+    /// Mark the ground a rect covers stale. An uncaught mark widens to cover
+    /// both rather than being replaced.
     pub fn touch(&mut self, rect: GridRect) {
         self.rect = Some(match self.rect {
-            // Marks accumulate: an uncaught mark is widened, never replaced.
             Some(held) => union(held, rect),
             None => rect,
         });
@@ -438,20 +438,17 @@ pub fn card_mesh(segments: u32) -> Mesh {
         ]);
     }
 
-    // Left readable on the main world: a card is a handful of vertices, and a
-    // mesh extracted away panics anything that reads its attributes.
-    Mesh::new(
-        PrimitiveTopology::TriangleList,
-        RenderAssetUsages::default(),
-    )
-    .with_inserted_attribute(Mesh::ATTRIBUTE_POSITION, positions)
-    .with_inserted_attribute(Mesh::ATTRIBUTE_NORMAL, normals)
-    .with_inserted_attribute(Mesh::ATTRIBUTE_UV_0, uvs)
-    .with_inserted_attribute(ATTRIBUTE_HEIGHT_FRACTION, fractions)
-    .with_inserted_indices(Indices::U32(indices))
+    let readable_on_the_main_world = RenderAssetUsages::default();
+    Mesh::new(PrimitiveTopology::TriangleList, readable_on_the_main_world)
+        .with_inserted_attribute(Mesh::ATTRIBUTE_POSITION, positions)
+        .with_inserted_attribute(Mesh::ATTRIBUTE_NORMAL, normals)
+        .with_inserted_attribute(Mesh::ATTRIBUTE_UV_0, uvs)
+        .with_inserted_attribute(ATTRIBUTE_HEIGHT_FRACTION, fractions)
+        .with_inserted_indices(Indices::U32(indices))
 }
 
 /// A tileable value-noise texture for the shader to read the wind from.
+/// Sampled at world coordinates over a tile size, so the sampler repeats.
 pub fn wind_noise_image() -> Image {
     let side = WIND_TEXTURE_SIZE;
     let scale = WIND_LATTICE / side as f32;
@@ -474,7 +471,6 @@ pub fn wind_noise_image() -> Image {
         TextureFormat::R8Unorm,
         RenderAssetUsages::RENDER_WORLD,
     );
-    // Sampled at world coordinates over a tile size, so the sampler repeats.
     image.sampler = ImageSampler::Descriptor(ImageSamplerDescriptor {
         address_mode_u: ImageAddressMode::Repeat,
         address_mode_v: ImageAddressMode::Repeat,
@@ -628,6 +624,12 @@ fn build_detail_meshes(
     }
 }
 
+/// The matrix that carries a normal through `affine`: the inverse transpose,
+/// so that a non-uniform scale tilts the normal the way the surface turns.
+fn normal_matrix_of(affine: Affine3A) -> Mat3A {
+    affine.matrix3.inverse().transpose()
+}
+
 /// Every primitive of a flattened glTF as one mesh, with the base colour
 /// texture the first textured primitive carries. `None` while any is loading.
 fn merge_primitives(
@@ -660,8 +662,7 @@ fn merge_primitives(
             continue;
         };
         let affine = primitive.local.compute_affine();
-        // A normal survives a non-uniform scale through the inverse transpose.
-        let normal_matrix = affine.matrix3.inverse().transpose();
+        let normal_matrix = normal_matrix_of(affine);
         let base = positions.len() as u32;
 
         let source_normals = mesh
@@ -793,8 +794,6 @@ fn rebuild_detail_tiles(
     )>,
     tiles: Query<(Entity, &DetailTile)>,
 ) {
-    // A tile is a root entity, not a child of its terrain, so it is retired
-    // here rather than with the terrain.
     for (tile_entity, tile) in &tiles {
         let layers = terrains
             .get(tile.terrain)
@@ -832,8 +831,6 @@ fn rebuild_detail_tiles(
                 if tile.terrain != entity || tile.layer != index {
                     continue;
                 }
-                // Asked with the level the tile already carries, which applies
-                // the hysteresis.
                 let level = detail_lod_at(
                     tile_centre_distance(viewer_cell, tile.tile, DETAIL_TILE_CELLS),
                     cull_cells,
@@ -856,20 +853,15 @@ fn rebuild_detail_tiles(
                 if standing.contains(&coord) {
                     continue;
                 }
-                // A layer whose asset is still loading draws nothing.
                 let Some(mesh) = layer_mesh(&assets, &built, &entry.layer, lod) else {
                     break;
                 };
                 spent += 1;
                 let instances = seed_tile(source, &settings, index, coord, lod, world_from_local);
-                // Bare ground is still a tile; extraction drops one with no
-                // instances.
                 let bounds = match instances.is_empty() {
                     true => footprint(source, coord, world_from_local),
                     false => tile_bounds(&instances, &entry.layer),
                 };
-                // Tagged out of the navmesh here: a tile carries a mesh, and
-                // the bake reads whatever mesh a scene entity carries.
                 commands.spawn((
                     DetailTile {
                         terrain: entity,
@@ -1081,8 +1073,8 @@ impl SpecializedMeshPipeline for DetailPipeline {
             fragment.shader = self.shader.clone();
         }
         descriptor.layout.push(self.layout.clone());
-        // A card is a sheet with no inside, so both of its faces draw.
-        descriptor.primitive.cull_mode = None;
+        let draw_both_faces_of_a_sheet = None;
+        descriptor.primitive.cull_mode = draw_both_faces_of_a_sheet;
         Ok(descriptor)
     }
 }
@@ -1113,7 +1105,8 @@ fn prepare_detail_buffers(
     }
 }
 
-/// Build one bind group per layer of every terrain drawing detail.
+/// Build one bind group per layer of every terrain drawing detail. A look
+/// whose textures have not reached the GPU is left out.
 fn prepare_detail_bind_groups(
     mut groups: ResMut<DetailBindGroups>,
     pipeline: Res<DetailPipeline>,
@@ -1127,7 +1120,6 @@ fn prepare_detail_bind_groups(
     groups.0.clear();
     let mut param = (images, fallback, buffers);
     for (key, bindings) in &looks.0 {
-        // A look whose textures have not reached the GPU is left out.
         if let Ok(prepared) = bindings.as_bind_group(
             &pipeline.layout,
             &render_device,
@@ -1160,7 +1152,7 @@ fn queue_detail_tiles(
     tiles: Query<(Entity, &MainEntity), With<DetailTile>>,
 ) {
     let draw_function = draw_functions.read().id::<DrawDetail>();
-    // A view that has gone takes its phase with it.
+    let draws_its_own_instances = BinnedRenderPhaseType::NonMesh;
     let live: HashSet<_> = views.iter().map(|view| view.retained_view_entity).collect();
     queued.0.retain(|view, _| live.contains(view));
 
@@ -1172,8 +1164,6 @@ fn queue_detail_tiles(
             continue;
         };
 
-        // The bin keeps what it is given; anything no longer a tile is
-        // removed below.
         let held = queued.0.entry(view.retained_view_entity).or_default();
         let mut present = HashSet::new();
 
@@ -1211,9 +1201,7 @@ fn queue_detail_tiles(
                 },
                 (entity, *main_entity),
                 instance.current_uniform_index,
-                // The draw does its own instancing and ignores the batch range,
-                // so it never joins a batch or an indirect draw.
-                BinnedRenderPhaseType::NonMesh,
+                draws_its_own_instances,
             );
         }
 
@@ -1482,10 +1470,10 @@ mod tests {
     fn two_layers_seed_their_own_tiles_from_their_own_channels() {
         let mut app = detail_app();
         let mut data = document(64, &["grass", "flowers"]);
-        // The second channel covers a corner of the ground rather than all of it.
+        let painted_corner = 32;
         for z in 0..64 {
             for x in 0..64 {
-                if x >= 32 || z >= 32 {
+                if x >= painted_corner || z >= painted_corner {
                     data.regions.set_channel(1, x, z, 0);
                 }
             }
@@ -1615,9 +1603,11 @@ mod tests {
         else {
             panic!("the merge carries a height fraction per vertex");
         };
-        // The parts stack two units tall, so the lower part's tip is halfway up.
         assert_eq!(fractions[0], 0.0);
-        assert_eq!(fractions[2], 0.5);
+        assert_eq!(
+            fractions[2], 0.5,
+            "the lower of two stacked units reaches halfway up"
+        );
         assert_eq!(fractions[5], 1.0);
     }
 
@@ -1694,13 +1684,11 @@ mod tests {
         )
         .with_inserted_attribute(Mesh::ATTRIBUTE_NORMAL, vec![diagonal; 3])
         .with_inserted_indices(Indices::U32(vec![0, 1, 2]));
-        // Stretched fourfold up: the surface flattens, so its normal turns
-        // toward straight up under the matrix and away from it under the
-        // inverse transpose.
+        let stretched_fourfold_up = Transform::from_scale(Vec3::new(1.0, 4.0, 1.0));
         let primitives = vec![ScatterPrimitive {
             mesh: meshes.add(leaning),
             material: Handle::default(),
-            local: Transform::from_scale(Vec3::new(1.0, 4.0, 1.0)),
+            local: stretched_fourfold_up,
         }];
 
         let (merged, _) = merge_primitives("models/leaning.gltf", &primitives, &meshes, &materials)
@@ -2118,8 +2106,6 @@ mod tests {
             "no slot is reused"
         );
 
-        // The mesh takes the first four slots, one per attribute the card and
-        // every merged asset carry.
         let card = card_mesh(NEAR_SEGMENTS);
         for attribute in [
             Mesh::ATTRIBUTE_POSITION.id,
@@ -2129,7 +2115,11 @@ mod tests {
         ] {
             assert!(card.attribute(attribute).is_some());
         }
-        assert_eq!(card.attributes().count(), 4);
+        assert_eq!(
+            card.attributes().count(),
+            4,
+            "the card and every merged asset carry one attribute per mesh slot"
+        );
         for location in &locations {
             assert!(*location >= 4, "slot {location} is already the mesh's");
         }

--- a/crates/jackdaw_terrain/src/render/detail.rs
+++ b/crates/jackdaw_terrain/src/render/detail.rs
@@ -1,0 +1,2147 @@
+//! Drawing a terrain's detail layers as one instanced call per layer per tile.
+//! A host writes [`TerrainDetailSource`] and [`DetailDirty`] onto the terrain.
+
+use std::sync::Arc;
+
+use bevy::asset::{RenderAssetUsages, embedded_asset};
+use bevy::camera::primitives::Aabb;
+use bevy::core_pipeline::core_3d::{Opaque3d, Opaque3dBatchSetKey, Opaque3dBinKey};
+use bevy::ecs::query::QueryItem;
+use bevy::ecs::system::SystemParamItem;
+use bevy::ecs::system::lifetimeless::{Read, SRes};
+use bevy::image::{ImageAddressMode, ImageSampler, ImageSamplerDescriptor};
+use bevy::math::Affine3A;
+use bevy::mesh::{
+    Indices, MeshVertexAttribute, MeshVertexBufferLayoutRef, PrimitiveTopology, VertexBufferLayout,
+};
+use bevy::pbr::{
+    MeshPipeline, MeshPipelineKey, MeshPipelineSystems, RenderMeshInstances, SetMeshBindGroup,
+    SetMeshViewBindGroup, SetMeshViewBindingArrayBindGroup,
+};
+use bevy::platform::collections::{HashMap, HashSet};
+use bevy::prelude::*;
+use bevy::render::extract_component::{ExtractComponent, ExtractComponentPlugin};
+use bevy::render::extract_resource::{ExtractResource, ExtractResourcePlugin};
+use bevy::render::mesh::allocator::MeshAllocator;
+use bevy::render::mesh::{RenderMesh, RenderMeshBufferInfo};
+use bevy::render::render_asset::RenderAssets;
+use bevy::render::render_phase::{
+    AddRenderCommand, BinnedRenderPhaseType, DrawFunctions, PhaseItem, RenderCommand,
+    RenderCommandResult, SetItemPipeline, TrackedRenderPass, ViewBinnedRenderPhases,
+};
+use bevy::render::render_resource::{
+    AsBindGroup, BindGroup, BindGroupLayoutDescriptor, BufferUsages, Extent3d, PipelineCache,
+    RawBufferVec, RenderPipelineDescriptor, SpecializedMeshPipeline, SpecializedMeshPipelineError,
+    SpecializedMeshPipelines, TextureDimension, TextureFormat, VertexAttribute, VertexFormat,
+    VertexStepMode,
+};
+use bevy::render::renderer::{RenderDevice, RenderQueue};
+use bevy::render::storage::GpuShaderBuffer;
+use bevy::render::sync_component::SyncComponent;
+use bevy::render::sync_world::MainEntity;
+use bevy::render::texture::{FallbackImage, GpuImage};
+use bevy::render::view::ExtractedView;
+use bevy::render::{Render, RenderApp, RenderStartup, RenderSystems};
+use bevy::shader::Shader;
+use jackdaw_scene_types::{DetailLayer, DetailMesh, DetailPresser, NavmeshExclude, Terrain};
+
+use crate::channel::ChannelElement;
+use crate::detail::{
+    DetailInstance, DetailLod, detail_lod_at, detail_tiles_around, place_detail,
+    tile_centre_distance, tileable_value_noise,
+};
+use crate::heightmap::Heightmap;
+use crate::rect::GridRect;
+use crate::sidecar::{GridShape, RegionTerrainData};
+
+use super::scatter::{ScatterAssets, ScatterPrimitive, ScatterSystems};
+
+const SHADER_PATH: &str = "embedded://jackdaw_terrain/render/shaders/detail.wgsl";
+
+/// Pressers the shader reads. Past this the nearest to the viewer win.
+pub const MAX_DETAIL_PRESSERS: usize = 16;
+
+/// Grid cells along one edge of a detail tile.
+pub const DETAIL_TILE_CELLS: u32 = 16;
+
+/// Tiles seeded per frame.
+pub const DETAIL_TILE_BUDGET: usize = 2;
+
+/// How far up its own mesh a vertex stands, in `0..1`. The shader bends and
+/// shades by it.
+pub const ATTRIBUTE_HEIGHT_FRACTION: MeshVertexAttribute =
+    MeshVertexAttribute::new("HeightFraction", 1_903_552_411, VertexFormat::Float32);
+
+/// Card segments at each detail level.
+const NEAR_SEGMENTS: u32 = 3;
+const FAR_SEGMENTS: u32 = 1;
+
+/// Edge of the generated wind texture, in texels.
+const WIND_TEXTURE_SIZE: u32 = 32;
+/// Lattice cells across that texture, which wraps on the lattice.
+const WIND_LATTICE: f32 = 4.0;
+
+/// What a terrain's detail is grown from: its ground, and one entry per layer.
+/// A projection of the terrain's document and component, shared in one `Arc`.
+#[derive(Component, Clone, Debug)]
+pub struct TerrainDetailSource(Arc<DetailSource>);
+
+/// The body of a [`TerrainDetailSource`].
+#[derive(Debug)]
+pub struct DetailSource {
+    /// The ground the instances stand on.
+    pub heightmap: Heightmap,
+    /// Where the grid sits and how far it reaches.
+    pub grid: GridShape,
+    /// One entry per layer, in the terrain's own order.
+    pub layers: Vec<DetailLayerSource>,
+}
+
+/// What one layer is grown from.
+#[derive(Debug)]
+pub struct DetailLayerSource {
+    /// The density channel as a dense row-major plane at the grid's resolution.
+    pub density: Vec<u16>,
+    /// The density channel's ceiling: a cell reading this is full coverage.
+    pub max: u16,
+    /// How the layer reads.
+    pub layer: DetailLayer,
+    /// What the placement is seeded from: the grid's placement and the density
+    /// channel's name.
+    pub seed: u64,
+}
+
+impl TerrainDetailSource {
+    /// The detail a document and its terrain component grow between them, or
+    /// `None` for a terrain with no layers.
+    pub fn from_document(data: &RegionTerrainData, terrain: &Terrain) -> Option<Self> {
+        if terrain.detail.is_empty() {
+            return None;
+        }
+        let grid = data.grid_shape(terrain.size, terrain.resolution);
+        let cells = (grid.resolution as usize) * (grid.resolution as usize);
+        let layers = terrain
+            .detail
+            .iter()
+            .map(|layer| {
+                let index = data
+                    .channels
+                    .iter()
+                    .position(|channel| channel.name == layer.density_channel);
+                let (density, max) = match index {
+                    Some(index) => (
+                        data.regions.read_grid_channel(index, grid.resolution),
+                        data.channels[index].element.max_value(),
+                    ),
+                    None => (vec![0; cells], ChannelElement::U8.max_value()),
+                };
+                DetailLayerSource {
+                    density,
+                    max,
+                    seed: seed_of(&grid, &layer.density_channel),
+                    layer: layer.clone(),
+                }
+            })
+            .collect();
+
+        let mut heights = Vec::new();
+        data.regions
+            .sample_grid_heights_into(grid.resolution, &mut heights);
+        Some(Self(Arc::new(DetailSource {
+            heightmap: Heightmap {
+                resolution: grid.resolution,
+                size: grid.size,
+                origin: grid.origin,
+                max_height: terrain.max_height,
+                heights,
+            },
+            grid,
+            layers,
+        })))
+    }
+
+    /// What the tiles are seeded from.
+    pub fn source(&self) -> &DetailSource {
+        &self.0
+    }
+
+    /// World units per grid cell edge.
+    pub fn cell_size(&self) -> f32 {
+        let grid = &self.0.grid;
+        grid.size.x / (grid.resolution.max(2) - 1) as f32
+    }
+}
+
+/// A seed stable across runs: the ground the grid covers, plus the name of
+/// the channel that grows the layer.
+fn seed_of(grid: &GridShape, density_channel: &str) -> u64 {
+    let mut seed = u64::from(grid.resolution);
+    for word in [
+        grid.origin.x.to_bits(),
+        grid.origin.y.to_bits(),
+        grid.size.x.to_bits(),
+    ] {
+        seed = seed.rotate_left(17) ^ u64::from(word);
+    }
+    for byte in density_channel.bytes() {
+        seed = seed.rotate_left(7) ^ u64::from(byte);
+    }
+    seed
+}
+
+/// Which of a terrain's ground the renderer has yet to catch up with. The rect
+/// covers the cells edits have touched; `None` is ground in step.
+#[derive(Component, Clone, Copy, Debug, Default)]
+pub struct DetailDirty {
+    pub rect: Option<GridRect>,
+}
+
+impl DetailDirty {
+    /// Mark the ground a rect covers stale.
+    pub fn touch(&mut self, rect: GridRect) {
+        self.rect = Some(match self.rect {
+            // Marks accumulate: an uncaught mark is widened, never replaced.
+            Some(held) => union(held, rect),
+            None => rect,
+        });
+    }
+}
+
+/// The smallest rect covering both.
+fn union(a: GridRect, b: GridRect) -> GridRect {
+    let x = a.x.min(b.x);
+    let z = a.z.min(b.z);
+    let max_x = (a.x + a.width).max(b.x + b.width);
+    let max_z = (a.z + a.height).max(b.z + b.height);
+    GridRect {
+        x,
+        z,
+        width: max_x - x,
+        height: max_z - z,
+    }
+}
+
+/// One seeded tile of one layer, and every instance standing on it.
+#[derive(Component, Clone, Debug)]
+pub struct DetailTile {
+    /// The terrain this grew from, whose layers the instances draw with.
+    pub terrain: Entity,
+    /// Which of that terrain's layers this tile belongs to.
+    pub layer: usize,
+    /// Which tile of that terrain's grid this is.
+    pub tile: IVec2,
+    pub lod: DetailLod,
+    /// The instances, in world space.
+    pub instances: Arc<Vec<DetailInstance>>,
+    /// What the instances occupy, for the frustum test.
+    pub bounds: Aabb,
+}
+
+impl SyncComponent for DetailTile {
+    type Target = Self;
+}
+
+impl ExtractComponent for DetailTile {
+    type QueryData = &'static DetailTile;
+    type QueryFilter = ();
+    type Out = Self;
+
+    fn extract_component(item: QueryItem<'_, '_, Self::QueryData>) -> Option<Self> {
+        (!item.instances.is_empty()).then(|| item.clone())
+    }
+}
+
+/// How far and how thickly detail draws, over what every layer declares.
+/// Not persisted.
+#[derive(Resource, Clone, Copy, Debug)]
+pub struct DetailSettings {
+    /// Multiplies every layer's instances per square metre.
+    pub density_scale: f32,
+    /// Multiplies every layer's cull distance.
+    pub cull_scale: f32,
+}
+
+impl Default for DetailSettings {
+    fn default() -> Self {
+        Self {
+            density_scale: 1.0,
+            cull_scale: 1.0,
+        }
+    }
+}
+
+/// What the detail is currently bending away from, nearest the viewer first.
+/// Filled from [`DetailPresser`] entities, capped at [`MAX_DETAIL_PRESSERS`].
+#[derive(Resource, Clone, Debug, Default)]
+pub struct DetailPressers {
+    /// World position and reach, one entry per presser.
+    pub pressers: Vec<(Vec3, f32)>,
+}
+
+/// The card meshes and the two shared textures, used by every terrain.
+#[derive(Resource, Clone, Debug)]
+pub struct DetailAssets {
+    pub near_card: Handle<Mesh>,
+    pub far_card: Handle<Mesh>,
+    pub wind_noise: Handle<Image>,
+    /// The one-texel white a layer with no texture of its own multiplies by.
+    pub white: Handle<Image>,
+}
+
+impl DetailAssets {
+    fn card(&self, lod: DetailLod) -> Handle<Mesh> {
+        match lod {
+            DetailLod::Near => self.near_card.clone(),
+            DetailLod::Far => self.far_card.clone(),
+        }
+    }
+}
+
+/// What one asset path flattened to, keyed by that path.
+#[derive(Resource, Default, Debug)]
+pub struct DetailMeshes(HashMap<String, BuiltDetailMesh>);
+
+/// One glTF, merged into the single mesh a layer instances.
+#[derive(Clone, Debug)]
+pub struct BuiltDetailMesh {
+    pub mesh: Handle<Mesh>,
+    /// The base colour texture the file's first textured primitive carries.
+    pub color: Option<Handle<Image>>,
+}
+
+impl DetailMeshes {
+    /// What a layer's asset path draws, or `None` until it has resolved.
+    pub fn get(&self, asset: &str) -> Option<&BuiltDetailMesh> {
+        self.0.get(asset)
+    }
+}
+
+/// The bind group one layer of one terrain draws with. A plain
+/// [`AsBindGroup`] rather than a `Material`, with a pipeline of its own.
+#[derive(AsBindGroup, Clone, Debug)]
+pub struct DetailBindings {
+    /// Linear colour at the foot of an instance. `w` is unused.
+    #[uniform(0)]
+    pub color_base: Vec4,
+    /// Linear colour at the top of an instance. `w` is unused.
+    #[uniform(0)]
+    pub color_tip: Vec4,
+    #[uniform(0)]
+    pub wind_direction: Vec2,
+    #[uniform(0)]
+    pub wind_speed: f32,
+    #[uniform(0)]
+    pub wind_strength: f32,
+    #[uniform(0)]
+    pub wind_vertical_strength: f32,
+    #[uniform(0)]
+    pub wind_tile_size: f32,
+    #[uniform(0)]
+    pub bend: f32,
+    #[uniform(0)]
+    pub push_strength: f32,
+    /// Shortest and tallest an instance stands, in world units.
+    #[uniform(0)]
+    pub height_range: Vec2,
+    /// Narrowest and widest an instance is drawn, over the mesh's own width.
+    #[uniform(0)]
+    pub width_range: Vec2,
+    #[uniform(0)]
+    pub cull_distance: f32,
+    #[uniform(0)]
+    pub presser_count: u32,
+    /// Whether the layer draws the built-in card, whose taper the fragment
+    /// stage carves.
+    #[uniform(0)]
+    pub is_card: u32,
+    /// `xyz` is a presser's world position, `w` how far it flattens detail.
+    #[uniform(0)]
+    pub pressers: [Vec4; MAX_DETAIL_PRESSERS],
+    #[texture(1)]
+    #[sampler(2)]
+    pub wind_noise: Handle<Image>,
+    #[texture(3)]
+    #[sampler(4)]
+    pub color_texture: Handle<Image>,
+}
+
+impl DetailBindings {
+    /// The bindings one layer's look and the pressers around it come to.
+    pub fn new(
+        layer: &DetailLayer,
+        settings: &DetailSettings,
+        pressers: &DetailPressers,
+        wind_noise: Handle<Image>,
+        color_texture: Handle<Image>,
+    ) -> Self {
+        let mut packed = [Vec4::ZERO; MAX_DETAIL_PRESSERS];
+        for (slot, (position, radius)) in packed.iter_mut().zip(&pressers.pressers) {
+            *slot = position.extend(radius * layer.push_radius);
+        }
+        Self {
+            color_base: linear_of(layer.color_base),
+            color_tip: linear_of(layer.color_tip),
+            wind_direction: Vec2::from(layer.wind_direction).normalize_or(Vec2::X),
+            wind_speed: layer.wind_speed,
+            wind_strength: layer.wind_strength,
+            wind_vertical_strength: layer.wind_vertical_strength,
+            wind_tile_size: layer.wind_tile_size,
+            bend: layer.bend,
+            push_strength: layer.push_strength,
+            height_range: Vec2::new(layer.height[0], layer.height[1]),
+            width_range: Vec2::new(layer.width[0], layer.width[1]),
+            cull_distance: layer.cull_distance * settings.cull_scale,
+            presser_count: pressers.pressers.len().min(MAX_DETAIL_PRESSERS) as u32,
+            is_card: u32::from(layer.mesh == DetailMesh::Card),
+            pressers: packed,
+            wind_noise,
+            color_texture,
+        }
+    }
+}
+
+/// Which terrain's layer a bind group belongs to.
+pub type DetailKey = (Entity, usize);
+
+/// The bindings every layer currently drawing is asking for.
+#[derive(Resource, Clone, Debug, Default, ExtractResource)]
+pub struct DetailLooks(pub Vec<(DetailKey, DetailBindings)>);
+
+/// A card of `segments` stacked quads, one unit tall and wide, its foot at the
+/// origin and its face on +Z. Straight-sided; the fragment stage carves it.
+pub fn card_mesh(segments: u32) -> Mesh {
+    let segments = segments.max(1);
+    let mut positions = Vec::new();
+    let mut normals = Vec::new();
+    let mut uvs = Vec::new();
+    let mut fractions = Vec::new();
+    let mut indices = Vec::new();
+
+    for row in 0..=segments {
+        let v = row as f32 / segments as f32;
+        for u in [0.0f32, 1.0] {
+            positions.push([u - 0.5, v, 0.0]);
+            normals.push([0.0, 0.0, 1.0]);
+            uvs.push([u, v]);
+            fractions.push(v);
+        }
+    }
+    for row in 0..segments {
+        let bottom = row * 2;
+        indices.extend_from_slice(&[
+            bottom,
+            bottom + 1,
+            bottom + 3,
+            bottom,
+            bottom + 3,
+            bottom + 2,
+        ]);
+    }
+
+    // Left readable on the main world: a card is a handful of vertices, and a
+    // mesh extracted away panics anything that reads its attributes.
+    Mesh::new(
+        PrimitiveTopology::TriangleList,
+        RenderAssetUsages::default(),
+    )
+    .with_inserted_attribute(Mesh::ATTRIBUTE_POSITION, positions)
+    .with_inserted_attribute(Mesh::ATTRIBUTE_NORMAL, normals)
+    .with_inserted_attribute(Mesh::ATTRIBUTE_UV_0, uvs)
+    .with_inserted_attribute(ATTRIBUTE_HEIGHT_FRACTION, fractions)
+    .with_inserted_indices(Indices::U32(indices))
+}
+
+/// A tileable value-noise texture for the shader to read the wind from.
+pub fn wind_noise_image() -> Image {
+    let side = WIND_TEXTURE_SIZE;
+    let scale = WIND_LATTICE / side as f32;
+    let mut data = Vec::with_capacity((side * side) as usize);
+    for z in 0..side {
+        for x in 0..side {
+            let at = Vec2::new(x as f32, z as f32) * scale;
+            let value = tileable_value_noise(at, WIND_LATTICE);
+            data.push((value.clamp(0.0, 1.0) * 255.0).round() as u8);
+        }
+    }
+    let mut image = Image::new(
+        Extent3d {
+            width: side,
+            height: side,
+            depth_or_array_layers: 1,
+        },
+        TextureDimension::D2,
+        data,
+        TextureFormat::R8Unorm,
+        RenderAssetUsages::RENDER_WORLD,
+    );
+    // Sampled at world coordinates over a tile size, so the sampler repeats.
+    image.sampler = ImageSampler::Descriptor(ImageSamplerDescriptor {
+        address_mode_u: ImageAddressMode::Repeat,
+        address_mode_v: ImageAddressMode::Repeat,
+        ..ImageSamplerDescriptor::linear()
+    });
+    image
+}
+
+/// One opaque white texel, which a layer with no texture multiplies by.
+pub fn white_image() -> Image {
+    Image::new(
+        Extent3d {
+            width: 1,
+            height: 1,
+            depth_or_array_layers: 1,
+        },
+        TextureDimension::D2,
+        vec![255, 255, 255, 255],
+        TextureFormat::Rgba8UnormSrgb,
+        RenderAssetUsages::RENDER_WORLD,
+    )
+}
+
+/// Seeds and retires the tiles around the viewer, and draws them. Independent
+/// of [`super::TerrainRenderPlugin`]; either can be added alone.
+pub struct DetailRenderPlugin;
+
+/// The stages a host orders its own detail work against.
+#[derive(SystemSet, Clone, Copy, Debug, PartialEq, Eq, Hash)]
+pub enum DetailSystems {
+    /// Reseeding the tiles a dirty mark names and the ones the viewer has
+    /// walked into. A host that writes [`TerrainDetailSource`] runs before this.
+    Rebuild,
+}
+
+impl Plugin for DetailRenderPlugin {
+    fn build(&self, app: &mut App) {
+        embedded_asset!(app, "shaders/detail.wgsl");
+        super::scatter::add_asset_plugin(app);
+        if !app.world().contains_resource::<Assets<Mesh>>() {
+            app.init_asset::<Mesh>();
+        }
+        app.init_resource::<DetailSettings>()
+            .init_resource::<DetailPressers>()
+            .init_resource::<DetailLooks>()
+            .init_resource::<DetailMeshes>()
+            .add_plugins((
+                ExtractComponentPlugin::<DetailTile>::extract_visible(),
+                ExtractResourcePlugin::<DetailLooks>::default(),
+            ))
+            .add_systems(Startup, init_detail_assets)
+            .add_systems(
+                Update,
+                (
+                    request_detail_assets.before(ScatterSystems::Resolve),
+                    (
+                        build_detail_meshes,
+                        collect_detail_pressers,
+                        rebuild_detail_tiles,
+                        build_detail_looks,
+                    )
+                        .chain()
+                        .after(ScatterSystems::Resolve),
+                )
+                    .in_set(DetailSystems::Rebuild)
+                    .run_if(resource_exists::<DetailAssets>),
+            );
+
+        let Some(render_app) = app.get_sub_app_mut(RenderApp) else {
+            return;
+        };
+        render_app
+            .init_resource::<SpecializedMeshPipelines<DetailPipeline>>()
+            .init_resource::<DetailBindGroups>()
+            .init_resource::<QueuedDetailTiles>()
+            .add_render_command::<Opaque3d, DrawDetail>()
+            .add_systems(
+                RenderStartup,
+                init_detail_pipeline.after(MeshPipelineSystems),
+            )
+            .add_systems(
+                Render,
+                (
+                    prepare_detail_buffers.in_set(RenderSystems::PrepareResources),
+                    prepare_detail_bind_groups.in_set(RenderSystems::PrepareBindGroups),
+                    queue_detail_tiles.in_set(RenderSystems::QueueMeshes),
+                ),
+            );
+    }
+}
+
+/// Build the card meshes and the shared textures once, for every layer to use.
+fn init_detail_assets(
+    mut commands: Commands,
+    mut meshes: ResMut<Assets<Mesh>>,
+    mut images: ResMut<Assets<Image>>,
+) {
+    commands.insert_resource(DetailAssets {
+        near_card: meshes.add(card_mesh(NEAR_SEGMENTS)),
+        far_card: meshes.add(card_mesh(FAR_SEGMENTS)),
+        wind_noise: images.add(wind_noise_image()),
+        white: images.add(white_image()),
+    });
+}
+
+/// Start loading the glTF every asset-backed layer names.
+fn request_detail_assets(
+    mut assets: ResMut<ScatterAssets>,
+    server: Res<AssetServer>,
+    terrains: Query<&TerrainDetailSource, Changed<TerrainDetailSource>>,
+) {
+    for source in &terrains {
+        for entry in &source.source().layers {
+            if let DetailMesh::Asset(path) = &entry.layer.mesh {
+                assets.request(&server, path);
+            }
+        }
+    }
+}
+
+/// Merge the primitives of every asset-backed layer whose glTF has resolved.
+fn build_detail_meshes(
+    mut built: ResMut<DetailMeshes>,
+    scatter: Res<ScatterAssets>,
+    mut meshes: ResMut<Assets<Mesh>>,
+    materials: Res<Assets<StandardMaterial>>,
+    terrains: Query<&TerrainDetailSource>,
+) {
+    let mut wanted: Vec<&String> = Vec::new();
+    for source in &terrains {
+        for entry in &source.source().layers {
+            if let DetailMesh::Asset(path) = &entry.layer.mesh
+                && !built.0.contains_key(path)
+                && !wanted.contains(&path)
+            {
+                wanted.push(path);
+            }
+        }
+    }
+    for path in wanted {
+        let Some(primitives) = scatter.primitives(path) else {
+            continue;
+        };
+        let Some((merged, color)) = merge_primitives(path, primitives, &meshes, &materials) else {
+            continue;
+        };
+        let mesh = meshes.add(merged);
+        built
+            .0
+            .insert(path.clone(), BuiltDetailMesh { mesh, color });
+    }
+}
+
+/// Every primitive of a flattened glTF as one mesh, with the base colour
+/// texture the first textured primitive carries. `None` while any is loading.
+fn merge_primitives(
+    asset: &str,
+    primitives: &[ScatterPrimitive],
+    meshes: &Assets<Mesh>,
+    materials: &Assets<StandardMaterial>,
+) -> Option<(Mesh, Option<Handle<Image>>)> {
+    let mut positions: Vec<[f32; 3]> = Vec::new();
+    let mut normals: Vec<[f32; 3]> = Vec::new();
+    let mut uvs: Vec<[f32; 2]> = Vec::new();
+    let mut indices: Vec<u32> = Vec::new();
+    let mut color = None;
+    let mut textures: Vec<Option<Handle<Image>>> = Vec::new();
+
+    for primitive in primitives {
+        if primitive.material.path().is_some() {
+            let material = materials.get(&primitive.material)?;
+            let texture = material.base_color_texture.clone();
+            color = color.or_else(|| texture.clone());
+            if !textures.contains(&texture) {
+                textures.push(texture);
+            }
+        }
+        let mesh = meshes.get(&primitive.mesh)?;
+        let Some(source) = mesh
+            .attribute(Mesh::ATTRIBUTE_POSITION)
+            .and_then(|values| values.as_float3())
+        else {
+            continue;
+        };
+        let affine = primitive.local.compute_affine();
+        // A normal survives a non-uniform scale through the inverse transpose.
+        let normal_matrix = affine.matrix3.inverse().transpose();
+        let base = positions.len() as u32;
+
+        let source_normals = mesh
+            .attribute(Mesh::ATTRIBUTE_NORMAL)
+            .and_then(|values| values.as_float3());
+        let source_uvs = match mesh.attribute(Mesh::ATTRIBUTE_UV_0) {
+            Some(bevy::mesh::VertexAttributeValues::Float32x2(values)) => Some(values.as_slice()),
+            _ => None,
+        };
+        for (vertex, point) in source.iter().enumerate() {
+            positions.push(affine.transform_point3(Vec3::from(*point)).to_array());
+            let normal = source_normals
+                .and_then(|values| values.get(vertex))
+                .map(|normal| normal_matrix.mul_vec3(Vec3::from(*normal)))
+                .unwrap_or(Vec3::Y);
+            normals.push(normal.normalize_or(Vec3::Y).to_array());
+            uvs.push(
+                source_uvs
+                    .and_then(|values| values.get(vertex))
+                    .copied()
+                    .unwrap_or([0.0, 0.0]),
+            );
+        }
+
+        match mesh.indices() {
+            Some(read) => indices.extend(read.iter().map(|index| base + index as u32)),
+            None => indices.extend(base..base + source.len() as u32),
+        }
+    }
+
+    if positions.is_empty() {
+        return None;
+    }
+    if textures.len() > 1 {
+        warn!(
+            "terrain detail: {asset} carries more than one base colour texture; \
+             the whole layer samples the first, so every part shares that look"
+        );
+    }
+    let lowest = positions
+        .iter()
+        .map(|point| point[1])
+        .fold(f32::MAX, f32::min);
+    let highest = positions
+        .iter()
+        .map(|point| point[1])
+        .fold(f32::MIN, f32::max);
+    let span = highest - lowest;
+    let fractions: Vec<f32> = positions
+        .iter()
+        .map(|point| match span > f32::EPSILON {
+            true => ((point[1] - lowest) / span).clamp(0.0, 1.0),
+            false => 0.0,
+        })
+        .collect();
+
+    let merged = Mesh::new(
+        PrimitiveTopology::TriangleList,
+        RenderAssetUsages::default(),
+    )
+    .with_inserted_attribute(Mesh::ATTRIBUTE_POSITION, positions)
+    .with_inserted_attribute(Mesh::ATTRIBUTE_NORMAL, normals)
+    .with_inserted_attribute(Mesh::ATTRIBUTE_UV_0, uvs)
+    .with_inserted_attribute(ATTRIBUTE_HEIGHT_FRACTION, fractions)
+    .with_inserted_indices(Indices::U32(indices));
+    Some((merged, color))
+}
+
+/// Cameras the field is laid out around, as both detail systems ask for them.
+type DetailViewers<'w, 's> =
+    Query<'w, 's, (Entity, &'static Camera, &'static GlobalTransform), With<Camera3d>>;
+
+/// Where the field is centred: the active 3D camera with the highest order.
+fn viewer_position(cameras: &DetailViewers<'_, '_>) -> Option<Vec3> {
+    cameras
+        .iter()
+        .filter(|(_, camera, _)| camera.is_active)
+        .max_by_key(|(entity, camera, _)| (camera.order, *entity))
+        .map(|(_, _, transform)| transform.translation())
+}
+
+/// Gather the pressers nearest the viewer.
+fn collect_detail_pressers(
+    mut pressers: ResMut<DetailPressers>,
+    viewers: DetailViewers,
+    pressing: Query<(&GlobalTransform, &DetailPresser)>,
+) {
+    let viewer = viewer_position(&viewers).unwrap_or(Vec3::ZERO);
+    let mut found: Vec<(Vec3, f32)> = pressing
+        .iter()
+        .map(|(transform, presser)| (transform.translation(), presser.radius))
+        .collect();
+    found.sort_by(|a, b| {
+        a.0.distance_squared(viewer)
+            .total_cmp(&b.0.distance_squared(viewer))
+    });
+    found.truncate(MAX_DETAIL_PRESSERS);
+    if pressers.pressers != found {
+        pressers.pressers = found;
+    }
+}
+
+/// The mesh one layer instances, or `None` while its asset is still resolving.
+fn layer_mesh(
+    assets: &DetailAssets,
+    built: &DetailMeshes,
+    layer: &DetailLayer,
+    lod: DetailLod,
+) -> Option<Handle<Mesh>> {
+    match &layer.mesh {
+        DetailMesh::Card => Some(assets.card(lod)),
+        DetailMesh::Asset(path) => built.get(path).map(|built| built.mesh.clone()),
+    }
+}
+
+/// Reseed the tiles around the viewer, layer by layer. Retiring is unbudgeted;
+/// seeding is capped at [`DETAIL_TILE_BUDGET`] a frame.
+fn rebuild_detail_tiles(
+    mut commands: Commands,
+    assets: Res<DetailAssets>,
+    built: Res<DetailMeshes>,
+    settings: Res<DetailSettings>,
+    viewers: DetailViewers,
+    mut terrains: Query<(
+        Entity,
+        &TerrainDetailSource,
+        &GlobalTransform,
+        &mut DetailDirty,
+    )>,
+    tiles: Query<(Entity, &DetailTile)>,
+) {
+    // A tile is a root entity, not a child of its terrain, so it is retired
+    // here rather than with the terrain.
+    for (tile_entity, tile) in &tiles {
+        let layers = terrains
+            .get(tile.terrain)
+            .map(|(_, source, _, _)| source.source().layers.len())
+            .unwrap_or(0);
+        if tile.layer >= layers {
+            commands.entity(tile_entity).despawn();
+        }
+    }
+
+    let Some(viewer) = viewer_position(&viewers) else {
+        return;
+    };
+
+    for (entity, source, placed, mut dirty) in &mut terrains {
+        let cell_size = source.cell_size();
+        if cell_size <= 0.0 || !cell_size.is_finite() {
+            continue;
+        }
+        let world_from_local = placed.affine();
+        let local = world_from_local.inverse().transform_point3(viewer);
+        let grid = &source.source().grid;
+        let viewer_cell = ((Vec2::new(local.x, local.z) - grid.origin) / cell_size)
+            .round()
+            .as_ivec2();
+        let stale = std::mem::take(&mut dirty.rect);
+        let mut spent = 0;
+
+        for (index, entry) in source.source().layers.iter().enumerate() {
+            let cull_cells = entry.layer.cull_distance * settings.cull_scale / cell_size;
+            let wanted = detail_tiles_around(viewer_cell, cull_cells, DETAIL_TILE_CELLS);
+
+            let mut standing = HashSet::new();
+            for (tile_entity, tile) in &tiles {
+                if tile.terrain != entity || tile.layer != index {
+                    continue;
+                }
+                // Asked with the level the tile already carries, which applies
+                // the hysteresis.
+                let level = detail_lod_at(
+                    tile_centre_distance(viewer_cell, tile.tile, DETAIL_TILE_CELLS),
+                    cull_cells,
+                    Some(tile.lod),
+                );
+                let retired = !wanted.iter().any(|(coord, _)| *coord == tile.tile)
+                    || level != tile.lod
+                    || stale.is_some_and(|rect| touches(rect, tile.tile));
+                if retired {
+                    commands.entity(tile_entity).despawn();
+                } else {
+                    standing.insert(tile.tile);
+                }
+            }
+
+            for (coord, lod) in wanted {
+                if spent >= DETAIL_TILE_BUDGET {
+                    break;
+                }
+                if standing.contains(&coord) {
+                    continue;
+                }
+                // A layer whose asset is still loading draws nothing.
+                let Some(mesh) = layer_mesh(&assets, &built, &entry.layer, lod) else {
+                    break;
+                };
+                spent += 1;
+                let instances = seed_tile(source, &settings, index, coord, lod, world_from_local);
+                // Bare ground is still a tile; extraction drops one with no
+                // instances.
+                let bounds = match instances.is_empty() {
+                    true => footprint(source, coord, world_from_local),
+                    false => tile_bounds(&instances, &entry.layer),
+                };
+                // Tagged out of the navmesh here: a tile carries a mesh, and
+                // the bake reads whatever mesh a scene entity carries.
+                commands.spawn((
+                    DetailTile {
+                        terrain: entity,
+                        layer: index,
+                        tile: coord,
+                        lod,
+                        instances: Arc::new(instances),
+                        bounds,
+                    },
+                    Mesh3d(mesh),
+                    Transform::IDENTITY,
+                    Visibility::default(),
+                    bounds,
+                    NavmeshExclude,
+                ));
+            }
+        }
+    }
+}
+
+/// Whether a tile covers any of a dirty rect.
+fn touches(rect: GridRect, tile: IVec2) -> bool {
+    let min = tile * DETAIL_TILE_CELLS as i32;
+    let max = min + IVec2::splat(DETAIL_TILE_CELLS as i32);
+    let rect_max = IVec2::new((rect.x + rect.width) as i32, (rect.z + rect.height) as i32);
+    min.x < rect_max.x && max.x > rect.x as i32 && min.y < rect_max.y && max.y > rect.z as i32
+}
+
+/// Seed one tile of one layer and lift its instances into world space.
+fn seed_tile(
+    source: &TerrainDetailSource,
+    settings: &DetailSettings,
+    index: usize,
+    tile: IVec2,
+    lod: DetailLod,
+    world_from_local: Affine3A,
+) -> Vec<DetailInstance> {
+    let body = source.source();
+    let Some(entry) = body.layers.get(index) else {
+        return Vec::new();
+    };
+    let mut instances = place_detail(
+        &entry.density,
+        entry.max,
+        &body.heightmap,
+        &entry.layer,
+        index,
+        tile,
+        DETAIL_TILE_CELLS,
+        source.cell_size(),
+        settings.density_scale,
+        lod.density_scale(),
+        entry.seed,
+    );
+    if world_from_local != Affine3A::IDENTITY {
+        for instance in &mut instances {
+            instance.position = world_from_local.transform_point3(instance.position);
+        }
+    }
+    instances
+}
+
+/// The ground one tile covers, for a tile with no instances.
+fn footprint(source: &TerrainDetailSource, tile: IVec2, world_from_local: Affine3A) -> Aabb {
+    let cell_size = source.cell_size();
+    let origin = source.source().grid.origin;
+    let min = origin + tile.as_vec2() * DETAIL_TILE_CELLS as f32 * cell_size;
+    let max = min + Vec2::splat(DETAIL_TILE_CELLS as f32 * cell_size);
+    let corner = |at: Vec2| world_from_local.transform_point3(Vec3::new(at.x, 0.0, at.y));
+    Aabb::from_min_max(corner(min), corner(max))
+}
+
+/// What a tile's instances occupy, widened for wind, bend and presser lean.
+fn tile_bounds(instances: &[DetailInstance], layer: &DetailLayer) -> Aabb {
+    let mut min = Vec3::splat(f32::INFINITY);
+    let mut max = Vec3::splat(f32::NEG_INFINITY);
+    for instance in instances {
+        min = min.min(instance.position);
+        max = max.max(instance.position);
+    }
+    let tall = layer.height[0].max(layer.height[1]);
+    let lean = layer.bend + layer.wind_strength + layer.push_strength;
+    Aabb::from_min_max(
+        min - Vec3::new(lean, tall, lean),
+        max + Vec3::new(lean, tall, lean),
+    )
+}
+
+/// Collect the bindings every layer currently drawing is asking for.
+fn build_detail_looks(
+    mut looks: ResMut<DetailLooks>,
+    assets: Res<DetailAssets>,
+    built: Res<DetailMeshes>,
+    settings: Res<DetailSettings>,
+    pressers: Res<DetailPressers>,
+    terrains: Query<(Entity, &TerrainDetailSource)>,
+) {
+    looks.0.clear();
+    for (entity, source) in &terrains {
+        for (index, entry) in source.source().layers.iter().enumerate() {
+            let color = match &entry.layer.mesh {
+                DetailMesh::Card => None,
+                DetailMesh::Asset(path) => built.get(path).and_then(|built| built.color.clone()),
+            };
+            looks.0.push((
+                (entity, index),
+                DetailBindings::new(
+                    &entry.layer,
+                    &settings,
+                    &pressers,
+                    assets.wind_noise.clone(),
+                    color.unwrap_or_else(|| assets.white.clone()),
+                ),
+            ));
+        }
+    }
+}
+
+/// One tile's instances, on the GPU.
+#[derive(Component)]
+pub struct DetailInstanceBuffer {
+    buffer: RawBufferVec<DetailInstance>,
+    length: usize,
+    /// Which `Arc` this was filled from; an unchanged tile is not re-uploaded.
+    source: usize,
+}
+
+/// The bind group each layer of each terrain draws with.
+#[derive(Resource, Default)]
+pub struct DetailBindGroups(HashMap<DetailKey, BindGroup>);
+
+/// The tiles each view has in its bin. A binned phase retains what it is given.
+#[derive(Resource, Default)]
+struct QueuedDetailTiles(HashMap<bevy::render::view::RetainedViewEntity, HashSet<MainEntity>>);
+
+/// The detail pipeline: the mesh pipeline with a per-instance vertex buffer, a
+/// bind group of its own, and both stages replaced.
+#[derive(Resource)]
+pub struct DetailPipeline {
+    shader: Handle<Shader>,
+    mesh_pipeline: MeshPipeline,
+    layout: BindGroupLayoutDescriptor,
+}
+
+fn init_detail_pipeline(
+    mut commands: Commands,
+    assets: Res<AssetServer>,
+    mesh_pipeline: Res<MeshPipeline>,
+    render_device: Res<RenderDevice>,
+) {
+    commands.insert_resource(DetailPipeline {
+        shader: assets.load(SHADER_PATH),
+        mesh_pipeline: mesh_pipeline.clone(),
+        layout: DetailBindings::bind_group_layout_descriptor(&render_device),
+    });
+}
+
+/// The per-instance vertex buffer one [`DetailInstance`] is read through.
+/// Locations start past the four the mesh carries.
+pub fn detail_instance_layout() -> VertexBufferLayout {
+    VertexBufferLayout {
+        array_stride: size_of::<DetailInstance>() as u64,
+        step_mode: VertexStepMode::Instance,
+        attributes: vec![
+            VertexAttribute {
+                format: VertexFormat::Float32x3,
+                offset: 0,
+                shader_location: 4,
+            },
+            VertexAttribute {
+                format: VertexFormat::Uint32,
+                offset: VertexFormat::Float32x3.size(),
+                shader_location: 5,
+            },
+            VertexAttribute {
+                format: VertexFormat::Float32x2,
+                offset: VertexFormat::Float32x3.size() + VertexFormat::Uint32.size(),
+                shader_location: 6,
+            },
+        ],
+    }
+}
+
+/// The four attributes every detail mesh carries, at the locations the shader
+/// declares them.
+fn detail_mesh_layout(
+    layout: &MeshVertexBufferLayoutRef,
+) -> Result<VertexBufferLayout, SpecializedMeshPipelineError> {
+    Ok(layout.0.get_layout(&[
+        Mesh::ATTRIBUTE_POSITION.at_shader_location(0),
+        Mesh::ATTRIBUTE_NORMAL.at_shader_location(1),
+        Mesh::ATTRIBUTE_UV_0.at_shader_location(2),
+        ATTRIBUTE_HEIGHT_FRACTION.at_shader_location(3),
+    ])?)
+}
+
+impl SpecializedMeshPipeline for DetailPipeline {
+    type Key = MeshPipelineKey;
+
+    fn specialize(
+        &self,
+        key: Self::Key,
+        layout: &MeshVertexBufferLayoutRef,
+    ) -> Result<RenderPipelineDescriptor, SpecializedMeshPipelineError> {
+        let mut descriptor = self.mesh_pipeline.specialize(key, layout)?;
+        descriptor.vertex.shader = self.shader.clone();
+        descriptor.vertex.buffers = vec![detail_mesh_layout(layout)?, detail_instance_layout()];
+        if let Some(fragment) = descriptor.fragment.as_mut() {
+            fragment.shader = self.shader.clone();
+        }
+        descriptor.layout.push(self.layout.clone());
+        // A card is a sheet with no inside, so both of its faces draw.
+        descriptor.primitive.cull_mode = None;
+        Ok(descriptor)
+    }
+}
+
+/// Upload the instances of every tile that has been reseeded since its last
+/// upload.
+fn prepare_detail_buffers(
+    mut commands: Commands,
+    render_device: Res<RenderDevice>,
+    render_queue: Res<RenderQueue>,
+    tiles: Query<(Entity, &DetailTile, Option<&DetailInstanceBuffer>)>,
+) {
+    for (entity, tile, held) in &tiles {
+        let source = Arc::as_ptr(&tile.instances) as usize;
+        if held.is_some_and(|held| held.source == source) {
+            continue;
+        }
+        let mut buffer = RawBufferVec::new(BufferUsages::VERTEX);
+        for instance in tile.instances.iter() {
+            buffer.push(*instance);
+        }
+        buffer.write_buffer(&render_device, &render_queue);
+        commands.entity(entity).insert(DetailInstanceBuffer {
+            buffer,
+            length: tile.instances.len(),
+            source,
+        });
+    }
+}
+
+/// Build one bind group per layer of every terrain drawing detail.
+fn prepare_detail_bind_groups(
+    mut groups: ResMut<DetailBindGroups>,
+    pipeline: Res<DetailPipeline>,
+    render_device: Res<RenderDevice>,
+    pipeline_cache: Res<PipelineCache>,
+    looks: Res<DetailLooks>,
+    images: Res<RenderAssets<GpuImage>>,
+    fallback: Res<FallbackImage>,
+    buffers: Res<RenderAssets<GpuShaderBuffer>>,
+) {
+    groups.0.clear();
+    let mut param = (images, fallback, buffers);
+    for (key, bindings) in &looks.0 {
+        // A look whose textures have not reached the GPU is left out.
+        if let Ok(prepared) = bindings.as_bind_group(
+            &pipeline.layout,
+            &render_device,
+            &pipeline_cache,
+            &mut param,
+        ) {
+            groups.0.insert(*key, prepared.bind_group);
+        }
+    }
+}
+
+/// Put every tile in view into the opaque phase. An instance writes depth and
+/// discards the pixels outside its own silhouette.
+#[expect(
+    clippy::too_many_arguments,
+    reason = "the queue reads the whole render world's mesh bookkeeping"
+)]
+fn queue_detail_tiles(
+    pipeline: Res<DetailPipeline>,
+    mut pipelines: ResMut<SpecializedMeshPipelines<DetailPipeline>>,
+    pipeline_cache: Res<PipelineCache>,
+    draw_functions: Res<DrawFunctions<Opaque3d>>,
+    mut phases: ResMut<ViewBinnedRenderPhases<Opaque3d>>,
+    mut queued: ResMut<QueuedDetailTiles>,
+    view_keys: Res<bevy::pbr::ViewKeyCache>,
+    meshes: Res<RenderAssets<RenderMesh>>,
+    mesh_instances: Res<RenderMeshInstances>,
+    mesh_allocator: Res<MeshAllocator>,
+    views: Query<&ExtractedView>,
+    tiles: Query<(Entity, &MainEntity), With<DetailTile>>,
+) {
+    let draw_function = draw_functions.read().id::<DrawDetail>();
+    // A view that has gone takes its phase with it.
+    let live: HashSet<_> = views.iter().map(|view| view.retained_view_entity).collect();
+    queued.0.retain(|view, _| live.contains(view));
+
+    for view in &views {
+        let Some(phase) = phases.get_mut(&view.retained_view_entity) else {
+            continue;
+        };
+        let Some(&view_key) = view_keys.get(&view.retained_view_entity) else {
+            continue;
+        };
+
+        // The bin keeps what it is given; anything no longer a tile is
+        // removed below.
+        let held = queued.0.entry(view.retained_view_entity).or_default();
+        let mut present = HashSet::new();
+
+        for (entity, main_entity) in &tiles {
+            let Some(instance) = mesh_instances.render_mesh_queue_data(*main_entity) else {
+                continue;
+            };
+            let Some(mesh) = meshes.get(instance.mesh_asset_id()) else {
+                continue;
+            };
+            let Some(slabs) = mesh_allocator.mesh_slabs(&instance.mesh_asset_id()) else {
+                continue;
+            };
+            let key = view_key
+                | MeshPipelineKey::from_primitive_topology_and_strip_index(
+                    mesh.primitive_topology(),
+                    mesh.index_format(),
+                );
+            let Ok(pipeline_id) =
+                pipelines.specialize(&pipeline_cache, &pipeline, key, &mesh.layout)
+            else {
+                continue;
+            };
+            present.insert(*main_entity);
+            phase.add(
+                Opaque3dBatchSetKey {
+                    draw_function,
+                    pipeline: pipeline_id,
+                    material_bind_group_index: None,
+                    slabs,
+                    lightmap_slab: None,
+                },
+                Opaque3dBinKey {
+                    asset_id: instance.mesh_asset_id().into(),
+                },
+                (entity, *main_entity),
+                instance.current_uniform_index,
+                // The draw does its own instancing and ignores the batch range,
+                // so it never joins a batch or an indirect draw.
+                BinnedRenderPhaseType::NonMesh,
+            );
+        }
+
+        for gone in held.difference(&present) {
+            phase.remove(*gone);
+        }
+        *held = present;
+    }
+}
+
+/// Everything one tile of detail takes to draw.
+type DrawDetail = (
+    SetItemPipeline,
+    SetMeshViewBindGroup<0>,
+    SetMeshViewBindingArrayBindGroup<1>,
+    SetMeshBindGroup<2>,
+    SetDetailBindGroup<3>,
+    DrawDetailInstanced,
+);
+
+/// Binds the look the tile's layer declared.
+pub struct SetDetailBindGroup<const I: usize>;
+
+impl<P: PhaseItem, const I: usize> RenderCommand<P> for SetDetailBindGroup<I> {
+    type Param = SRes<DetailBindGroups>;
+    type ViewQuery = ();
+    type ItemQuery = Read<DetailTile>;
+
+    fn render<'w>(
+        _item: &P,
+        _view: (),
+        tile: Option<&'w DetailTile>,
+        groups: SystemParamItem<'w, '_, Self::Param>,
+        pass: &mut TrackedRenderPass<'w>,
+    ) -> RenderCommandResult {
+        let Some(tile) = tile else {
+            return RenderCommandResult::Skip;
+        };
+        let Some(group) = groups.into_inner().0.get(&(tile.terrain, tile.layer)) else {
+            return RenderCommandResult::Skip;
+        };
+        pass.set_bind_group(I, group, &[]);
+        RenderCommandResult::Success
+    }
+}
+
+/// Draws the layer's mesh once per instance.
+pub struct DrawDetailInstanced;
+
+impl<P: PhaseItem> RenderCommand<P> for DrawDetailInstanced {
+    type Param = (
+        SRes<RenderAssets<RenderMesh>>,
+        SRes<RenderMeshInstances>,
+        SRes<MeshAllocator>,
+    );
+    type ViewQuery = ();
+    type ItemQuery = Read<DetailInstanceBuffer>;
+
+    fn render<'w>(
+        item: &P,
+        _view: (),
+        instances: Option<&'w DetailInstanceBuffer>,
+        (meshes, mesh_instances, mesh_allocator): SystemParamItem<'w, '_, Self::Param>,
+        pass: &mut TrackedRenderPass<'w>,
+    ) -> RenderCommandResult {
+        let mesh_allocator = mesh_allocator.into_inner();
+        let Some(instances) = instances else {
+            return RenderCommandResult::Skip;
+        };
+        let Some(buffer) = instances.buffer.buffer() else {
+            return RenderCommandResult::Skip;
+        };
+        let Some(instance) = mesh_instances.render_mesh_queue_data(item.main_entity()) else {
+            return RenderCommandResult::Skip;
+        };
+        let Some(mesh) = meshes.into_inner().get(instance.mesh_asset_id()) else {
+            return RenderCommandResult::Skip;
+        };
+        let Some(vertices) = mesh_allocator.mesh_vertex_slice(&instance.mesh_asset_id()) else {
+            return RenderCommandResult::Skip;
+        };
+
+        pass.set_vertex_buffer(0, vertices.buffer.slice(..));
+        pass.set_vertex_buffer(1, buffer.slice(..));
+
+        match &mesh.buffer_info {
+            RenderMeshBufferInfo::Indexed {
+                index_format,
+                count,
+            } => {
+                let Some(index) = mesh_allocator.mesh_index_slice(&instance.mesh_asset_id()) else {
+                    return RenderCommandResult::Skip;
+                };
+                pass.set_index_buffer(index.buffer.slice(..), *index_format);
+                pass.draw_indexed(
+                    index.range.start..(index.range.start + count),
+                    vertices.range.start as i32,
+                    0..instances.length as u32,
+                );
+            }
+            RenderMeshBufferInfo::NonIndexed => {
+                pass.draw(vertices.range.clone(), 0..instances.length as u32);
+            }
+        }
+        RenderCommandResult::Success
+    }
+}
+
+/// An authored sRGB colour as the linear vector the shader multiplies by.
+fn linear_of(rgb: [f32; 3]) -> Vec4 {
+    let linear = Color::srgb(rgb[0], rgb[1], rgb[2]).to_linear();
+    Vec4::new(linear.red, linear.green, linear.blue, 1.0)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::channel::ChannelDescriptor;
+    use crate::region::{RegionSize, TerrainRegions};
+
+    /// A terrain of flat ground, `side` cells on an edge, with one fully
+    /// painted channel per name given.
+    fn document(side: u32, channels: &[&str]) -> RegionTerrainData {
+        let mut data = RegionTerrainData {
+            channels: channels
+                .iter()
+                .map(|name| ChannelDescriptor::new(*name, ChannelElement::U8))
+                .collect(),
+            regions: TerrainRegions::new(RegionSize::new(side).unwrap()),
+            ..RegionTerrainData::default()
+        };
+        data.regions.set_channel_count(channels.len());
+        for z in 0..side as i32 {
+            for x in 0..side as i32 {
+                data.regions.set_height(x, z, 0.0);
+                for channel in 0..channels.len() {
+                    data.regions.set_channel(channel, x, z, 255);
+                }
+            }
+        }
+        data
+    }
+
+    fn layer(name: &str, channel: &str) -> DetailLayer {
+        DetailLayer {
+            name: name.to_string(),
+            density_channel: channel.to_string(),
+            cull_distance: 24.0,
+            density_per_m2: 4.0,
+            ..DetailLayer::default()
+        }
+    }
+
+    fn terrain(layers: Vec<DetailLayer>) -> Terrain {
+        Terrain {
+            cell_size: 1.0,
+            detail: layers,
+            ..Terrain::default()
+        }
+    }
+
+    /// An app with everything the rebuild reads and no renderer at all.
+    fn detail_app() -> App {
+        let mut app = App::new();
+        app.add_plugins(bevy::asset::AssetPlugin::default())
+            .init_asset::<Mesh>()
+            .init_asset::<Image>()
+            .init_resource::<DetailSettings>()
+            .init_resource::<DetailPressers>()
+            .init_resource::<DetailMeshes>()
+            .add_systems(Startup, init_detail_assets)
+            .add_systems(Update, rebuild_detail_tiles);
+        app
+    }
+
+    fn spawn_terrain(app: &mut App, terrain: &Terrain, data: &RegionTerrainData) -> Entity {
+        let source =
+            TerrainDetailSource::from_document(data, terrain).expect("the terrain grows detail");
+        app.world_mut()
+            .spawn((
+                source,
+                DetailDirty::default(),
+                Transform::IDENTITY,
+                GlobalTransform::IDENTITY,
+            ))
+            .id()
+    }
+
+    fn spawn_grassy_terrain(app: &mut App) -> Entity {
+        spawn_terrain(
+            app,
+            &terrain(vec![layer("grass", "grass")]),
+            &document(64, &["grass"]),
+        )
+    }
+
+    fn spawn_viewer(app: &mut App, at: Vec3) -> Entity {
+        app.world_mut()
+            .spawn((
+                Camera3d::default(),
+                Transform::from_translation(at),
+                GlobalTransform::from_translation(at),
+            ))
+            .id()
+    }
+
+    fn tiles(app: &mut App) -> Vec<DetailTile> {
+        app.world_mut()
+            .query::<&DetailTile>()
+            .iter(app.world())
+            .cloned()
+            .collect()
+    }
+
+    /// Enough frames for the per-frame budget to fill the field.
+    fn settle(app: &mut App) {
+        for _ in 0..400 {
+            app.update();
+        }
+    }
+
+    #[test]
+    fn a_terrain_with_no_layers_has_no_source() {
+        assert!(
+            TerrainDetailSource::from_document(&document(8, &["grass"]), &Terrain::default())
+                .is_none()
+        );
+    }
+
+    #[test]
+    fn an_unpainted_density_channel_is_bare_ground() {
+        let data = document(8, &[]);
+        let source = TerrainDetailSource::from_document(&data, &terrain(vec![layer("g", "grass")]))
+            .expect("the terrain still grows detail");
+        assert!(
+            source.source().layers[0]
+                .density
+                .iter()
+                .all(|value| *value == 0)
+        );
+    }
+
+    #[test]
+    fn a_rebuild_seeds_the_tiles_inside_the_cull_distance_and_no_further() {
+        let mut app = detail_app();
+        spawn_grassy_terrain(&mut app);
+        spawn_viewer(&mut app, Vec3::new(32.0, 5.0, 32.0));
+        settle(&mut app);
+
+        let placed = tiles(&mut app);
+        assert!(!placed.is_empty(), "the field is seeded");
+        let cull = layer("grass", "grass").cull_distance;
+        for tile in &placed {
+            let min = tile.tile.as_vec2() * DETAIL_TILE_CELLS as f32;
+            let nearest = Vec2::splat(32.0).clamp(min, min + Vec2::splat(DETAIL_TILE_CELLS as f32));
+            assert!(
+                Vec2::splat(32.0).distance(nearest) <= cull + 1.0,
+                "tile {} stands inside the cull distance",
+                tile.tile
+            );
+            assert!(!tile.instances.is_empty(), "a seeded tile has instances");
+        }
+    }
+
+    #[test]
+    fn two_layers_seed_their_own_tiles_from_their_own_channels() {
+        let mut app = detail_app();
+        let mut data = document(64, &["grass", "flowers"]);
+        // The second channel covers a corner of the ground rather than all of it.
+        for z in 0..64 {
+            for x in 0..64 {
+                if x >= 32 || z >= 32 {
+                    data.regions.set_channel(1, x, z, 0);
+                }
+            }
+        }
+        spawn_terrain(
+            &mut app,
+            &terrain(vec![layer("grass", "grass"), layer("flowers", "flowers")]),
+            &data,
+        );
+        spawn_viewer(&mut app, Vec3::new(32.0, 5.0, 32.0));
+        settle(&mut app);
+
+        let placed = tiles(&mut app);
+        assert!(placed.iter().any(|tile| tile.layer == 0));
+        assert!(placed.iter().any(|tile| tile.layer == 1));
+        let grown = |layer: usize| -> usize {
+            placed
+                .iter()
+                .filter(|tile| tile.layer == layer)
+                .map(|tile| tile.instances.len())
+                .sum()
+        };
+        assert!(
+            grown(1) > 0 && grown(1) < grown(0),
+            "the second layer grows only where its own channel is painted: \
+             {} against {}",
+            grown(1),
+            grown(0)
+        );
+    }
+
+    #[test]
+    fn removing_a_layer_retires_its_tiles() {
+        let mut app = detail_app();
+        let data = document(64, &["grass", "flowers"]);
+        let entity = spawn_terrain(
+            &mut app,
+            &terrain(vec![layer("grass", "grass"), layer("flowers", "flowers")]),
+            &data,
+        );
+        spawn_viewer(&mut app, Vec3::new(32.0, 5.0, 32.0));
+        settle(&mut app);
+        assert!(tiles(&mut app).iter().any(|tile| tile.layer == 1));
+
+        let trimmed =
+            TerrainDetailSource::from_document(&data, &terrain(vec![layer("grass", "grass")]))
+                .expect("the terrain still grows detail");
+        app.world_mut().entity_mut(entity).insert(trimmed);
+        app.update();
+
+        let placed = tiles(&mut app);
+        assert!(!placed.is_empty(), "the layer that stayed still draws");
+        assert!(
+            placed.iter().all(|tile| tile.layer == 0),
+            "no tile outlives the layer it grew from"
+        );
+    }
+
+    #[test]
+    fn an_asset_layer_draws_nothing_until_its_mesh_has_resolved() {
+        let mut app = detail_app();
+        let mut grown = layer("ferns", "grass");
+        grown.mesh = DetailMesh::Asset("models/fern.gltf".to_string());
+        spawn_terrain(&mut app, &terrain(vec![grown]), &document(64, &["grass"]));
+        spawn_viewer(&mut app, Vec3::new(32.0, 5.0, 32.0));
+        settle(&mut app);
+        assert!(
+            tiles(&mut app).is_empty(),
+            "a layer whose asset has not loaded draws nothing"
+        );
+
+        let mesh = app
+            .world_mut()
+            .resource_mut::<Assets<Mesh>>()
+            .add(card_mesh(1));
+        app.world_mut().resource_mut::<DetailMeshes>().0.insert(
+            "models/fern.gltf".to_string(),
+            BuiltDetailMesh { mesh, color: None },
+        );
+        settle(&mut app);
+        assert!(
+            !tiles(&mut app).is_empty(),
+            "and draws once the asset has resolved"
+        );
+    }
+
+    #[test]
+    fn an_asset_layer_merges_the_scatter_primitives_into_one_mesh() {
+        let mut meshes = Assets::<Mesh>::default();
+        let materials = Assets::<StandardMaterial>::default();
+        let mut part = |offset: f32| {
+            let mesh = Mesh::new(
+                PrimitiveTopology::TriangleList,
+                RenderAssetUsages::default(),
+            )
+            .with_inserted_attribute(
+                Mesh::ATTRIBUTE_POSITION,
+                vec![[0.0, 0.0, 0.0], [1.0, 0.0, 0.0], [0.0, 1.0, 0.0]],
+            )
+            .with_inserted_attribute(Mesh::ATTRIBUTE_NORMAL, vec![[0.0, 0.0, 1.0]; 3])
+            .with_inserted_indices(Indices::U32(vec![0, 1, 2]));
+            ScatterPrimitive {
+                mesh: meshes.add(mesh),
+                material: Handle::default(),
+                local: Transform::from_xyz(0.0, offset, 0.0),
+            }
+        };
+        let primitives = vec![part(0.0), part(1.0)];
+
+        let (merged, color) =
+            merge_primitives("models/fern.gltf", &primitives, &meshes, &materials)
+                .expect("both parts are loaded");
+        assert!(color.is_none(), "neither part carries a material");
+        assert_eq!(merged.count_vertices(), 6);
+        assert_eq!(
+            merged.indices().expect("the merge is indexed").len(),
+            6,
+            "both parts keep their own triangle"
+        );
+        let uvs = merged
+            .attribute(Mesh::ATTRIBUTE_UV_0)
+            .expect("the merge carries a uv set");
+        assert_eq!(uvs.len(), 6, "a part with no uvs still gets one per vertex");
+
+        let Some(bevy::mesh::VertexAttributeValues::Float32(fractions)) =
+            merged.attribute(ATTRIBUTE_HEIGHT_FRACTION)
+        else {
+            panic!("the merge carries a height fraction per vertex");
+        };
+        // The parts stack two units tall, so the lower part's tip is halfway up.
+        assert_eq!(fractions[0], 0.0);
+        assert_eq!(fractions[2], 0.5);
+        assert_eq!(fractions[5], 1.0);
+    }
+
+    #[test]
+    fn a_merged_asset_fills_in_the_attributes_a_primitive_left_out() {
+        let mut meshes = Assets::<Mesh>::default();
+        let materials = Assets::<StandardMaterial>::default();
+        let bare = Mesh::new(
+            PrimitiveTopology::TriangleList,
+            RenderAssetUsages::default(),
+        )
+        .with_inserted_attribute(
+            Mesh::ATTRIBUTE_POSITION,
+            vec![[0.0, 0.0, 0.0], [1.0, 0.0, 0.0], [0.0, 1.0, 0.0]],
+        )
+        .with_inserted_indices(Indices::U16(vec![0, 1, 2]));
+        let primitives = vec![ScatterPrimitive {
+            mesh: meshes.add(bare),
+            material: Handle::default(),
+            local: Transform::from_scale(Vec3::new(3.0, 1.0, 1.0)),
+        }];
+
+        let (merged, color) =
+            merge_primitives("models/bare.gltf", &primitives, &meshes, &materials)
+                .expect("the one part is loaded");
+        assert!(color.is_none());
+        assert_eq!(merged.attributes().count(), 4);
+        assert_eq!(
+            merged.indices().expect("a u16 source still merges indexed"),
+            &Indices::U32(vec![0, 1, 2])
+        );
+
+        let positions = merged
+            .attribute(Mesh::ATTRIBUTE_POSITION)
+            .expect("the merge carries positions")
+            .as_float3()
+            .expect("positions are three floats");
+        assert_eq!(
+            positions[1],
+            [3.0, 0.0, 0.0],
+            "the placement scale is folded in"
+        );
+
+        let normals = merged
+            .attribute(Mesh::ATTRIBUTE_NORMAL)
+            .expect("the merge carries normals")
+            .as_float3()
+            .expect("normals are three floats");
+        assert!(
+            normals.iter().all(|normal| *normal == [0.0, 1.0, 0.0]),
+            "a part with no normals stands its own up"
+        );
+
+        let Some(bevy::mesh::VertexAttributeValues::Float32x2(uvs)) =
+            merged.attribute(Mesh::ATTRIBUTE_UV_0)
+        else {
+            panic!("the merge carries a uv per vertex");
+        };
+        assert!(uvs.iter().all(|uv| *uv == [0.0, 0.0]));
+    }
+
+    #[test]
+    fn a_merged_normal_survives_a_non_uniform_scale() {
+        let mut meshes = Assets::<Mesh>::default();
+        let materials = Assets::<StandardMaterial>::default();
+        let diagonal = Vec3::new(1.0, 1.0, 0.0).normalize().to_array();
+        let leaning = Mesh::new(
+            PrimitiveTopology::TriangleList,
+            RenderAssetUsages::default(),
+        )
+        .with_inserted_attribute(
+            Mesh::ATTRIBUTE_POSITION,
+            vec![[0.0, 0.0, 0.0], [1.0, 0.0, 0.0], [0.0, 1.0, 0.0]],
+        )
+        .with_inserted_attribute(Mesh::ATTRIBUTE_NORMAL, vec![diagonal; 3])
+        .with_inserted_indices(Indices::U32(vec![0, 1, 2]));
+        // Stretched fourfold up: the surface flattens, so its normal turns
+        // toward straight up under the matrix and away from it under the
+        // inverse transpose.
+        let primitives = vec![ScatterPrimitive {
+            mesh: meshes.add(leaning),
+            material: Handle::default(),
+            local: Transform::from_scale(Vec3::new(1.0, 4.0, 1.0)),
+        }];
+
+        let (merged, _) = merge_primitives("models/leaning.gltf", &primitives, &meshes, &materials)
+            .expect("the one part is loaded");
+        let normals = merged
+            .attribute(Mesh::ATTRIBUTE_NORMAL)
+            .expect("the merge carries normals")
+            .as_float3()
+            .expect("normals are three floats");
+        let normal = Vec3::from(normals[0]);
+        assert!((normal.length() - 1.0).abs() < 1e-5);
+        assert!(
+            normal.x > normal.y,
+            "the scale shortens the normal's y rather than lengthening it, but it is {normal}"
+        );
+    }
+
+    #[test]
+    fn a_flat_asset_gives_every_vertex_the_same_height_fraction() {
+        let mut meshes = Assets::<Mesh>::default();
+        let materials = Assets::<StandardMaterial>::default();
+        let flat = Mesh::new(
+            PrimitiveTopology::TriangleList,
+            RenderAssetUsages::default(),
+        )
+        .with_inserted_attribute(
+            Mesh::ATTRIBUTE_POSITION,
+            vec![[0.0, 0.0, 0.0], [1.0, 0.0, 0.0], [0.0, 0.0, 1.0]],
+        )
+        .with_inserted_indices(Indices::U32(vec![0, 1, 2]));
+        let primitives = vec![ScatterPrimitive {
+            mesh: meshes.add(flat),
+            material: Handle::default(),
+            local: Transform::IDENTITY,
+        }];
+
+        let (merged, _) = merge_primitives("models/flat.gltf", &primitives, &meshes, &materials)
+            .expect("the one part is loaded");
+        let Some(bevy::mesh::VertexAttributeValues::Float32(fractions)) =
+            merged.attribute(ATTRIBUTE_HEIGHT_FRACTION)
+        else {
+            panic!("the merge carries a height fraction per vertex");
+        };
+        assert_eq!(
+            fractions,
+            &vec![0.0; 3],
+            "an asset with no height stands flat"
+        );
+    }
+
+    #[test]
+    fn two_layers_over_one_channel_stand_their_instances_apart() {
+        let mut app = detail_app();
+        spawn_terrain(
+            &mut app,
+            &terrain(vec![layer("near", "grass"), layer("far", "grass")]),
+            &document(64, &["grass"]),
+        );
+        spawn_viewer(&mut app, Vec3::new(32.0, 5.0, 32.0));
+        settle(&mut app);
+
+        let placed = tiles(&mut app);
+        let of = |index: usize, at: IVec2| {
+            placed
+                .iter()
+                .find(|tile| tile.layer == index && tile.tile == at)
+                .map(|tile| tile.instances.clone())
+        };
+        let at = placed
+            .iter()
+            .find(|tile| tile.layer == 0 && !tile.instances.is_empty())
+            .expect("the first layer grew somewhere")
+            .tile;
+        assert_ne!(
+            of(0, at),
+            of(1, at),
+            "two layers sharing a channel cover the same ground without standing in one another"
+        );
+    }
+
+    #[test]
+    fn a_rebuild_clears_the_dirty_mark_it_caught_up_with() {
+        let mut app = detail_app();
+        let terrain_entity = spawn_grassy_terrain(&mut app);
+        spawn_viewer(&mut app, Vec3::new(32.0, 5.0, 32.0));
+        settle(&mut app);
+        let before = tiles(&mut app).len();
+
+        app.world_mut()
+            .get_mut::<DetailDirty>(terrain_entity)
+            .expect("the terrain is marked")
+            .touch(GridRect::whole(64));
+        app.update();
+
+        assert!(
+            app.world()
+                .get::<DetailDirty>(terrain_entity)
+                .expect("the terrain is marked")
+                .rect
+                .is_none(),
+            "the mark is cleared once the tiles it named are retired"
+        );
+        assert!(
+            tiles(&mut app).len() < before,
+            "the marked tiles were retired"
+        );
+        settle(&mut app);
+        assert_eq!(tiles(&mut app).len(), before, "and then seeded again");
+    }
+
+    #[test]
+    fn walking_away_retires_the_tiles_left_behind() {
+        let mut app = detail_app();
+        spawn_grassy_terrain(&mut app);
+        let viewer = spawn_viewer(&mut app, Vec3::new(16.0, 5.0, 16.0));
+        settle(&mut app);
+        let near_first = tiles(&mut app);
+        assert!(!near_first.is_empty());
+
+        let moved = Vec3::new(56.0, 5.0, 56.0);
+        *app.world_mut()
+            .get_mut::<GlobalTransform>(viewer)
+            .expect("the viewer has a transform") = GlobalTransform::from_translation(moved);
+        settle(&mut app);
+
+        let after = tiles(&mut app);
+        assert!(!after.is_empty());
+        let kept: Vec<IVec2> = after.iter().map(|tile| tile.tile).collect();
+        assert!(
+            near_first.iter().any(|tile| !kept.contains(&tile.tile)),
+            "a tile the viewer walked away from was retired"
+        );
+        for tile in &after {
+            let min = tile.tile.as_vec2() * DETAIL_TILE_CELLS as f32;
+            let nearest = Vec2::new(56.0, 56.0).clamp(min, min + Vec2::splat(16.0));
+            assert!(Vec2::new(56.0, 56.0).distance(nearest) <= 25.0);
+        }
+    }
+
+    #[test]
+    fn bare_ground_is_tiled_once_rather_than_reseeded_every_frame() {
+        let mut app = detail_app();
+        let mut data = document(64, &["grass"]);
+        for z in 0..64 {
+            for x in 0..64 {
+                data.regions.set_channel(0, x, z, 0);
+            }
+        }
+        spawn_terrain(&mut app, &terrain(vec![layer("grass", "grass")]), &data);
+        spawn_viewer(&mut app, Vec3::new(32.0, 5.0, 32.0));
+        settle(&mut app);
+
+        let placed = tiles(&mut app);
+        assert!(!placed.is_empty(), "the bare ground is tiled");
+        assert!(
+            placed.iter().all(|tile| tile.instances.is_empty()),
+            "and every tile of it draws nothing"
+        );
+        let settled = placed.len();
+        app.update();
+        assert_eq!(
+            tiles(&mut app).len(),
+            settled,
+            "a settled field seeds nothing further"
+        );
+    }
+
+    #[test]
+    fn a_terrain_that_stops_growing_detail_retires_its_tiles() {
+        let mut app = detail_app();
+        let terrain_entity = spawn_grassy_terrain(&mut app);
+        spawn_viewer(&mut app, Vec3::new(32.0, 5.0, 32.0));
+        settle(&mut app);
+        assert!(!tiles(&mut app).is_empty());
+
+        app.world_mut()
+            .entity_mut(terrain_entity)
+            .remove::<TerrainDetailSource>();
+        app.update();
+        assert!(
+            tiles(&mut app).is_empty(),
+            "no tile outlives the terrain it grew from"
+        );
+    }
+
+    #[test]
+    fn a_card_stands_one_unit_tall_from_its_foot() {
+        for segments in [1, 3] {
+            let mesh = card_mesh(segments);
+            let positions = mesh
+                .attribute(Mesh::ATTRIBUTE_POSITION)
+                .expect("the card has positions")
+                .as_float3()
+                .expect("positions are three floats");
+            assert_eq!(positions.len() as u32, (segments + 1) * 2);
+            let lowest = positions.iter().map(|p| p[1]).fold(f32::MAX, f32::min);
+            let highest = positions.iter().map(|p| p[1]).fold(f32::MIN, f32::max);
+            assert_eq!(lowest, 0.0);
+            assert_eq!(highest, 1.0);
+            assert_eq!(
+                mesh.indices().expect("the card is indexed").len(),
+                segments as usize * 6
+            );
+            let Some(bevy::mesh::VertexAttributeValues::Float32(fractions)) =
+                mesh.attribute(ATTRIBUTE_HEIGHT_FRACTION)
+            else {
+                panic!("the card carries a height fraction per vertex");
+            };
+            assert_eq!(fractions.first().copied(), Some(0.0));
+            assert_eq!(fractions.last().copied(), Some(1.0));
+        }
+    }
+
+    #[test]
+    fn the_wind_texture_is_a_repeating_single_channel_field() {
+        let image = wind_noise_image();
+        assert_eq!(image.texture_descriptor.format, TextureFormat::R8Unorm);
+        assert_eq!(image.texture_descriptor.size.width, WIND_TEXTURE_SIZE);
+        assert_eq!(image.texture_descriptor.size.height, WIND_TEXTURE_SIZE);
+        let ImageSampler::Descriptor(sampler) = &image.sampler else {
+            panic!("the wind texture carries a sampler of its own");
+        };
+        assert_eq!(sampler.address_mode_u, ImageAddressMode::Repeat);
+        assert_eq!(sampler.address_mode_v, ImageAddressMode::Repeat);
+
+        let data = image.data.as_ref().expect("the texture has texels");
+        assert_eq!(data.len(), (WIND_TEXTURE_SIZE * WIND_TEXTURE_SIZE) as usize);
+        assert!(
+            data.iter().any(|texel| *texel != data[0]),
+            "the field varies rather than being flat"
+        );
+    }
+
+    #[test]
+    fn a_layer_with_no_texture_multiplies_by_one_white_texel() {
+        let image = white_image();
+        assert_eq!(image.texture_descriptor.size.width, 1);
+        assert_eq!(image.texture_descriptor.size.height, 1);
+        assert_eq!(
+            image.data.as_ref().expect("the texture has texels"),
+            &[255, 255, 255, 255]
+        );
+    }
+
+    #[test]
+    fn two_edits_before_a_rebuild_cover_both() {
+        let mut dirty = DetailDirty::default();
+        dirty.touch(GridRect {
+            x: 0,
+            z: 0,
+            width: 4,
+            height: 4,
+        });
+        dirty.touch(GridRect {
+            x: 20,
+            z: 20,
+            width: 4,
+            height: 4,
+        });
+        let rect = dirty.rect.expect("both edits are marked");
+        assert_eq!(rect.x, 0);
+        assert_eq!(rect.z, 0);
+        assert_eq!(rect.width, 24);
+        assert_eq!(rect.height, 24);
+    }
+
+    /// The shader source, for the binding checks below. naga-oil input rather
+    /// than plain WGSL, so the checks are textual.
+    const SHADER_SOURCE: &str = include_str!("shaders/detail.wgsl");
+
+    #[test]
+    fn every_detail_binding_is_declared_in_the_shader_at_its_derive_index() {
+        for (binding, declaration) in [
+            (0, "var<uniform> detail: DetailUniform"),
+            (1, "var wind_noise: texture_2d<f32>"),
+            (2, "var wind_sampler: sampler"),
+            (3, "var color_texture: texture_2d<f32>"),
+            (4, "var color_sampler: sampler"),
+        ] {
+            let expected = format!("@group(3) @binding({binding}) {declaration};");
+            assert!(
+                SHADER_SOURCE.contains(&expected),
+                "the AsBindGroup derive binds {binding} as `{declaration}`, \
+                 but the shader does not declare it that way"
+            );
+        }
+    }
+
+    #[test]
+    fn the_detail_uniform_struct_matches_the_bindings_field_order() {
+        let declared: Vec<String> = shader_uniform_members()
+            .into_iter()
+            .map(|(name, _)| name)
+            .collect();
+        assert_eq!(
+            declared,
+            [
+                "color_base",
+                "color_tip",
+                "wind_direction",
+                "wind_speed",
+                "wind_strength",
+                "wind_vertical_strength",
+                "wind_tile_size",
+                "bend",
+                "push_strength",
+                "height_range",
+                "width_range",
+                "cull_distance",
+                "presser_count",
+                "is_card",
+                "pressers",
+            ]
+        );
+    }
+
+    /// The bytes the shader reads are the bytes the derive writes. `Mirror`
+    /// repeats the `#[uniform(0)]` field types in declaration order.
+    #[test]
+    fn the_detail_uniform_lays_out_the_same_bytes_the_shader_reads() {
+        use bevy::render::render_resource::ShaderType;
+
+        #[derive(ShaderType)]
+        struct Mirror {
+            color_base: Vec4,
+            color_tip: Vec4,
+            wind_direction: Vec2,
+            wind_speed: f32,
+            wind_strength: f32,
+            wind_vertical_strength: f32,
+            wind_tile_size: f32,
+            bend: f32,
+            push_strength: f32,
+            height_range: Vec2,
+            width_range: Vec2,
+            cull_distance: f32,
+            presser_count: u32,
+            is_card: u32,
+            pressers: [Vec4; MAX_DETAIL_PRESSERS],
+        }
+
+        let mut offset = 0u64;
+        let mut declared = Vec::new();
+        for (name, ty) in shader_uniform_members() {
+            let (size, align) = match ty.as_str() {
+                "f32" | "u32" => (4, 4),
+                "vec2<f32>" => (8, 8),
+                "vec4<f32>" => (16, 16),
+                "array<vec4<f32>, 16>" => (16 * MAX_DETAIL_PRESSERS as u64, 16),
+                other => panic!("no layout rule for `{other}`"),
+            };
+            offset = offset.next_multiple_of(align);
+            declared.push((name, offset));
+            offset += size;
+        }
+        let size = offset.next_multiple_of(16);
+
+        assert_eq!(
+            declared,
+            vec![
+                ("color_base".to_string(), 0),
+                ("color_tip".to_string(), 16),
+                ("wind_direction".to_string(), 32),
+                ("wind_speed".to_string(), 40),
+                ("wind_strength".to_string(), 44),
+                ("wind_vertical_strength".to_string(), 48),
+                ("wind_tile_size".to_string(), 52),
+                ("bend".to_string(), 56),
+                ("push_strength".to_string(), 60),
+                ("height_range".to_string(), 64),
+                ("width_range".to_string(), 72),
+                ("cull_distance".to_string(), 80),
+                ("presser_count".to_string(), 84),
+                ("is_card".to_string(), 88),
+                ("pressers".to_string(), 96),
+            ]
+        );
+        assert_eq!(size, Mirror::min_size().get());
+    }
+
+    /// The name and type of each member of the shader's uniform struct.
+    fn shader_uniform_members() -> Vec<(String, String)> {
+        let start = SHADER_SOURCE
+            .find("struct DetailUniform {")
+            .expect("DetailUniform is declared");
+        let body = &SHADER_SOURCE[start..];
+        let body = &body[..body.find('}').expect("DetailUniform is closed")];
+        body.lines()
+            .skip(1)
+            .filter_map(|line| line.trim().strip_suffix(','))
+            .filter(|line| !line.starts_with("//"))
+            .map(|line| {
+                let (name, ty) = line.split_once(':').expect("a member is `name: type`");
+                (name.trim().to_string(), ty.trim().to_string())
+            })
+            .collect()
+    }
+
+    #[test]
+    fn the_instance_and_the_mesh_take_separate_attribute_slots() {
+        let layout = detail_instance_layout();
+        assert_eq!(layout.step_mode, VertexStepMode::Instance);
+        assert_eq!(layout.array_stride, size_of::<DetailInstance>() as u64);
+
+        let mut locations: Vec<u32> = layout
+            .attributes
+            .iter()
+            .map(|attribute| attribute.shader_location)
+            .collect();
+        locations.sort_unstable();
+        locations.dedup();
+        assert_eq!(
+            locations.len(),
+            layout.attributes.len(),
+            "no slot is reused"
+        );
+
+        // The mesh takes the first four slots, one per attribute the card and
+        // every merged asset carry.
+        let card = card_mesh(NEAR_SEGMENTS);
+        for attribute in [
+            Mesh::ATTRIBUTE_POSITION.id,
+            Mesh::ATTRIBUTE_NORMAL.id,
+            Mesh::ATTRIBUTE_UV_0.id,
+            ATTRIBUTE_HEIGHT_FRACTION.id,
+        ] {
+            assert!(card.attribute(attribute).is_some());
+        }
+        assert_eq!(card.attributes().count(), 4);
+        for location in &locations {
+            assert!(*location >= 4, "slot {location} is already the mesh's");
+        }
+    }
+
+    #[test]
+    fn the_shader_reads_the_same_presser_count_the_bindings_write() {
+        assert!(SHADER_SOURCE.contains(&format!(
+            "const MAX_PRESSERS: u32 = {MAX_DETAIL_PRESSERS}u;"
+        )));
+        assert!(SHADER_SOURCE.contains(&format!(
+            "pressers: array<vec4<f32>, {MAX_DETAIL_PRESSERS}>,"
+        )));
+    }
+}

--- a/crates/jackdaw_terrain/src/render/mod.rs
+++ b/crates/jackdaw_terrain/src/render/mod.rs
@@ -23,12 +23,20 @@ use bevy::render::render_resource::{
 use bevy::shader::ShaderRef;
 use path_slash::PathExt as _;
 
+pub mod detail;
 pub mod scatter;
 
+pub use detail::{
+    ATTRIBUTE_HEIGHT_FRACTION, BuiltDetailMesh, DETAIL_TILE_BUDGET, DETAIL_TILE_CELLS,
+    DetailAssets, DetailBindings, DetailDirty, DetailInstanceBuffer, DetailKey, DetailLayerSource,
+    DetailLooks, DetailMeshes, DetailPipeline, DetailPressers, DetailRenderPlugin, DetailSettings,
+    DetailSource, DetailSystems, DetailTile, MAX_DETAIL_PRESSERS, TerrainDetailSource, card_mesh,
+    detail_instance_layout, white_image, wind_noise_image,
+};
 pub use scatter::{
-    GROUND_COVER_CULL_DISTANCE, GROUND_COVER_HEIGHT, ScatterAssets, ScatterChunk, ScatterDirty,
-    ScatterPrimitive, ScatterRegion, ScatterRenderPlugin, ScatterRendered, ScatterSystems,
-    TerrainScatter,
+    GROUND_COVER_CULL_DISTANCE, GROUND_COVER_HEIGHT, ScatterAssetPlugin, ScatterAssets,
+    ScatterChunk, ScatterDirty, ScatterPrimitive, ScatterRegion, ScatterRenderPlugin,
+    ScatterRendered, ScatterSystems, TerrainScatter,
 };
 
 use crate::heightmap::Heightmap;

--- a/crates/jackdaw_terrain/src/render/scatter.rs
+++ b/crates/jackdaw_terrain/src/render/scatter.rs
@@ -217,6 +217,16 @@ pub struct ScatterAssets {
 }
 
 impl ScatterAssets {
+    /// Start loading `asset` unless it is already known.
+    pub fn request(&mut self, server: &AssetServer, asset: &str) {
+        if self.entries.contains_key(asset) {
+            return;
+        }
+        let asset = asset.to_string();
+        let handle = server.load(asset.clone());
+        self.entries.insert(asset, ScatterAsset::Loading(handle));
+    }
+
     /// The primitives a palette entry draws, or `None` while it is loading
     /// or after it failed.
     pub fn primitives(&self, asset: &str) -> Option<&[ScatterPrimitive]> {
@@ -254,6 +264,9 @@ pub enum ScatterSystems {
     /// Resolving palette assets and respawning the chunks a dirty mark
     /// names. A host that writes [`TerrainScatter`] runs before this.
     Rebuild,
+    /// Flattening the glTFs that have finished loading, which both the
+    /// scatter and the detail renderers read the results of.
+    Resolve,
     /// Hiding the chunks no camera can see.
     Cull,
 }
@@ -264,7 +277,11 @@ fn init_asset_if_absent<A: Asset>(app: &mut App) {
     }
 }
 
-impl Plugin for ScatterRenderPlugin {
+/// The glTF store, shared by everything that draws a flattened asset. Added by
+/// [`ScatterRenderPlugin`] and [`super::detail::DetailRenderPlugin`] alike.
+pub struct ScatterAssetPlugin;
+
+impl Plugin for ScatterAssetPlugin {
     fn build(&self, app: &mut App) {
         // A headless build has no glTF loader to register these; a rendering
         // build already owns them, and registering again would replace the
@@ -274,14 +291,34 @@ impl Plugin for ScatterRenderPlugin {
         init_asset_if_absent::<GltfMesh>(app);
         init_asset_if_absent::<Mesh>(app);
         init_asset_if_absent::<StandardMaterial>(app);
-        app.init_resource::<ScatterAssets>().add_systems(
+        app.init_resource::<ScatterAssets>()
+            .configure_sets(
+                Update,
+                ScatterSystems::Resolve.in_set(ScatterSystems::Rebuild),
+            )
+            .add_systems(
+                Update,
+                resolve_palette_assets.in_set(ScatterSystems::Resolve),
+            );
+    }
+}
+
+/// Add the shared glTF store unless a sibling renderer already did.
+pub(super) fn add_asset_plugin(app: &mut App) {
+    if !app.is_plugin_added::<ScatterAssetPlugin>() {
+        app.add_plugins(ScatterAssetPlugin);
+    }
+}
+
+impl Plugin for ScatterRenderPlugin {
+    fn build(&self, app: &mut App) {
+        add_asset_plugin(app);
+        app.add_systems(
             Update,
             (
-                request_palette_assets,
-                resolve_palette_assets,
-                rebuild_chunks,
+                request_palette_assets.before(ScatterSystems::Resolve),
+                rebuild_chunks.after(ScatterSystems::Resolve),
             )
-                .chain()
                 .in_set(ScatterSystems::Rebuild),
         );
         // After the frusta are written and before they are read: culling against
@@ -305,13 +342,10 @@ fn request_palette_assets(
     let assets = assets.into_inner();
     for scatter in &terrains {
         for entry in &scatter.palette.assets {
-            if entry.is_tombstone() || assets.entries.contains_key(&entry.asset) {
+            if entry.is_tombstone() {
                 continue;
             }
-            assets.entries.insert(
-                entry.asset.clone(),
-                ScatterAsset::Loading(server.load(&entry.asset)),
-            );
+            assets.request(&server, &entry.asset);
         }
     }
 }

--- a/crates/jackdaw_terrain/src/render/shaders/detail.wgsl
+++ b/crates/jackdaw_terrain/src/render/shaders/detail.wgsl
@@ -1,5 +1,4 @@
-// One detail instance per draw instance. Vertex buffer 0 is the layer's mesh,
-// buffer 1 one `DetailInstance` per instance, already in world space.
+// Instanced ground detail with wind, bend and pressers.
 
 #import bevy_pbr::{
     forward_io::FragmentOutput,
@@ -21,10 +20,10 @@ const ALPHA_CUTOFF: f32 = 0.5;
 const TAU: f32 = 6.2831855;
 
 struct DetailUniform {
-    // Linear colour at the foot and at the top of an instance. `w` is unused.
+    /// Linear colour at the foot and at the top of an instance. `w` is unused.
     color_base: vec4<f32>,
     color_tip: vec4<f32>,
-    // Direction the wind pattern travels across the terrain, on XZ.
+    /// Direction the wind pattern travels across the terrain, on XZ.
     wind_direction: vec2<f32>,
     wind_speed: f32,
     wind_strength: f32,
@@ -32,15 +31,16 @@ struct DetailUniform {
     wind_tile_size: f32,
     bend: f32,
     push_strength: f32,
-    // Shortest and tallest an instance stands, in world units.
+    /// Shortest and tallest an instance stands, in world units.
     height_range: vec2<f32>,
-    // Narrowest and widest it is drawn, over its mesh's own width.
+    /// Narrowest and widest it is drawn, over its mesh's own width.
     width_range: vec2<f32>,
     cull_distance: f32,
     presser_count: u32,
-    // Whether the mesh is the built-in card, whose taper is carved below.
+    /// Whether the mesh is the built-in card, a straight strip whose taper the
+    /// fragment stage carves. An asset mesh is cut out by its texture instead.
     is_card: u32,
-    // `xyz` is a presser's world position, `w` how far it flattens detail.
+    /// `xyz` is a presser's world position, `w` how far it flattens detail.
     pressers: array<vec4<f32>, 16>,
 }
 
@@ -50,13 +50,17 @@ struct DetailUniform {
 @group(3) @binding(3) var color_texture: texture_2d<f32>;
 @group(3) @binding(4) var color_sampler: sampler;
 
+/// Vertex buffer 0 is the layer's mesh, buffer 1 one `DetailInstance` per draw
+/// instance, already in world space.
 struct Vertex {
     @location(0) position: vec3<f32>,
     @location(1) normal: vec3<f32>,
     @location(2) uv: vec2<f32>,
+    /// 0 at the foot of the mesh and 1 at its top.
     @location(3) height_fraction: f32,
     @location(4) instance_position: vec3<f32>,
     @location(5) instance_packed: u32,
+    /// The xz of the ground normal the placement recorded; zero stands up.
     @location(6) instance_tilt: vec2<f32>,
 }
 
@@ -105,13 +109,9 @@ fn vertex(in: Vertex) -> DetailOutput {
     );
     let variation = vec4<f32>(packed) / 255.0;
 
-    // Up the mesh, 0 at the foot and 1 at the top; every lean below is
-    // weighted by it.
-    let t = in.height_fraction;
+    let up_the_mesh = in.height_fraction;
     let base = in.instance_position;
 
-    // Instances shrink into the ground over the last FADE_BAND of the cull
-    // distance.
     let to_viewer = distance(view.world_position, base);
     let fade_start = detail.cull_distance * (1.0 - FADE_BAND);
     let fade = 1.0 - smoothstep(fade_start, detail.cull_distance, to_viewer);
@@ -120,27 +120,25 @@ fn vertex(in: Vertex) -> DetailOutput {
     let width = mix(detail.width_range.x, detail.width_range.y, variation.y);
     let yaw = variation.z * TAU;
 
-    // Squared, so the bend gathers toward the top.
+    let bend_gathered_toward_the_top = up_the_mesh * up_the_mesh * detail.bend;
     let local = vec3<f32>(
         in.position.x * width,
-        t * height,
-        in.position.z * width + t * t * detail.bend,
+        up_the_mesh * height,
+        in.position.z * width + bend_gathered_toward_the_top,
     );
-    let normal = normalize(mix(in.normal, vec3<f32>(0.0, 1.0, 0.0), t));
+    let normal = normalize(mix(in.normal, vec3<f32>(0.0, 1.0, 0.0), up_the_mesh));
 
-    // The instance stands along the ground normal the placement recorded, or
-    // straight up where it recorded none.
     let tilt = in.instance_tilt;
-    let up = vec3<f32>(tilt.x, sqrt(max(1.0 - dot(tilt, tilt), 0.0)), tilt.y);
-    var offset = tilt_toward(rotate_y(local, yaw), up);
-    let world_normal = tilt_toward(rotate_y(normal, yaw), up);
+    let ground_normal = vec3<f32>(tilt.x, sqrt(max(1.0 - dot(tilt, tilt), 0.0)), tilt.y);
+    var offset = tilt_toward(rotate_y(local, yaw), ground_normal);
+    let world_normal = tilt_toward(rotate_y(normal, yaw), ground_normal);
 
     let wind = wind_at(base.xz);
     let along = normalize(detail.wind_direction + vec2<f32>(1e-6, 0.0));
     offset += vec3<f32>(
-        along.x * wind * detail.wind_strength * t,
-        abs(wind) * detail.wind_vertical_strength * t,
-        along.y * wind * detail.wind_strength * t,
+        along.x * wind * detail.wind_strength * up_the_mesh,
+        abs(wind) * detail.wind_vertical_strength * up_the_mesh,
+        along.y * wind * detail.wind_strength * up_the_mesh,
     );
 
     for (var i = 0u; i < min(detail.presser_count, MAX_PRESSERS); i += 1u) {
@@ -151,29 +149,28 @@ fn vertex(in: Vertex) -> DetailOutput {
         let strength = 1.0 - smoothstep(0.0, reach, length(flat_away));
         if strength > 0.0 {
             let direction = normalize(vec3<f32>(flat_away.x, 0.0, flat_away.y) + vec3<f32>(1e-6, 0.0, 0.0));
-            offset += direction * strength * detail.push_strength * t;
-            // Pressed down as well as aside.
-            offset.y -= strength * detail.push_strength * t * 0.5;
+            let pushed = strength * detail.push_strength * up_the_mesh;
+            offset += direction * pushed;
+            let pressed_down = pushed * 0.5;
+            offset.y -= pressed_down;
         }
     }
 
     let world = base + offset;
     let tint = mix(DIMMEST, 1.0, variation.w);
-    let shade = mix(AMBIENT_FLOOR, 1.0, t);
+    let shade = mix(AMBIENT_FLOOR, 1.0, up_the_mesh);
 
     var out: DetailOutput;
     out.world_position = vec4<f32>(world, 1.0);
     out.position = view.clip_from_world * out.world_position;
     out.world_normal = normalize(world_normal);
     out.uv = in.uv;
-    out.color = mix(detail.color_base.rgb, detail.color_tip.rgb, t) * tint * shade;
+    out.color = mix(detail.color_base.rgb, detail.color_tip.rgb, up_the_mesh) * tint * shade;
     return out;
 }
 
 @fragment
 fn fragment(in: DetailOutput, @builtin(front_facing) is_front: bool) -> FragmentOutput {
-    // The card is a straight strip; the taper is carved here. An asset mesh
-    // brings its own silhouette and is cut out by its texture instead.
     if detail.is_card != 0u {
         let half_span = 1.0 - in.uv.y * in.uv.y;
         if abs(in.uv.x - 0.5) * 2.0 > half_span {
@@ -185,8 +182,8 @@ fn fragment(in: DetailOutput, @builtin(front_facing) is_front: bool) -> Fragment
         discard;
     }
 
-    // Both faces are lit as front-facing; a card is a sheet with no inside.
-    let n = normalize(pbr_functions::prepare_world_normal(in.world_normal, true, is_front));
+    let double_sided = true;
+    let n = normalize(pbr_functions::prepare_world_normal(in.world_normal, double_sided, is_front));
 
     var pbr_input = pbr_types::pbr_input_new();
     pbr_input.flags = mesh_types::MESH_FLAGS_SHADOW_RECEIVER_BIT;

--- a/crates/jackdaw_terrain/src/render/shaders/detail.wgsl
+++ b/crates/jackdaw_terrain/src/render/shaders/detail.wgsl
@@ -1,0 +1,208 @@
+// One detail instance per draw instance. Vertex buffer 0 is the layer's mesh,
+// buffer 1 one `DetailInstance` per instance, already in world space.
+
+#import bevy_pbr::{
+    forward_io::FragmentOutput,
+    mesh_types,
+    mesh_view_bindings::{view, globals},
+    pbr_functions,
+    pbr_types,
+}
+
+const MAX_PRESSERS: u32 = 16u;
+/// Darkest the tint byte takes an instance, as a fraction of its own colour.
+const DIMMEST: f32 = 0.7;
+/// How dark the foot of an instance sits under its top, as a fraction.
+const AMBIENT_FLOOR: f32 = 0.45;
+/// Fraction of the cull distance the instances spend shrinking into the ground.
+const FADE_BAND: f32 = 0.25;
+/// Alpha a textured instance has to clear to draw.
+const ALPHA_CUTOFF: f32 = 0.5;
+const TAU: f32 = 6.2831855;
+
+struct DetailUniform {
+    // Linear colour at the foot and at the top of an instance. `w` is unused.
+    color_base: vec4<f32>,
+    color_tip: vec4<f32>,
+    // Direction the wind pattern travels across the terrain, on XZ.
+    wind_direction: vec2<f32>,
+    wind_speed: f32,
+    wind_strength: f32,
+    wind_vertical_strength: f32,
+    wind_tile_size: f32,
+    bend: f32,
+    push_strength: f32,
+    // Shortest and tallest an instance stands, in world units.
+    height_range: vec2<f32>,
+    // Narrowest and widest it is drawn, over its mesh's own width.
+    width_range: vec2<f32>,
+    cull_distance: f32,
+    presser_count: u32,
+    // Whether the mesh is the built-in card, whose taper is carved below.
+    is_card: u32,
+    // `xyz` is a presser's world position, `w` how far it flattens detail.
+    pressers: array<vec4<f32>, 16>,
+}
+
+@group(3) @binding(0) var<uniform> detail: DetailUniform;
+@group(3) @binding(1) var wind_noise: texture_2d<f32>;
+@group(3) @binding(2) var wind_sampler: sampler;
+@group(3) @binding(3) var color_texture: texture_2d<f32>;
+@group(3) @binding(4) var color_sampler: sampler;
+
+struct Vertex {
+    @location(0) position: vec3<f32>,
+    @location(1) normal: vec3<f32>,
+    @location(2) uv: vec2<f32>,
+    @location(3) height_fraction: f32,
+    @location(4) instance_position: vec3<f32>,
+    @location(5) instance_packed: u32,
+    @location(6) instance_tilt: vec2<f32>,
+}
+
+struct DetailOutput {
+    @builtin(position) position: vec4<f32>,
+    @location(0) world_position: vec4<f32>,
+    @location(1) world_normal: vec3<f32>,
+    @location(2) uv: vec2<f32>,
+    @location(3) color: vec3<f32>,
+}
+
+fn rotate_y(v: vec3<f32>, yaw: f32) -> vec3<f32> {
+    let s = sin(yaw);
+    let c = cos(yaw);
+    return vec3<f32>(v.x * c + v.z * s, v.y, v.z * c - v.x * s);
+}
+
+/// `v` turned by the rotation that takes straight up onto `up`.
+fn tilt_toward(v: vec3<f32>, up: vec3<f32>) -> vec3<f32> {
+    let axis = cross(vec3<f32>(0.0, 1.0, 0.0), up);
+    let span = length(axis);
+    if span < 1e-5 {
+        return v;
+    }
+    let unit_axis = axis / span;
+    let angle = atan2(span, clamp(up.y, -1.0, 1.0));
+    let c = cos(angle);
+    return v * c + cross(unit_axis, v) * sin(angle) + unit_axis * dot(unit_axis, v) * (1.0 - c);
+}
+
+/// The wind pattern where an instance stands, in `-1..1`. Sampled at the
+/// instance's foot, not per vertex.
+fn wind_at(world_xz: vec2<f32>) -> f32 {
+    let travel = detail.wind_direction * globals.time * detail.wind_speed;
+    let uv = world_xz / max(detail.wind_tile_size, 0.001) + travel;
+    return textureSampleLevel(wind_noise, wind_sampler, uv, 0.0).r * 2.0 - 1.0;
+}
+
+@vertex
+fn vertex(in: Vertex) -> DetailOutput {
+    let packed = vec4<u32>(
+        in.instance_packed & 0xffu,
+        (in.instance_packed >> 8u) & 0xffu,
+        (in.instance_packed >> 16u) & 0xffu,
+        (in.instance_packed >> 24u) & 0xffu,
+    );
+    let variation = vec4<f32>(packed) / 255.0;
+
+    // Up the mesh, 0 at the foot and 1 at the top; every lean below is
+    // weighted by it.
+    let t = in.height_fraction;
+    let base = in.instance_position;
+
+    // Instances shrink into the ground over the last FADE_BAND of the cull
+    // distance.
+    let to_viewer = distance(view.world_position, base);
+    let fade_start = detail.cull_distance * (1.0 - FADE_BAND);
+    let fade = 1.0 - smoothstep(fade_start, detail.cull_distance, to_viewer);
+
+    let height = mix(detail.height_range.x, detail.height_range.y, variation.x) * fade;
+    let width = mix(detail.width_range.x, detail.width_range.y, variation.y);
+    let yaw = variation.z * TAU;
+
+    // Squared, so the bend gathers toward the top.
+    let local = vec3<f32>(
+        in.position.x * width,
+        t * height,
+        in.position.z * width + t * t * detail.bend,
+    );
+    let normal = normalize(mix(in.normal, vec3<f32>(0.0, 1.0, 0.0), t));
+
+    // The instance stands along the ground normal the placement recorded, or
+    // straight up where it recorded none.
+    let tilt = in.instance_tilt;
+    let up = vec3<f32>(tilt.x, sqrt(max(1.0 - dot(tilt, tilt), 0.0)), tilt.y);
+    var offset = tilt_toward(rotate_y(local, yaw), up);
+    let world_normal = tilt_toward(rotate_y(normal, yaw), up);
+
+    let wind = wind_at(base.xz);
+    let along = normalize(detail.wind_direction + vec2<f32>(1e-6, 0.0));
+    offset += vec3<f32>(
+        along.x * wind * detail.wind_strength * t,
+        abs(wind) * detail.wind_vertical_strength * t,
+        along.y * wind * detail.wind_strength * t,
+    );
+
+    for (var i = 0u; i < min(detail.presser_count, MAX_PRESSERS); i += 1u) {
+        let presser = detail.pressers[i];
+        let away = base - presser.xyz;
+        let flat_away = vec2<f32>(away.x, away.z);
+        let reach = max(presser.w, 0.001);
+        let strength = 1.0 - smoothstep(0.0, reach, length(flat_away));
+        if strength > 0.0 {
+            let direction = normalize(vec3<f32>(flat_away.x, 0.0, flat_away.y) + vec3<f32>(1e-6, 0.0, 0.0));
+            offset += direction * strength * detail.push_strength * t;
+            // Pressed down as well as aside.
+            offset.y -= strength * detail.push_strength * t * 0.5;
+        }
+    }
+
+    let world = base + offset;
+    let tint = mix(DIMMEST, 1.0, variation.w);
+    let shade = mix(AMBIENT_FLOOR, 1.0, t);
+
+    var out: DetailOutput;
+    out.world_position = vec4<f32>(world, 1.0);
+    out.position = view.clip_from_world * out.world_position;
+    out.world_normal = normalize(world_normal);
+    out.uv = in.uv;
+    out.color = mix(detail.color_base.rgb, detail.color_tip.rgb, t) * tint * shade;
+    return out;
+}
+
+@fragment
+fn fragment(in: DetailOutput, @builtin(front_facing) is_front: bool) -> FragmentOutput {
+    // The card is a straight strip; the taper is carved here. An asset mesh
+    // brings its own silhouette and is cut out by its texture instead.
+    if detail.is_card != 0u {
+        let half_span = 1.0 - in.uv.y * in.uv.y;
+        if abs(in.uv.x - 0.5) * 2.0 > half_span {
+            discard;
+        }
+    }
+    let sampled = textureSample(color_texture, color_sampler, in.uv);
+    if sampled.a < ALPHA_CUTOFF {
+        discard;
+    }
+
+    // Both faces are lit as front-facing; a card is a sheet with no inside.
+    let n = normalize(pbr_functions::prepare_world_normal(in.world_normal, true, is_front));
+
+    var pbr_input = pbr_types::pbr_input_new();
+    pbr_input.flags = mesh_types::MESH_FLAGS_SHADOW_RECEIVER_BIT;
+    pbr_input.material.base_color = vec4<f32>(in.color * sampled.rgb, 1.0);
+    pbr_input.material.perceptual_roughness = 0.9;
+    pbr_input.material.metallic = 0.0;
+    pbr_input.material.flags |= pbr_types::STANDARD_MATERIAL_FLAGS_FOG_ENABLED_BIT;
+    pbr_input.frag_coord = in.position;
+    pbr_input.world_position = in.world_position;
+    pbr_input.world_normal = n;
+    pbr_input.N = n;
+    pbr_input.is_orthographic = view.clip_from_view[3].w == 1.0;
+    pbr_input.V = pbr_functions::calculate_view(in.world_position, pbr_input.is_orthographic);
+
+    var out: FragmentOutput;
+    out.color = pbr_functions::apply_pbr_lighting(pbr_input);
+    out.color = pbr_functions::main_pass_post_lighting_processing(pbr_input, out.color);
+    return out;
+}

--- a/crates/jackdaw_terrain/src/sidecar.rs
+++ b/crates/jackdaw_terrain/src/sidecar.rs
@@ -3112,6 +3112,37 @@ mod tests {
         }
     }
 
+    /// A detail layer's density is an ordinary channel, so it travels in the
+    /// file the same way every other painted layer does and needs no format
+    /// of its own.
+    #[test]
+    fn a_detail_density_channel_survives_a_save_and_load() {
+        let mut regions = TerrainRegions::new(RegionSize::new(8).unwrap());
+        for z in 0..8 {
+            for x in 0..8 {
+                regions.set_height(x, z, 0.0);
+            }
+        }
+        regions.set_channel_count(2);
+        regions.set_channel(1, 2, 3, 200);
+        regions.set_channel(1, 5, 6, 41);
+        let data = RegionTerrainData {
+            channels: vec![
+                ChannelDescriptor::new("biome", ChannelElement::U8),
+                ChannelDescriptor::new("grass", ChannelElement::U8),
+            ],
+            regions,
+            ..RegionTerrainData::default()
+        };
+
+        let back = load(&save(&data).expect("encodes")).expect("decodes");
+        assert_eq!(back.channels, data.channels);
+        assert_eq!(back.regions.channel_at(1, 2, 3), 200);
+        assert_eq!(back.regions.channel_at(1, 5, 6), 41);
+        assert_eq!(back.regions.channel_at(1, 0, 0), 0);
+        assert_eq!(back, data);
+    }
+
     #[test]
     fn grid_geometry_round_trips_through_a_version_5_file() {
         let mut data = bare_document();

--- a/crates/jackdaw_terrain/src/tint.rs
+++ b/crates/jackdaw_terrain/src/tint.rs
@@ -81,7 +81,7 @@ pub fn apply_color_brush(
 
 /// Brush strength at `dist`, with a hard plateau out to `hardness` of the
 /// radius and [`crate::control`]'s falloff shape over the rest.
-fn brush_weight(dist: f32, radius: f32, falloff: f32, hardness: f32) -> f32 {
+pub(crate) fn brush_weight(dist: f32, radius: f32, falloff: f32, hardness: f32) -> f32 {
     if dist >= radius {
         return 0.0;
     }

--- a/src/core_extension.rs
+++ b/src/core_extension.rs
@@ -313,6 +313,7 @@ impl JackdawExtension for JackdawCoreExtension {
         crate::animation::add_to_extension(ctx);
         crate::terrain::texture_ops::add_to_extension(ctx);
         crate::terrain::tint_ops::add_to_extension(ctx);
+        crate::terrain::detail_ops::add_to_extension(ctx);
         crate::terrain::autoterrain_ops::add_to_extension(ctx);
         crate::asset_browser::add_to_extension(ctx);
         crate::material_browser::add_to_extension(ctx);

--- a/src/terrain/channel_ops.rs
+++ b/src/terrain/channel_ops.rs
@@ -87,7 +87,7 @@ mod mint_channel_name_tests {
 
 /// Push the terrain's channel table back into the scene document and
 /// force a mesh rebuild, so a table edit is both saved and visible.
-fn commit_channels(world: &mut World, entity: Entity) {
+pub(super) fn commit_channels(world: &mut World, entity: Entity) {
     let Some(terrain) = world.get::<jackdaw_scene_types::Terrain>(entity) else {
         return;
     };

--- a/src/terrain/detail.rs
+++ b/src/terrain/detail.rs
@@ -60,18 +60,16 @@ pub fn sync_terrain_detail(
             Some(held) => reseeds_field(held.source(), projected.source()),
             None => true,
         };
-        // An edit that moved neither the store nor a layer rewrites nothing.
         let layers_changed =
             held.is_none_or(|held| looks_of(held.source()) != looks_of(projected.source()));
         if !store_changed && !layers_changed && !reseeds {
             continue;
         }
-        // Merged rather than replaced: an uncaught mark is still owed a reseed.
-        let mut mark = marked.copied().unwrap_or_default();
+        let mut merged_mark = marked.copied().unwrap_or_default();
         if reseeds {
-            mark.touch(GridRect::whole(projected.source().grid.resolution));
+            merged_mark.touch(GridRect::whole(projected.source().grid.resolution));
         }
-        commands.entity(entity).insert((projected, mark));
+        commands.entity(entity).insert((projected, merged_mark));
     }
 }
 
@@ -130,10 +128,10 @@ mod tests {
             ..RegionTerrainData::default()
         };
         data.regions.set_channel_count(1);
-        // A height of zero writes no cell, so the ground is painted instead.
+        let density_everywhere = 128;
         for z in 0..8 {
             for x in 0..8 {
-                data.regions.set_channel(0, x, z, 128);
+                data.regions.set_channel(0, x, z, density_everywhere);
             }
         }
         data
@@ -324,9 +322,10 @@ mod tests {
         let after = TerrainDetailSource::from_document(&data, &trimmed)
             .expect("the terrain carries layers");
 
-        // A tile names the layer it grew from by index, so the layers past the
-        // gap draw the wrong instances until the field is seeded again.
-        assert!(reseeds_field(before.source(), after.source()));
+        assert!(
+            reseeds_field(before.source(), after.source()),
+            "the layers after the gap kept their old indices"
+        );
     }
 
     #[test]

--- a/src/terrain/detail.rs
+++ b/src/terrain/detail.rs
@@ -1,0 +1,357 @@
+//! Projecting an editor document's detail layers into what the renderer draws.
+//! The store holds the density and the heights; `Terrain` holds the layers.
+
+use bevy::prelude::*;
+use jackdaw_scene_types::DetailLayer;
+use jackdaw_terrain::GridRect;
+use jackdaw_terrain::render::{DetailDirty, DetailSource, DetailTile, TerrainDetailSource};
+
+use super::TerrainDataStore;
+
+/// The layer the brush and the panel act on for one terrain: the selection,
+/// clamped to what that terrain carries.
+pub(crate) fn selected_detail_layer(
+    terrain: &jackdaw_scene_types::Terrain,
+    selected: usize,
+) -> Option<usize> {
+    (!terrain.detail.is_empty()).then(|| selected.min(terrain.detail.len() - 1))
+}
+
+/// Mark the ground a rect covers stale. A terrain with no layers carries no
+/// [`DetailDirty`] and is left alone.
+pub(crate) fn mark_detail_dirty(world: &mut World, entity: Entity, rect: GridRect) {
+    if let Some(mut dirty) = world.get_mut::<DetailDirty>(entity) {
+        dirty.touch(rect);
+    }
+}
+
+/// Keep every terrain's detail source following its document and its layers.
+/// The whole field is marked stale only for a change no per-cell mark covers.
+pub fn sync_terrain_detail(
+    mut commands: Commands,
+    store: Res<TerrainDataStore>,
+    terrains: Query<(
+        Entity,
+        Ref<jackdaw_scene_types::Terrain>,
+        Option<&TerrainDetailSource>,
+        Option<&DetailDirty>,
+    )>,
+) {
+    let store_changed = store.is_changed();
+    for (entity, terrain, held, marked) in &terrains {
+        let carries_layers = !terrain.detail.is_empty();
+        if !store_changed && !terrain.is_changed() && held.is_some() == carries_layers {
+            continue;
+        }
+
+        let projected = store
+            .get(&terrain.data_path)
+            .and_then(|data| TerrainDetailSource::from_document(data, &terrain));
+        let Some(projected) = projected else {
+            if held.is_some() {
+                commands
+                    .entity(entity)
+                    .remove::<(TerrainDetailSource, DetailDirty)>();
+            }
+            continue;
+        };
+
+        let reseeds = match held {
+            Some(held) => reseeds_field(held.source(), projected.source()),
+            None => true,
+        };
+        // An edit that moved neither the store nor a layer rewrites nothing.
+        let layers_changed =
+            held.is_none_or(|held| looks_of(held.source()) != looks_of(projected.source()));
+        if !store_changed && !layers_changed && !reseeds {
+            continue;
+        }
+        // Merged rather than replaced: an uncaught mark is still owed a reseed.
+        let mut mark = marked.copied().unwrap_or_default();
+        if reseeds {
+            mark.touch(GridRect::whole(projected.source().grid.resolution));
+        }
+        commands.entity(entity).insert((projected, mark));
+    }
+}
+
+/// Keep the seeded tiles out of the outliner and out of the saved scene.
+/// A tile is grown from the terrain's document rather than saved with it.
+pub fn hide_drawn_detail(add: On<Add, DetailTile>, mut commands: Commands) {
+    commands
+        .entity(add.entity)
+        .insert((crate::EditorHidden, crate::NonSerializable));
+}
+
+/// The layers a projection carries, in order.
+fn looks_of(source: &DetailSource) -> Vec<&DetailLayer> {
+    source.layers.iter().map(|entry| &entry.layer).collect()
+}
+
+/// Whether two projections of the same terrain stand every instance somewhere
+/// else.
+fn reseeds_field(before: &DetailSource, after: &DetailSource) -> bool {
+    if before.heightmap.resolution != after.heightmap.resolution || before.grid != after.grid {
+        return true;
+    }
+    if before.layers.len() != after.layers.len() {
+        return true;
+    }
+    before
+        .layers
+        .iter()
+        .zip(&after.layers)
+        .any(|(before, after)| {
+            before.max != after.max || places_differently(&before.layer, &after.layer)
+        })
+}
+
+/// Whether two versions of one layer stand instances in different places, or
+/// draw them with a different mesh. Every other field costs no reseed.
+fn places_differently(before: &DetailLayer, after: &DetailLayer) -> bool {
+    before.density_channel != after.density_channel
+        || before.density_per_m2 != after.density_per_m2
+        || before.height != after.height
+        || before.align_to_normal != after.align_to_normal
+        || before.mesh != after.mesh
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use jackdaw_scene_types::{DetailMesh, Terrain};
+    use jackdaw_terrain::region::{RegionSize, TerrainRegions};
+    use jackdaw_terrain::{ChannelDescriptor, ChannelElement, RegionTerrainData};
+
+    fn document() -> RegionTerrainData {
+        let mut data = RegionTerrainData {
+            channels: vec![ChannelDescriptor::new("grass", ChannelElement::U8)],
+            regions: TerrainRegions::new(RegionSize::new(8).unwrap()),
+            ..RegionTerrainData::default()
+        };
+        data.regions.set_channel_count(1);
+        // A height of zero writes no cell, so the ground is painted instead.
+        for z in 0..8 {
+            for x in 0..8 {
+                data.regions.set_channel(0, x, z, 128);
+            }
+        }
+        data
+    }
+
+    fn terrain_with(layers: Vec<DetailLayer>) -> Terrain {
+        Terrain {
+            data_path: "t.jdterrain".to_string(),
+            detail: layers,
+            ..Terrain::default()
+        }
+    }
+
+    fn terrain() -> Terrain {
+        terrain_with(vec![DetailLayer::default()])
+    }
+
+    fn source_of(data: &RegionTerrainData) -> TerrainDetailSource {
+        TerrainDetailSource::from_document(data, &terrain()).expect("the terrain carries a layer")
+    }
+
+    fn source_with(data: &RegionTerrainData, layer: DetailLayer) -> TerrainDetailSource {
+        TerrainDetailSource::from_document(data, &terrain_with(vec![layer]))
+            .expect("the terrain carries a layer")
+    }
+
+    #[test]
+    fn a_painted_cell_alone_reseeds_nothing() {
+        let before = document();
+        let mut after = document();
+        after.regions.set_channel(0, 3, 5, 255);
+        assert!(!reseeds_field(
+            source_of(&before).source(),
+            source_of(&after).source()
+        ));
+    }
+
+    #[test]
+    fn changing_where_instances_stand_reseeds_the_field() {
+        let data = document();
+        let before = source_of(&data);
+        let after = source_with(
+            &data,
+            DetailLayer {
+                density_per_m2: 90.0,
+                ..DetailLayer::default()
+            },
+        );
+        assert!(reseeds_field(before.source(), after.source()));
+    }
+
+    #[test]
+    fn only_the_placement_fields_reseed_the_field() {
+        let data = document();
+        let base = source_of(&data);
+        let reseeded_by =
+            |layer: DetailLayer| reseeds_field(base.source(), source_with(&data, layer).source());
+        let default = DetailLayer::default;
+
+        for (name, layer) in [
+            (
+                "density_channel",
+                DetailLayer {
+                    density_channel: "meadow".to_string(),
+                    ..default()
+                },
+            ),
+            (
+                "height",
+                DetailLayer {
+                    height: [0.1, 2.0],
+                    ..default()
+                },
+            ),
+            (
+                "density_per_m2",
+                DetailLayer {
+                    density_per_m2: 90.0,
+                    ..default()
+                },
+            ),
+            (
+                "align_to_normal",
+                DetailLayer {
+                    align_to_normal: true,
+                    ..default()
+                },
+            ),
+            (
+                "mesh",
+                DetailLayer {
+                    mesh: DetailMesh::Asset("models/fern.gltf".to_string()),
+                    ..default()
+                },
+            ),
+        ] {
+            assert!(reseeded_by(layer), "{name} moves instances and must reseed");
+        }
+
+        for (name, layer) in [
+            (
+                "cull_distance",
+                DetailLayer {
+                    cull_distance: 150.0,
+                    ..default()
+                },
+            ),
+            (
+                "width",
+                DetailLayer {
+                    width: [0.1, 0.5],
+                    ..default()
+                },
+            ),
+            (
+                "color_base",
+                DetailLayer {
+                    color_base: [1.0, 0.0, 0.0],
+                    ..default()
+                },
+            ),
+            (
+                "wind_strength",
+                DetailLayer {
+                    wind_strength: 0.9,
+                    ..default()
+                },
+            ),
+            (
+                "wind_direction",
+                DetailLayer {
+                    wind_direction: [-1.0, 0.0],
+                    ..default()
+                },
+            ),
+            (
+                "bend",
+                DetailLayer {
+                    bend: 0.9,
+                    ..default()
+                },
+            ),
+            (
+                "push_strength",
+                DetailLayer {
+                    push_strength: 2.0,
+                    ..default()
+                },
+            ),
+            (
+                "name",
+                DetailLayer {
+                    name: "meadow".to_string(),
+                    ..default()
+                },
+            ),
+        ] {
+            assert!(
+                !reseeded_by(layer),
+                "{name} moves no instance and must not reseed"
+            );
+        }
+    }
+
+    #[test]
+    fn adding_a_layer_reseeds_the_field() {
+        let data = document();
+        let before = source_of(&data);
+        let after = TerrainDetailSource::from_document(
+            &data,
+            &terrain_with(vec![DetailLayer::default(), DetailLayer::default()]),
+        )
+        .expect("the terrain carries two layers");
+        assert!(reseeds_field(before.source(), after.source()));
+    }
+
+    #[test]
+    fn removing_a_middle_layer_reseeds_the_field() {
+        let data = document();
+        let named = |name: &str| DetailLayer {
+            name: name.to_string(),
+            ..DetailLayer::default()
+        };
+        let all = terrain_with(vec![named("a"), named("b"), named("c")]);
+        let trimmed = terrain_with(vec![named("a"), named("c")]);
+        let before =
+            TerrainDetailSource::from_document(&data, &all).expect("the terrain carries layers");
+        let after = TerrainDetailSource::from_document(&data, &trimmed)
+            .expect("the terrain carries layers");
+
+        // A tile names the layer it grew from by index, so the layers past the
+        // gap draw the wrong instances until the field is seeded again.
+        assert!(reseeds_field(before.source(), after.source()));
+    }
+
+    #[test]
+    fn changing_only_the_look_reseeds_nothing() {
+        let data = document();
+        let before = source_of(&data);
+        let after = source_with(
+            &data,
+            DetailLayer {
+                color_tip: [1.0, 0.0, 0.0],
+                width: [0.1, 0.5],
+                ..DetailLayer::default()
+            },
+        );
+
+        assert!(!reseeds_field(before.source(), after.source()));
+        assert_ne!(looks_of(before.source()), looks_of(after.source()));
+    }
+
+    #[test]
+    fn an_unchanged_projection_reseeds_nothing() {
+        let data = document();
+        assert!(!reseeds_field(
+            source_of(&data).source(),
+            source_of(&data).source()
+        ));
+    }
+}

--- a/src/terrain/detail_ops.rs
+++ b/src/terrain/detail_ops.rs
@@ -39,8 +39,17 @@ fn detail_terrain(world: &mut World, params: &OperatorParameters, id: &str) -> O
     entity
 }
 
+/// The layer some text addresses, an index before a name, so that an index
+/// still wins over a layer whose name is a number.
+fn layer_by_index_or_name(layers: &[DetailLayer], addressed: &str) -> Option<usize> {
+    match addressed.parse::<usize>() {
+        Ok(index) if index < layers.len() => Some(index),
+        _ => layers.iter().position(|layer| layer.name == addressed),
+    }
+}
+
 /// The layer a `layer=` parameter addresses: an index, a name, or the selected
-/// layer when it is left out.
+/// layer when it is left out. A selection past the end falls back to the last.
 fn resolve_layer(
     world: &mut World,
     entity: Entity,
@@ -53,17 +62,9 @@ fn resolve_layer(
         .map(str::to_string)
         .or_else(|| params.as_int("layer").map(|index| index.to_string()));
     let index = match addressed {
-        // An index wins over a layer whose name is a number.
-        Some(addressed) => match addressed.trim().parse::<usize>() {
-            Ok(index) if index < layers.len() => Some(index),
-            _ => layers
-                .iter()
-                .position(|layer| layer.name == addressed.trim()),
-        },
+        Some(addressed) => layer_by_index_or_name(&layers, addressed.trim()),
         None => {
             let selected = world.resource::<TerrainPaintState>().detail_layer;
-            // A selection left past the end, by an undo or a removal, falls
-            // back to the last layer rather than addressing nothing.
             (!layers.is_empty()).then(|| selected.min(layers.len() - 1))
         }
     };
@@ -181,6 +182,15 @@ fn unique_layer_name(wanted: &str, layers: &[DetailLayer]) -> String {
         .expect("the candidate space is unbounded")
 }
 
+/// Where the selection lands once the layer at `removed` is gone: it follows
+/// the layer it was on, and onto the last layer when that was the removed one.
+fn selection_after_removing(selected: usize, removed: usize, layers_left: usize) -> usize {
+    match selected {
+        selected if selected > removed => selected - 1,
+        selected => selected.min(layers_left.saturating_sub(1)),
+    }
+}
+
 /// Remove one detail layer, leaving the channel it grew from painted.
 #[operator(
     id = "terrain.detail.remove",
@@ -213,7 +223,7 @@ pub(crate) fn terrain_detail_remove(
     };
     let mut after = before.clone();
     after.remove(index);
-    let left = after.len();
+    let layers_left = after.len();
 
     world.resource_scope(|world, mut history: Mut<CommandHistory>| {
         history.execute(
@@ -226,13 +236,7 @@ pub(crate) fn terrain_detail_remove(
         );
     });
     let mut paint = world.resource_mut::<TerrainPaintState>();
-    // The selection follows the layer it was on: one earlier when that layer
-    // stood after the removed one, and onto the last layer when it was the
-    // removed one itself.
-    paint.detail_layer = match paint.detail_layer {
-        selected if selected > index => selected - 1,
-        selected => selected.min(left.saturating_sub(1)),
-    };
+    paint.detail_layer = selection_after_removing(paint.detail_layer, index, layers_left);
     OperatorResult::Finished
 }
 
@@ -497,7 +501,7 @@ pub(crate) fn terrain_detail_stamp(
         };
         let before = data.channel_values(channel);
         let mut values = before.clone();
-        // dt = 1.0, so `opacity` reads as an amount rather than a rate.
+        let one_whole_application = 1.0;
         let changed = jackdaw_terrain::apply_density_brush(
             &mut values,
             placement.resolution,
@@ -507,7 +511,7 @@ pub(crate) fn terrain_detail_stamp(
             hardness,
             falloff,
             opacity,
-            1.0,
+            one_whole_application,
             erase,
         );
         if changed == 0 {
@@ -620,13 +624,12 @@ fn write_field(layer: &mut DetailLayer, field: &str, value: &str) -> bool {
             _ => return false,
         },
         "height" | "width" => match numbers::<2>(value) {
-            // Stored low end first, so a range typed backwards is still a range.
             Some([a, b]) if a >= 0.0 && b >= 0.0 => {
-                let range = [a.min(b), a.max(b)];
+                let low_end_first = [a.min(b), a.max(b)];
                 if field == "height" {
-                    layer.height = range;
+                    layer.height = low_end_first;
                 } else {
-                    layer.width = range;
+                    layer.width = low_end_first;
                 }
             }
             _ => return false,
@@ -681,13 +684,11 @@ impl SetTerrainDetail {
         let Some(mut terrain) = world.get_mut::<Terrain>(self.entity) else {
             return;
         };
-        let left = detail.len();
+        let layers_left = detail.len();
         terrain.detail = detail;
         let terrain = terrain.clone();
-        // A shorter list would otherwise leave the brush and the panel
-        // pointing past the end.
         let mut paint = world.resource_mut::<TerrainPaintState>();
-        paint.detail_layer = paint.detail_layer.min(left.saturating_sub(1));
+        paint.detail_layer = paint.detail_layer.min(layers_left.saturating_sub(1));
         crate::commands::sync_component_to_ast(
             world,
             self.entity,
@@ -730,11 +731,11 @@ impl EditorCommand for AddTerrainChannel {
         {
             return;
         }
+        let continuous_coverage = Vec::new();
         terrain.channels.push(TerrainChannel {
             name: self.name.clone(),
             element: TerrainChannelElement::U8,
-            // No palette: coverage is a continuous fraction of the ceiling.
-            palette: Vec::new(),
+            palette: continuous_coverage,
         });
         super::channel_ops::commit_channels(world, self.entity);
     }

--- a/src/terrain/detail_ops.rs
+++ b/src/terrain/detail_ops.rs
@@ -1,0 +1,841 @@
+//! Operators for a terrain's detail layers: adding and removing them, the look
+//! each one draws with, and the density brush that decides where it grows.
+
+use std::path::PathBuf;
+
+use bevy::prelude::*;
+use jackdaw_api::prelude::*;
+use jackdaw_commands::CommandHistory;
+use jackdaw_scene_types::{
+    DetailLayer, DetailMesh, Terrain, TerrainChannel, TerrainChannelElement,
+};
+
+use super::detail::mark_detail_dirty;
+use super::paint::{PaintDomain, SetTerrainChannel, TerrainPaintState};
+use super::scatter::resolve_terrain;
+use super::stamp_ops::{StampTarget, stamp_target};
+use super::store::TerrainDataStore;
+use crate::commands::EditorCommand;
+
+pub(crate) fn add_to_extension(ctx: &mut ExtensionContext) {
+    ctx.register_operator::<TerrainDetailAddOp>()
+        .register_operator::<TerrainDetailRemoveOp>()
+        .register_operator::<TerrainDetailSelectOp>()
+        .register_operator::<TerrainDetailSetOp>()
+        .register_operator::<TerrainDetailPaintOp>()
+        .register_operator::<TerrainDetailStampOp>();
+}
+
+/// The terrain a detail operator addresses, or a warning to the caller naming
+/// what was missing.
+fn detail_terrain(world: &mut World, params: &OperatorParameters, id: &str) -> Option<Entity> {
+    let entity = resolve_terrain(world, params.as_str("terrain"));
+    if entity.is_none() {
+        warn_caller(
+            world,
+            format!("{id}: no terrain named; name one with terrain=<Name>"),
+        );
+    }
+    entity
+}
+
+/// The layer a `layer=` parameter addresses: an index, a name, or the selected
+/// layer when it is left out.
+fn resolve_layer(
+    world: &mut World,
+    entity: Entity,
+    params: &OperatorParameters,
+    id: &str,
+) -> Option<(usize, DetailLayer)> {
+    let layers = world.get::<Terrain>(entity)?.detail.clone();
+    let addressed = params
+        .as_str("layer")
+        .map(str::to_string)
+        .or_else(|| params.as_int("layer").map(|index| index.to_string()));
+    let index = match addressed {
+        // An index wins over a layer whose name is a number.
+        Some(addressed) => match addressed.trim().parse::<usize>() {
+            Ok(index) if index < layers.len() => Some(index),
+            _ => layers
+                .iter()
+                .position(|layer| layer.name == addressed.trim()),
+        },
+        None => {
+            let selected = world.resource::<TerrainPaintState>().detail_layer;
+            // A selection left past the end, by an undo or a removal, falls
+            // back to the last layer rather than addressing nothing.
+            (!layers.is_empty()).then(|| selected.min(layers.len() - 1))
+        }
+    };
+    let Some(index) = index else {
+        warn_caller(
+            world,
+            format!("{id}: this terrain has no such detail layer; add one with terrain.detail.add"),
+        );
+        return None;
+    };
+    Some((index, layers[index].clone()))
+}
+
+/// Add a detail layer to a terrain, minting the density channel it grows from.
+/// One undo entry covers both the layer and the channel.
+#[operator(
+    id = "terrain.detail.add",
+    label = "Add Detail Layer",
+    description = "Add a ground detail layer to a terrain.",
+    allows_undo = false,
+    params(
+        terrain(String, doc = "Name of the terrain entity. Defaults to the selection."),
+        name(
+            String,
+            doc = "What to call the layer. Defaults to \"grass\", with a suffix when \
+                   another layer answers to it."
+        ),
+        channel(
+            String,
+            doc = "Name of the density channel it grows from. Defaults to the layer's name."
+        ),
+    )
+)]
+pub(crate) fn terrain_detail_add(
+    params: In<OperatorParameters>,
+    world: &mut World,
+) -> OperatorResult {
+    let params = params.0;
+    let id = "terrain.detail.add";
+    let Some(entity) = detail_terrain(world, &params, id) else {
+        return OperatorResult::Cancelled;
+    };
+    let Some(terrain) = world.get::<Terrain>(entity) else {
+        return OperatorResult::Cancelled;
+    };
+    let wanted = params
+        .as_str("name")
+        .map(str::trim)
+        .filter(|name| !name.is_empty())
+        .map(str::to_string)
+        .unwrap_or_else(|| DetailLayer::default().name);
+    let name = unique_layer_name(&wanted, &terrain.detail);
+    let channel = params
+        .as_str("channel")
+        .map(str::trim)
+        .filter(|channel| !channel.is_empty())
+        .map(str::to_string)
+        .unwrap_or_else(|| name.clone());
+
+    let before = terrain.detail.clone();
+    let index = before.len();
+    let mut after = before.clone();
+    after.push(DetailLayer {
+        name: name.clone(),
+        density_channel: channel.clone(),
+        ..DetailLayer::default()
+    });
+    let adopted = terrain
+        .channels
+        .iter()
+        .find(|declared| declared.name == channel);
+    let adopted_palette = adopted.is_some_and(|declared| !declared.palette.is_empty());
+    let missing_channel = adopted.is_none().then(|| channel.clone());
+    if adopted_palette {
+        warn_caller(
+            world,
+            format!(
+                "{id}: {channel:?} already carries a palette, and a detail brush ramps \
+                 its cells toward full cover rather than writing palette values"
+            ),
+        );
+    }
+
+    let span = world.resource_mut::<CommandHistory>().begin_span();
+    world.resource_scope(|world, mut history: Mut<CommandHistory>| {
+        history.execute(
+            Box::new(SetTerrainDetail {
+                entity,
+                before,
+                after,
+            }),
+            world,
+        );
+        if let Some(name) = missing_channel {
+            history.execute(Box::new(AddTerrainChannel { entity, name }), world);
+        }
+    });
+    world
+        .resource_mut::<CommandHistory>()
+        .end_span(span, "Add Detail Layer");
+    world.resource_mut::<TerrainPaintState>().detail_layer = index;
+    report_to_caller(world, format!("{id}: added layer {index} named {name:?}"));
+    OperatorResult::Finished
+}
+
+/// `wanted`, or the first `wanted-N` no layer already answers to.
+fn unique_layer_name(wanted: &str, layers: &[DetailLayer]) -> String {
+    let taken = |candidate: &str| layers.iter().any(|layer| layer.name == candidate);
+    if !taken(wanted) {
+        return wanted.to_string();
+    }
+    (1..)
+        .map(|n| format!("{wanted}-{n}"))
+        .find(|candidate| !taken(candidate))
+        .expect("the candidate space is unbounded")
+}
+
+/// Remove one detail layer, leaving the channel it grew from painted.
+#[operator(
+    id = "terrain.detail.remove",
+    label = "Remove Detail Layer",
+    description = "Remove a ground detail layer from a terrain.",
+    allows_undo = false,
+    params(
+        terrain(String, doc = "Name of the terrain entity. Defaults to the selection."),
+        layer(
+            String,
+            doc = "Which layer: its index, or its name when it is not an index. \
+                   Defaults to the selected layer."
+        ),
+    )
+)]
+pub(crate) fn terrain_detail_remove(
+    params: In<OperatorParameters>,
+    world: &mut World,
+) -> OperatorResult {
+    let params = params.0;
+    let id = "terrain.detail.remove";
+    let Some(entity) = detail_terrain(world, &params, id) else {
+        return OperatorResult::Cancelled;
+    };
+    let Some((index, _)) = resolve_layer(world, entity, &params, id) else {
+        return OperatorResult::Cancelled;
+    };
+    let Some(before) = world.get::<Terrain>(entity).map(|t| t.detail.clone()) else {
+        return OperatorResult::Cancelled;
+    };
+    let mut after = before.clone();
+    after.remove(index);
+    let left = after.len();
+
+    world.resource_scope(|world, mut history: Mut<CommandHistory>| {
+        history.execute(
+            Box::new(SetTerrainDetail {
+                entity,
+                before,
+                after,
+            }),
+            world,
+        );
+    });
+    let mut paint = world.resource_mut::<TerrainPaintState>();
+    // The selection follows the layer it was on: one earlier when that layer
+    // stood after the removed one, and onto the last layer when it was the
+    // removed one itself.
+    paint.detail_layer = match paint.detail_layer {
+        selected if selected > index => selected - 1,
+        selected => selected.min(left.saturating_sub(1)),
+    };
+    OperatorResult::Finished
+}
+
+/// Make a layer the one the brush paints and the panel edits.
+#[operator(
+    id = "terrain.detail.select",
+    label = "Select Detail Layer",
+    description = "Choose which detail layer the brush and the panel act on.",
+    allows_undo = false,
+    params(
+        terrain(String, doc = "Name of the terrain entity. Defaults to the selection."),
+        layer(
+            String,
+            doc = "Which layer: its index, or its name when it is not an index."
+        ),
+    )
+)]
+pub(crate) fn terrain_detail_select(
+    params: In<OperatorParameters>,
+    world: &mut World,
+) -> OperatorResult {
+    let params = params.0;
+    let id = "terrain.detail.select";
+    let Some(entity) = detail_terrain(world, &params, id) else {
+        return OperatorResult::Cancelled;
+    };
+    let Some((index, _)) = resolve_layer(world, entity, &params, id) else {
+        return OperatorResult::Cancelled;
+    };
+    world.resource_mut::<TerrainPaintState>().detail_layer = index;
+    OperatorResult::Finished
+}
+
+/// Write one field of one detail layer. Values are text: a number, `r,g,b` for
+/// a colour, `min,max` for a range, and `x,z` for a direction.
+#[operator(
+    id = "terrain.detail.set",
+    label = "Set Detail Layer",
+    description = "Set one field of a terrain's detail layer.",
+    allows_undo = false,
+    params(
+        terrain(String, doc = "Name of the terrain entity. Defaults to the selection."),
+        layer(
+            String,
+            doc = "Which layer: its index, or its name when it is not an index. \
+                   Defaults to the selected layer."
+        ),
+        field(
+            String,
+            doc = "Which field: name, density_channel, mesh, height, width, color_base, \
+                   color_tip, wind_speed, wind_strength, wind_vertical_strength, \
+                   wind_direction, wind_tile_size, bend, push_strength, push_radius, \
+                   density_per_m2, cull_distance or align_to_normal."
+        ),
+        value(
+            String,
+            doc = "The value: a number, a name, \"card\" or an assets-relative model path \
+                   for mesh, \"min,max\" for a range, \"x,z\" for wind_direction, or \
+                   \"r,g,b\" for a colour."
+        ),
+    )
+)]
+pub(crate) fn terrain_detail_set(
+    params: In<OperatorParameters>,
+    world: &mut World,
+) -> OperatorResult {
+    let params = params.0;
+    let id = "terrain.detail.set";
+    let Some(field) = params.as_str("field").map(str::to_string) else {
+        warn_caller(world, format!("{id}: field= is required"));
+        return OperatorResult::Cancelled;
+    };
+    let Some(value) = params.as_str("value").map(str::to_string) else {
+        warn_caller(world, format!("{id}: value= is required"));
+        return OperatorResult::Cancelled;
+    };
+    let Some(entity) = detail_terrain(world, &params, id) else {
+        return OperatorResult::Cancelled;
+    };
+    let Some((index, before_layer)) = resolve_layer(world, entity, &params, id) else {
+        return OperatorResult::Cancelled;
+    };
+
+    let mut after_layer = before_layer.clone();
+    if !write_field(&mut after_layer, &field, &value) {
+        warn_caller(
+            world,
+            format!("{id}: {field}= cannot take {value:?}; see the operator's field list"),
+        );
+        return OperatorResult::Cancelled;
+    }
+    if after_layer == before_layer {
+        return OperatorResult::Finished;
+    }
+    let undeclared = field == "density_channel"
+        && world.get::<Terrain>(entity).is_some_and(|terrain| {
+            !terrain
+                .channels
+                .iter()
+                .any(|declared| declared.name == after_layer.density_channel)
+        });
+    if undeclared {
+        warn_caller(
+            world,
+            format!(
+                "{id}: this terrain declares no {:?} channel, so the layer grows nothing \
+                 until one is added with terrain.channel.add",
+                after_layer.density_channel
+            ),
+        );
+    }
+    let Some(before) = world.get::<Terrain>(entity).map(|t| t.detail.clone()) else {
+        return OperatorResult::Cancelled;
+    };
+    let mut after = before.clone();
+    after[index] = after_layer;
+    world.resource_scope(|world, mut history: Mut<CommandHistory>| {
+        history.execute(
+            Box::new(SetTerrainDetail {
+                entity,
+                before,
+                after,
+            }),
+            world,
+        );
+    });
+    OperatorResult::Finished
+}
+
+/// Load the paint brush with one layer's density. Brush state, with no history
+/// entry of its own; the stroke it produces records one.
+#[operator(
+    id = "terrain.detail.paint",
+    label = "Paint Detail",
+    description = "Point the paint brush at a detail layer's density.",
+    allows_undo = false,
+    params(
+        terrain(String, doc = "Name of the terrain entity. Defaults to the selection."),
+        layer(
+            String,
+            doc = "Which layer: its index, or its name when it is not an index. \
+                   Defaults to the selected layer."
+        ),
+        opacity(
+            f64,
+            doc = "How far a cell crosses toward full cover per second at full brush \
+                   strength, 0..1. Defaults to what the bar is showing."
+        ),
+        erase(
+            bool,
+            doc = "Thin cells out rather than thicken them. Omit to flip the current \
+                   direction."
+        ),
+    )
+)]
+pub(crate) fn terrain_detail_paint(
+    params: In<OperatorParameters>,
+    world: &mut World,
+) -> OperatorResult {
+    let params = params.0;
+    let id = "terrain.detail.paint";
+    let Some(entity) = detail_terrain(world, &params, id) else {
+        return OperatorResult::Cancelled;
+    };
+    let Some((index, _)) = resolve_layer(world, entity, &params, id) else {
+        return OperatorResult::Cancelled;
+    };
+    let opacity = params.as_float("opacity");
+    let erase = params.as_bool("erase");
+    let mut paint = world.resource_mut::<TerrainPaintState>();
+    paint.domain = PaintDomain::Detail;
+    paint.detail_layer = index;
+    if let Some(opacity) = opacity {
+        paint.detail_opacity = (opacity as f32).clamp(0.01, 1.0);
+    }
+    paint.detail_erase = erase.unwrap_or(!paint.detail_erase);
+    OperatorResult::Finished
+}
+
+/// Thicken one layer's density once at a named place, as a released stroke
+/// would. Coordinates are terrain-local metres.
+#[operator(
+    id = "terrain.detail.stamp",
+    label = "Detail Stamp",
+    description = "Apply a detail layer's density brush once at a named place.",
+    allows_undo = false,
+    params(
+        terrain(String, doc = "Name of the terrain entity. Defaults to the selection."),
+        layer(
+            String,
+            doc = "Which layer: its index, or its name when it is not an index. \
+                   Defaults to the selected layer."
+        ),
+        x(f64, doc = "Terrain-local X of the stamp centre, in metres."),
+        z(f64, doc = "Terrain-local Z of the stamp centre, in metres."),
+        radius(f64, doc = "Brush radius in metres."),
+        opacity(
+            f64,
+            doc = "How far each cell crosses toward full cover, 0..1. Defaults to 1, \
+                   a full-strength stamp."
+        ),
+        hardness(
+            f64,
+            doc = "Fraction of the radius held at full strength before the falloff \
+                   starts, 0..1. Defaults to 0.5."
+        ),
+        falloff(
+            f64,
+            doc = "Edge falloff power: 1 is linear, 2 is quadratic. Defaults to 2."
+        ),
+        erase(bool, doc = "Thin the cells out rather than thicken them."),
+    )
+)]
+pub(crate) fn terrain_detail_stamp(
+    params: In<OperatorParameters>,
+    world: &mut World,
+) -> OperatorResult {
+    let params = params.0;
+    let id = "terrain.detail.stamp";
+    let Some(entity) = detail_terrain(world, &params, id) else {
+        return OperatorResult::Cancelled;
+    };
+    let Some((_, layer)) = resolve_layer(world, entity, &params, id) else {
+        return OperatorResult::Cancelled;
+    };
+    let Some(StampTarget {
+        entity: target,
+        terrain,
+        placement,
+        rect,
+        falloff,
+    }) = stamp_target(world, &params, id)
+    else {
+        return OperatorResult::Cancelled;
+    };
+    let opacity = params.as_float("opacity").unwrap_or(1.0) as f32;
+    let hardness = params.as_float("hardness").unwrap_or(0.5) as f32;
+    let erase = params.as_bool("erase").unwrap_or(false);
+
+    let outcome = world.resource_scope(|world, mut store: Mut<TerrainDataStore>| {
+        let Some(mut data) = store.entry_for(&terrain) else {
+            warn_caller(world, format!("{id}: the terrain has no document to write"));
+            return Stamped::Refused;
+        };
+        let Some(channel) = data
+            .channels()
+            .iter()
+            .position(|channel| channel.name == layer.density_channel)
+        else {
+            warn_caller(
+                world,
+                format!(
+                    "{id}: the terrain declares no {:?} channel for this layer to grow from",
+                    layer.density_channel
+                ),
+            );
+            return Stamped::Refused;
+        };
+        let Some(element) = data.channel_mut(channel).map(|channel| channel.element) else {
+            warn_caller(world, format!("{id}: the terrain has no document to write"));
+            return Stamped::Refused;
+        };
+        let before = data.channel_values(channel);
+        let mut values = before.clone();
+        // dt = 1.0, so `opacity` reads as an amount rather than a rate.
+        let changed = jackdaw_terrain::apply_density_brush(
+            &mut values,
+            placement.resolution,
+            element,
+            placement.center,
+            placement.radius_cells,
+            hardness,
+            falloff,
+            opacity,
+            1.0,
+            erase,
+        );
+        if changed == 0 {
+            return Stamped::Unchanged;
+        }
+        data.set_channel_values(channel, &values);
+        Stamped::Wrote {
+            channel,
+            before,
+            after: values,
+        }
+    });
+    let (channel, old_values, new_values) = match outcome {
+        Stamped::Refused => return OperatorResult::Cancelled,
+        Stamped::Unchanged => return OperatorResult::Finished,
+        Stamped::Wrote {
+            channel,
+            before,
+            after,
+        } => (channel, before, after),
+    };
+    mark_detail_dirty(world, target, rect);
+    world
+        .resource_mut::<CommandHistory>()
+        .push_executed(Box::new(SetTerrainChannel {
+            entity: target,
+            channel,
+            old_values,
+            new_values,
+            label: "Detail Stamp".to_string(),
+        }));
+    OperatorResult::Finished
+}
+
+/// What one detail stamp left behind.
+enum Stamped {
+    /// The terrain has no document, or no channel for the layer to grow from.
+    Refused,
+    /// The brush landed but moved no cell.
+    Unchanged,
+    Wrote {
+        channel: usize,
+        before: Vec<u16>,
+        after: Vec<u16>,
+    },
+}
+
+/// A scalar, a pair or a triple parsed out of `text`, or `None` when it is
+/// not `N` finite numbers separated by commas.
+fn numbers<const N: usize>(text: &str) -> Option<[f32; N]> {
+    let mut parsed = [0.0; N];
+    let mut parts = text.split(',');
+    for slot in parsed.iter_mut() {
+        let value: f32 = parts.next()?.trim().parse().ok()?;
+        if !value.is_finite() {
+            return None;
+        }
+        *slot = value;
+    }
+    parts.next().is_none().then_some(parsed)
+}
+
+/// Most instances a square metre may be asked for.
+const MAX_DENSITY_PER_M2: f32 = 512.0;
+
+/// Furthest detail may be asked to draw, in world units.
+const MAX_CULL_DISTANCE: f32 = 1000.0;
+
+/// Where an assets-relative path resolves on disk: the open project's assets
+/// directory, or `assets` beside the process.
+fn assets_dir() -> PathBuf {
+    crate::project::open_project_assets_dir().unwrap_or_else(|| PathBuf::from("assets"))
+}
+
+/// The mesh `value` names: `card`, or a model file that is really there.
+fn resolve_detail_mesh(value: &str) -> Option<DetailMesh> {
+    let value = value.trim();
+    if value.eq_ignore_ascii_case("card") {
+        return Some(DetailMesh::Card);
+    }
+    jackdaw_terrain::validate_scatter_asset(value).ok()?;
+    assets_dir()
+        .join(value)
+        .is_file()
+        .then(|| DetailMesh::Asset(value.to_string()))
+}
+
+/// Write one named field of a layer, reporting whether the name and the value
+/// were both understood.
+fn write_field(layer: &mut DetailLayer, field: &str, value: &str) -> bool {
+    match field {
+        "name" | "density_channel" => {
+            let trimmed = value.trim();
+            if trimmed.is_empty() {
+                return false;
+            }
+            if field == "name" {
+                layer.name = trimmed.to_string();
+            } else {
+                layer.density_channel = trimmed.to_string();
+            }
+        }
+        "mesh" => match resolve_detail_mesh(value) {
+            Some(mesh) => layer.mesh = mesh,
+            None => return false,
+        },
+        "align_to_normal" => match value.trim() {
+            "true" => layer.align_to_normal = true,
+            "false" => layer.align_to_normal = false,
+            _ => return false,
+        },
+        "height" | "width" => match numbers::<2>(value) {
+            // Stored low end first, so a range typed backwards is still a range.
+            Some([a, b]) if a >= 0.0 && b >= 0.0 => {
+                let range = [a.min(b), a.max(b)];
+                if field == "height" {
+                    layer.height = range;
+                } else {
+                    layer.width = range;
+                }
+            }
+            _ => return false,
+        },
+        "wind_direction" => match numbers::<2>(value) {
+            Some(pair) => layer.wind_direction = pair,
+            None => return false,
+        },
+        "color_base" | "color_tip" => match numbers::<3>(value) {
+            Some(rgb) => {
+                let rgb = rgb.map(|channel| channel.clamp(0.0, 1.0));
+                if field == "color_base" {
+                    layer.color_base = rgb;
+                } else {
+                    layer.color_tip = rgb;
+                }
+            }
+            None => return false,
+        },
+        _ => {
+            let Some([scalar]) = numbers::<1>(value) else {
+                return false;
+            };
+            match field {
+                "wind_speed" => layer.wind_speed = scalar,
+                "wind_strength" => layer.wind_strength = scalar,
+                "wind_vertical_strength" => layer.wind_vertical_strength = scalar,
+                "wind_tile_size" => layer.wind_tile_size = scalar.max(0.01),
+                "bend" => layer.bend = scalar,
+                "push_strength" => layer.push_strength = scalar,
+                "push_radius" => layer.push_radius = scalar.max(0.0),
+                "density_per_m2" => {
+                    layer.density_per_m2 = scalar.clamp(0.0, MAX_DENSITY_PER_M2);
+                }
+                "cull_distance" => layer.cull_distance = scalar.clamp(0.0, MAX_CULL_DISTANCE),
+                _ => return false,
+            }
+        }
+    }
+    true
+}
+
+/// One undo entry for a terrain's detail layers, whatever moved them.
+pub struct SetTerrainDetail {
+    pub entity: Entity,
+    pub before: Vec<DetailLayer>,
+    pub after: Vec<DetailLayer>,
+}
+
+impl SetTerrainDetail {
+    fn apply(&self, world: &mut World, detail: Vec<DetailLayer>) {
+        let Some(mut terrain) = world.get_mut::<Terrain>(self.entity) else {
+            return;
+        };
+        let left = detail.len();
+        terrain.detail = detail;
+        let terrain = terrain.clone();
+        // A shorter list would otherwise leave the brush and the panel
+        // pointing past the end.
+        let mut paint = world.resource_mut::<TerrainPaintState>();
+        paint.detail_layer = paint.detail_layer.min(left.saturating_sub(1));
+        crate::commands::sync_component_to_ast(
+            world,
+            self.entity,
+            "jackdaw_scene_types::types::Terrain",
+            &terrain,
+        );
+    }
+}
+
+impl EditorCommand for SetTerrainDetail {
+    fn execute(&mut self, world: &mut World) {
+        self.apply(world, self.after.clone());
+    }
+
+    fn undo(&mut self, world: &mut World) {
+        self.apply(world, self.before.clone());
+    }
+
+    fn description(&self) -> &str {
+        "Detail"
+    }
+}
+
+/// One undo entry for the density channel `terrain.detail.add` mints. Undo
+/// drops the descriptor; the store's reconcile drops the zeroed plane.
+struct AddTerrainChannel {
+    entity: Entity,
+    name: String,
+}
+
+impl EditorCommand for AddTerrainChannel {
+    fn execute(&mut self, world: &mut World) {
+        let Some(mut terrain) = world.get_mut::<Terrain>(self.entity) else {
+            return;
+        };
+        if terrain
+            .channels
+            .iter()
+            .any(|channel| channel.name == self.name)
+        {
+            return;
+        }
+        terrain.channels.push(TerrainChannel {
+            name: self.name.clone(),
+            element: TerrainChannelElement::U8,
+            // No palette: coverage is a continuous fraction of the ceiling.
+            palette: Vec::new(),
+        });
+        super::channel_ops::commit_channels(world, self.entity);
+    }
+
+    fn undo(&mut self, world: &mut World) {
+        let Some(mut terrain) = world.get_mut::<Terrain>(self.entity) else {
+            return;
+        };
+        let Some(at) = terrain
+            .channels
+            .iter()
+            .position(|channel| channel.name == self.name)
+        else {
+            return;
+        };
+        terrain.channels.remove(at);
+        super::channel_ops::commit_channels(world, self.entity);
+    }
+
+    fn description(&self) -> &str {
+        "Add Detail Density"
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn a_scalar_field_takes_a_number_and_refuses_anything_else() {
+        let mut layer = DetailLayer::default();
+        assert!(write_field(&mut layer, "cull_distance", "80"));
+        assert_eq!(layer.cull_distance, 80.0);
+        assert!(!write_field(&mut layer, "cull_distance", "far"));
+        assert!(!write_field(&mut layer, "cull_distance", "1,2"));
+        assert_eq!(layer.cull_distance, 80.0, "a refusal writes nothing");
+    }
+
+    #[test]
+    fn the_fields_a_frame_pays_for_are_capped() {
+        let mut layer = DetailLayer::default();
+        assert!(write_field(&mut layer, "density_per_m2", "1e9"));
+        assert_eq!(layer.density_per_m2, MAX_DENSITY_PER_M2);
+        assert!(write_field(&mut layer, "cull_distance", "1e9"));
+        assert_eq!(layer.cull_distance, MAX_CULL_DISTANCE);
+        assert!(!write_field(&mut layer, "density_per_m2", "inf"));
+    }
+
+    #[test]
+    fn an_unknown_field_is_refused() {
+        let mut layer = DetailLayer::default();
+        assert!(!write_field(&mut layer, "colour", "1,0,0"));
+        assert!(!write_field(&mut layer, "", "1"));
+    }
+
+    #[test]
+    fn a_range_is_stored_low_end_first() {
+        let mut layer = DetailLayer::default();
+        assert!(write_field(&mut layer, "height", "0.9, 0.2"));
+        assert_eq!(layer.height, [0.2, 0.9]);
+        assert!(write_field(&mut layer, "width", "0.4,0.1"));
+        assert_eq!(layer.width, [0.1, 0.4]);
+        assert!(!write_field(&mut layer, "height", "0.2"));
+        assert!(!write_field(&mut layer, "height", "-1,2"));
+    }
+
+    #[test]
+    fn a_colour_takes_three_channels_and_clamps_them() {
+        let mut layer = DetailLayer::default();
+        assert!(write_field(&mut layer, "color_tip", "0.5,2.0,-1"));
+        assert_eq!(layer.color_tip, [0.5, 1.0, 0.0]);
+        assert!(!write_field(&mut layer, "color_base", "0.5,0.5"));
+    }
+
+    #[test]
+    fn the_name_and_the_density_channel_take_a_name_but_not_an_empty_one() {
+        let mut layer = DetailLayer::default();
+        assert!(write_field(&mut layer, "name", " Meadow "));
+        assert_eq!(layer.name, "Meadow");
+        assert!(write_field(&mut layer, "density_channel", " meadow "));
+        assert_eq!(layer.density_channel, "meadow");
+        assert!(!write_field(&mut layer, "name", "  "));
+    }
+
+    #[test]
+    fn the_mesh_takes_the_card_and_refuses_a_file_that_is_not_there() {
+        let mut layer = DetailLayer::default();
+        assert!(write_field(&mut layer, "mesh", "card"));
+        assert_eq!(layer.mesh, DetailMesh::Card);
+        assert!(!write_field(&mut layer, "mesh", "models/absent.gltf"));
+        assert!(!write_field(&mut layer, "mesh", "../outside.gltf"));
+        assert!(!write_field(&mut layer, "mesh", "models/notamodel.txt"));
+        assert_eq!(layer.mesh, DetailMesh::Card, "a refusal writes nothing");
+    }
+
+    #[test]
+    fn aligning_to_the_normal_takes_only_a_bool() {
+        let mut layer = DetailLayer::default();
+        assert!(write_field(&mut layer, "align_to_normal", "true"));
+        assert!(layer.align_to_normal);
+        assert!(!write_field(&mut layer, "align_to_normal", "yes"));
+        assert!(layer.align_to_normal);
+    }
+}

--- a/src/terrain/mod.rs
+++ b/src/terrain/mod.rs
@@ -34,6 +34,8 @@ pub use palette::TerrainPalette;
 pub use regions::{RegionVisibility, TerrainRegionView};
 pub use store::TerrainDataStore;
 
+/// Terrain editing: sculpt, paint, scatter and detail, plus the projections
+/// the scatter and detail renderers rebuild from.
 pub struct TerrainPlugin;
 
 impl Plugin for TerrainPlugin {
@@ -55,9 +57,6 @@ impl Plugin for TerrainPlugin {
                     detail::sync_terrain_detail,
                 )
                     .chain()
-                    // The projections this writes are what the renderers
-                    // rebuild from, so they are written before the rebuilds
-                    // read them rather than a frame behind them.
                     .before(jackdaw_terrain::render::ScatterSystems::Rebuild)
                     .before(jackdaw_terrain::render::DetailSystems::Rebuild)
                     .run_if(in_state(crate::AppState::Editor)),

--- a/src/terrain/mod.rs
+++ b/src/terrain/mod.rs
@@ -1,5 +1,7 @@
 pub mod autoterrain_ops;
 pub mod channel_ops;
+pub mod detail;
+pub mod detail_ops;
 pub mod export;
 pub mod inspector;
 pub mod mesh;
@@ -50,17 +52,21 @@ impl Plugin for TerrainPlugin {
                     sync_terrain_bounds,
                     prune_terrain_heightmaps,
                     scatter_data::sync_terrain_scatter,
+                    detail::sync_terrain_detail,
                 )
                     .chain()
-                    // The projection this writes is what the renderer
-                    // rebuilds from, so it is written before the rebuild
-                    // reads it rather than a frame behind it.
+                    // The projections this writes are what the renderers
+                    // rebuild from, so they are written before the rebuilds
+                    // read them rather than a frame behind them.
                     .before(jackdaw_terrain::render::ScatterSystems::Rebuild)
+                    .before(jackdaw_terrain::render::DetailSystems::Rebuild)
                     .run_if(in_state(crate::AppState::Editor)),
             )
             .add_observer(scatter_data::hide_drawn_scatter)
+            .add_observer(detail::hide_drawn_detail)
             .add_plugins((
                 jackdaw_terrain::render::ScatterRenderPlugin,
+                jackdaw_terrain::render::DetailRenderPlugin,
                 mesh::plugin,
                 sculpt::plugin,
                 paint::plugin,

--- a/src/terrain/navmesh_bake.rs
+++ b/src/terrain/navmesh_bake.rs
@@ -476,13 +476,22 @@ impl SceneGeometry<'_, '_> {
     fn candidates(&self) -> impl Iterator<Item = (Entity, Affine3A, &Mesh3d)> + '_ {
         self.meshes
             .iter()
-            .filter(|(entity, _, _, body, sensor)| {
+            .filter(|(entity, _, handle, body, sensor)| {
                 // A body that moves is not ground, and nothing stands on a
                 // trigger volume. A collider with no body is static, like an
                 // unsimulated scene mesh.
-                !moves(*body) && sensor.is_none() && !self.hidden(*entity)
+                !moves(*body) && sensor.is_none() && !self.hidden(*entity) && self.readable(handle)
             })
             .map(|(entity, transform, handle, _, _)| (entity, transform.affine(), handle))
+    }
+
+    /// Whether this mesh can be read here: one extracted to the render world
+    /// panics on its attributes, and an unloaded handle counts as readable.
+    fn readable(&self, handle: &Mesh3d) -> bool {
+        self.assets.get(handle).is_none_or(|mesh| {
+            mesh.asset_usage
+                .contains(bevy::asset::RenderAssetUsages::MAIN_WORLD)
+        })
     }
 
     /// Every mesh that belongs in the bake, with where it stands.
@@ -3193,6 +3202,29 @@ mod tests {
             .run_system_cached(|geometry: SceneGeometry| geometry.placements().count())
             .expect("the geometry gather runs");
         assert_eq!(count, 0);
+    }
+
+    /// A mesh the render world owns cannot be read on the main world, and
+    /// reading its attributes there panics.
+    #[test]
+    fn a_render_only_mesh_is_left_out_of_the_staleness_hash() {
+        let dir = std::env::temp_dir().join(format!("jd_render_only_{}", std::process::id()));
+        std::fs::create_dir_all(&dir).expect("a place to write the artifact");
+        let mut world = world_with_terrain(&dir);
+        let mut built = Mesh::from(Cuboid::new(2.0, 2.0, 2.0));
+        built.asset_usage = bevy::asset::RenderAssetUsages::RENDER_WORLD;
+        let mesh = world.resource_mut::<Assets<Mesh>>().add(built);
+        world.spawn((
+            Mesh3d(mesh),
+            Transform::default(),
+            GlobalTransform::default(),
+        ));
+        world.flush();
+
+        let hashes = world
+            .run_system_cached(|geometry: SceneGeometry| geometry_hashes(geometry.placements()))
+            .expect("the geometry gather runs");
+        assert!(hashes.is_empty(), "the hash skips a mesh it cannot read");
     }
 
     #[test]

--- a/src/terrain/options_bar.rs
+++ b/src/terrain/options_bar.rs
@@ -94,6 +94,11 @@ struct RestoreAutoCheckbox;
 #[derive(Component)]
 struct NavmeshOverlayCheckbox;
 
+/// Tags the Detail bar's erase checkbox, same reasoning as
+/// [`QuantizationToggleCheckbox`].
+#[derive(Component)]
+struct DetailEraseCheckbox;
+
 /// Builds the options bar as a `bsn!` Scene. Starts empty and hidden
 /// (`Display::None`); content is rebuilt by `update_options_bar_content` from
 /// the active [`TerrainEditMode`].
@@ -153,6 +158,8 @@ enum TextureField {
     VariationSeed,
     VariationFrequency,
     VariationAmount,
+    /// How fast a detail stroke thickens the cells under it.
+    DetailOpacity,
 }
 
 /// Tags the Navmesh bar's agent chips. They describe the character a bake is
@@ -222,6 +229,11 @@ struct TextureBarSignature {
     /// Whether the brush is restoring rather than painting, so the bar rebuilds
     /// when an undo or a scripted call flips it.
     restore_auto: bool,
+    /// The same for the detail brush's erase checkbox.
+    detail_erase: bool,
+    /// Which detail layer the bar is naming, so it rebuilds when the selection
+    /// moves to another one.
+    detail_layer: usize,
 }
 
 fn update_options_bar_content(
@@ -275,6 +287,8 @@ fn update_options_bar_content(
             })
             .unwrap_or(0),
         restore_auto: paint_state.restore_auto,
+        detail_erase: paint_state.detail_erase,
+        detail_layer: paint_state.detail_layer,
     });
 
     let region_signature = (*edit_mode == TerrainEditMode::Regions).then(|| RegionBarSignature {
@@ -363,6 +377,15 @@ fn update_options_bar_content(
                     }
                     PaintDomain::Color => {
                         spawn_color_paint_bar(&mut commands, bar, &brush_settings, &paint_state);
+                    }
+                    PaintDomain::Detail => {
+                        spawn_detail_paint_bar(
+                            &mut commands,
+                            bar,
+                            &brush_settings,
+                            &paint_state,
+                            terrain.as_ref(),
+                        );
                     }
                 }
             }
@@ -500,6 +523,7 @@ fn spawn_paint_target_picker(commands: &mut Commands, parent: Entity, domain: Pa
         PaintDomain::Channels => 0,
         PaintDomain::Textures => 1,
         PaintDomain::Color => 2,
+        PaintDomain::Detail => 3,
     };
     commands
         .spawn((
@@ -508,6 +532,7 @@ fn spawn_paint_target_picker(commands: &mut Commands, parent: Entity, domain: Pa
                     "Scatter Masks".to_string(),
                     "Textures".to_string(),
                     "Color".to_string(),
+                    "Detail".to_string(),
                 ],
                 selected,
             ),
@@ -517,6 +542,7 @@ fn spawn_paint_target_picker(commands: &mut Commands, parent: Entity, domain: Pa
             let target = match event.selected {
                 1 => "textures",
                 2 => "color",
+                3 => "detail",
                 _ => "channels",
             };
             commands
@@ -658,6 +684,67 @@ fn spawn_color_paint_bar(
         ),
         ChildOf(parent),
     ));
+}
+
+/// The Detail-mode bar: which layer the brush is loaded with, the brush's
+/// shape, how fast it thickens a cell, and whether it is thinning cells out.
+fn spawn_detail_paint_bar(
+    commands: &mut Commands,
+    parent: Entity,
+    brush: &TerrainBrushSettings,
+    paint: &TerrainPaintState,
+    terrain: Option<&jackdaw_scene_types::Terrain>,
+) {
+    let Some(layer) = terrain.and_then(|terrain| {
+        let index = super::detail::selected_detail_layer(terrain, paint.detail_layer)?;
+        terrain.detail.get(index)
+    }) else {
+        spawn_hint(
+            commands,
+            parent,
+            "This terrain has no detail layer selected. Add one in the Terrain panel's \
+             Detail tab.",
+        );
+        return;
+    };
+    spawn_hint(commands, parent, &format!("Layer: {}", layer.name));
+    spawn_scrub_chip(
+        commands,
+        parent,
+        "Radius",
+        "Area of effect for the brush",
+        brush.radius,
+        0.1..50.0,
+        FieldKind::Continuous,
+        BrushField::Radius,
+    );
+    spawn_scrub_chip(
+        commands,
+        parent,
+        "Falloff",
+        "Brush edge softness (1=linear, 2=smooth)",
+        brush.falloff,
+        0.1..8.0,
+        FieldKind::Continuous,
+        BrushField::Falloff,
+    );
+    spawn_scrub_chip(
+        commands,
+        parent,
+        "Opacity",
+        "How far a cell crosses toward full cover per second at full brush strength",
+        paint.detail_opacity,
+        0.01..1.0,
+        FieldKind::Continuous,
+        TextureField::DetailOpacity,
+    );
+    spawn_checkbox(
+        commands,
+        parent,
+        "Erase",
+        paint.detail_erase,
+        DetailEraseCheckbox,
+    );
 }
 
 /// The Texture-mode bar: brush radius and falloff, opacity, which texture is
@@ -1080,6 +1167,9 @@ fn on_scrub_value_change(
             TextureField::VariationAmount => {
                 paint_state.variation_amount = event.value.clamp(0.0, 1.0);
             }
+            TextureField::DetailOpacity => {
+                paint_state.detail_opacity = event.value.clamp(0.01, 1.0);
+            }
         }
         return;
     }
@@ -1130,6 +1220,7 @@ fn on_terrain_checkbox_value_change(
     show_painted_values: Query<(), With<ShowPaintedValuesCheckbox>>,
     region_grid: Query<(), With<RegionGridCheckbox>>,
     restore_auto: Query<(), With<RestoreAutoCheckbox>>,
+    detail_erase: Query<(), With<DetailEraseCheckbox>>,
     navmesh_overlay: Query<(), With<NavmeshOverlayCheckbox>>,
     mut commands: Commands,
 ) {
@@ -1142,6 +1233,8 @@ fn on_terrain_checkbox_value_change(
         crate::terrain::regions::TerrainRegionToggleGridOp::ID
     } else if restore_auto.contains(target) {
         crate::terrain::texture_ops::TerrainPaintRestoreOp::ID
+    } else if detail_erase.contains(target) {
+        crate::terrain::detail_ops::TerrainDetailPaintOp::ID
     } else if navmesh_overlay.contains(target) {
         crate::terrain::navmesh_bake::TerrainNavmeshToggleOverlayOp::ID
     } else {
@@ -1220,6 +1313,7 @@ fn sync_texture_opacity_field(
                 TextureField::VariationSeed => paint_state.variation_seed as f32,
                 TextureField::VariationFrequency => paint_state.variation_frequency,
                 TextureField::VariationAmount => paint_state.variation_amount,
+                TextureField::DetailOpacity => paint_state.detail_opacity,
             };
             (entity, value)
         })
@@ -1277,6 +1371,8 @@ mod tests {
                 base_material: None,
                 thumbnails_ready: 0,
                 restore_auto: false,
+                detail_erase: false,
+                detail_layer: 0,
             }),
             region_signature: None,
             navmesh_signature: None,

--- a/src/terrain/paint.rs
+++ b/src/terrain/paint.rs
@@ -217,15 +217,14 @@ impl SetTerrainChannel {
         if let Some(mut dirty) = world.get_mut::<TerrainDirtyChunks>(self.entity) {
             dirty.rebuild_all = true;
         }
-        // The entry holds two whole-channel copies, so the mark is narrowed
-        // to the cells that differ.
-        if terrain.detail.iter().any(|layer| {
+        let channel_grows_detail = terrain.detail.iter().any(|layer| {
             terrain
                 .channels
                 .iter()
                 .position(|channel| channel.name == layer.density_channel)
                 == Some(self.channel)
-        }) {
+        });
+        if channel_grows_detail {
             let resolution = world
                 .resource::<TerrainDataStore>()
                 .grid_shape(&terrain)
@@ -863,8 +862,6 @@ pub fn terrain_paint(
             if super::stroke_should_end(&mouse) {
                 paint_state.active = false;
                 paint_state.detail_disc = None;
-                // The whole stroke once it is over, in case the renderer took
-                // a mark before those cells reached the projection.
                 if let Some(rect) = paint_state.stroke_detail_rect.take()
                     && let Some(mut detail_dirty) = detail_dirty
                 {
@@ -904,14 +901,12 @@ pub fn terrain_paint(
                         Some(grown) => grown.union(rect),
                         None => rect,
                     });
-                    // This frame's disc and the last one's, not the stroke so
-                    // far: the renderer retires every tile a mark covers.
-                    let mark = match paint_state.detail_disc.replace(rect) {
+                    let this_disc_and_the_last = match paint_state.detail_disc.replace(rect) {
                         Some(last) => last.union(rect),
                         None => rect,
                     };
                     if let Some(mut detail_dirty) = detail_dirty {
-                        detail_dirty.touch(mark);
+                        detail_dirty.touch(this_disc_and_the_last);
                     }
                 }
             }
@@ -928,6 +923,8 @@ const DETAIL_HARDNESS: f32 = 0.5;
 /// ring's half-intensity contour.
 const PAINT_THRESHOLD: f32 = 0.5;
 
+/// End a stroke that was abandoned, marking the ground it grew so that the
+/// detail standing on those cells is reseeded.
 fn cancel_terrain_paint(
     mut paint_state: ResMut<TerrainPaintState>,
     mut terrain_query: Query<(&jackdaw_scene_types::Terrain, &mut TerrainDirtyChunks)>,
@@ -940,8 +937,6 @@ fn cancel_terrain_paint(
     paint_state.active = false;
     paint_state.detail_disc = None;
 
-    // What an abandoned stroke grew stands until the ground under it is
-    // marked.
     if let Some(rect) = paint_state.stroke_detail_rect.take()
         && let Some(target) = paint_state.target
         && let Ok(mut dirty) = detail_dirty.get_mut(target)

--- a/src/terrain/paint.rs
+++ b/src/terrain/paint.rs
@@ -18,9 +18,13 @@
 //! [`PaintDomain::Color`] is the tint layer the splat material multiplies its
 //! albedo by. It accumulates like the texture brush, and Ctrl paints white,
 //! the layer's identity and so its eraser.
+//!
+//! [`PaintDomain::Detail`] is the coverage channel one detail layer grows from.
+//! The brush eases cells toward its ceiling; Ctrl or Erase walks them to zero.
 
 use bevy::prelude::*;
 use jackdaw_api::prelude::*;
+use jackdaw_terrain::render::DetailDirty;
 use jackdaw_terrain::{Control, GridRect};
 
 use super::{
@@ -57,6 +61,7 @@ pub enum PaintDomain {
     Channels,
     Textures,
     Color,
+    Detail,
 }
 
 /// Which channel/value or texture/opacity the paint brush writes, and
@@ -109,6 +114,20 @@ pub struct TerrainPaintState {
     pub variation_frequency: f32,
     /// How far a channel travels from white in that wash, `0.0..=1.0`.
     pub variation_amount: f32,
+    /// Which detail layer the brush paints and the panel edits.
+    pub detail_layer: usize,
+    /// How far a cell crosses toward full detail cover per second at full brush
+    /// strength, `0.0..=1.0`, scaled by falloff and frame `dt`.
+    pub detail_opacity: f32,
+    /// Whether the detail brush thins cells out rather than thickening them.
+    /// Ctrl does the same for one stroke.
+    pub detail_erase: bool,
+    /// The ground a detail stroke has covered so far, marked for a reseed when
+    /// the stroke is released or abandoned.
+    pub stroke_detail_rect: Option<GridRect>,
+    /// The disc the previous frame of that stroke wrote, which the next
+    /// frame's mark is widened by.
+    pub detail_disc: Option<GridRect>,
     /// Whether the brush hands cells back to autoterrain instead of
     /// painting a texture into them. The paint bar's Restore Auto
     /// checkbox switches this.
@@ -143,6 +162,11 @@ impl Default for TerrainPaintState {
             variation_seed: 0,
             variation_frequency: 0.01,
             variation_amount: 0.15,
+            detail_layer: 0,
+            detail_opacity: 0.5,
+            detail_erase: false,
+            stroke_detail_rect: None,
+            detail_disc: None,
             restore_auto: false,
             stroke_restores: false,
         }
@@ -192,6 +216,23 @@ impl SetTerrainChannel {
         }
         if let Some(mut dirty) = world.get_mut::<TerrainDirtyChunks>(self.entity) {
             dirty.rebuild_all = true;
+        }
+        // The entry holds two whole-channel copies, so the mark is narrowed
+        // to the cells that differ.
+        if terrain.detail.iter().any(|layer| {
+            terrain
+                .channels
+                .iter()
+                .position(|channel| channel.name == layer.density_channel)
+                == Some(self.channel)
+        }) {
+            let resolution = world
+                .resource::<TerrainDataStore>()
+                .grid_shape(&terrain)
+                .resolution;
+            if let Some(rect) = changed_rect(&self.old_values, &self.new_values, resolution) {
+                super::detail::mark_detail_dirty(world, self.entity, rect);
+            }
         }
     }
 }
@@ -567,7 +608,11 @@ pub fn terrain_paint(
     edit_mode: Res<TerrainEditMode>,
     brush_settings: Res<TerrainBrushSettings>,
     mut paint_state: ResMut<TerrainPaintState>,
-    mut terrain_query: Query<(&jackdaw_scene_types::Terrain, &mut TerrainDirtyChunks)>,
+    mut terrain_query: Query<(
+        &jackdaw_scene_types::Terrain,
+        &mut TerrainDirtyChunks,
+        Option<&mut DetailDirty>,
+    )>,
     mut store: ResMut<TerrainDataStore>,
     mut history: ResMut<CommandHistory>,
     time: Res<Time>,
@@ -580,7 +625,7 @@ pub fn terrain_paint(
 
     match paint_state.domain {
         PaintDomain::Channels => {
-            let (terrain, mut dirty) = terrain_query.get_mut(target)?;
+            let (terrain, mut dirty, _) = terrain_query.get_mut(target)?;
             let terrain = terrain.clone();
 
             let erase = keyboard.any_pressed([KeyCode::ControlLeft, KeyCode::ControlRight]);
@@ -652,7 +697,7 @@ pub fn terrain_paint(
             OperatorResult::Running
         }
         PaintDomain::Textures => {
-            let (terrain, _dirty) = terrain_query.get_mut(target)?;
+            let (terrain, _dirty, _) = terrain_query.get_mut(target)?;
             let terrain = terrain.clone();
             // The stroke lands on the cells the terrain holds, so the brush
             // reaches wherever ground has been allocated.
@@ -736,7 +781,7 @@ pub fn terrain_paint(
             OperatorResult::Running
         }
         PaintDomain::Color => {
-            let (terrain, _dirty) = terrain_query.get_mut(target)?;
+            let (terrain, _dirty, _) = terrain_query.get_mut(target)?;
             let terrain = terrain.clone();
             let resolution = store.grid_shape(&terrain).resolution;
             // Ctrl paints white, the layer's identity, so the eraser is
@@ -790,8 +835,93 @@ pub fn terrain_paint(
             }
             OperatorResult::Running
         }
+        PaintDomain::Detail => {
+            let (terrain, _dirty, detail_dirty) = terrain_query.get_mut(target)?;
+            let terrain = terrain.clone();
+            let index = super::detail::selected_detail_layer(&terrain, paint_state.detail_layer)?;
+            let layer = terrain.detail[index].clone();
+            let erase = paint_state.detail_erase
+                || keyboard.any_pressed([KeyCode::ControlLeft, KeyCode::ControlRight]);
+
+            let mut data = store.entry_for(&terrain)?;
+            let channel_index = data
+                .channels()
+                .iter()
+                .position(|channel| channel.name == layer.density_channel)?;
+            let element = data.channel_mut(channel_index)?.element;
+            let resolution = data.document().grid_resolution();
+            let mut values = data.channel_values(channel_index);
+
+            if !active.is_modal_running() {
+                paint_state.active = true;
+                paint_state.stroke_channel = channel_index;
+                paint_state.stroke_snapshot = values.clone();
+                paint_state.stroke_detail_rect = None;
+                paint_state.detail_disc = None;
+            }
+
+            if super::stroke_should_end(&mouse) {
+                paint_state.active = false;
+                paint_state.detail_disc = None;
+                // The whole stroke once it is over, in case the renderer took
+                // a mark before those cells reached the projection.
+                if let Some(rect) = paint_state.stroke_detail_rect.take()
+                    && let Some(mut detail_dirty) = detail_dirty
+                {
+                    detail_dirty.touch(rect);
+                }
+                let old_values = std::mem::take(&mut paint_state.stroke_snapshot);
+                if old_values != values {
+                    history.push_executed(Box::new(SetTerrainChannel {
+                        entity: target,
+                        channel: channel_index,
+                        old_values,
+                        new_values: values.clone(),
+                        label: "Paint Detail".to_string(),
+                    }));
+                }
+                return OperatorResult::Finished;
+            }
+
+            if let Some(grid_pos) = paint_state.brush_position
+                && let Some(rect) = GridRect::brush(resolution, grid_pos, brush_settings.radius)
+            {
+                let changed = jackdaw_terrain::apply_density_brush(
+                    &mut values,
+                    resolution,
+                    element,
+                    grid_pos,
+                    brush_settings.radius,
+                    DETAIL_HARDNESS,
+                    brush_settings.falloff,
+                    paint_state.detail_opacity,
+                    time.delta_secs(),
+                    erase,
+                );
+                if changed > 0 {
+                    data.set_channel_values(channel_index, &values);
+                    paint_state.stroke_detail_rect = Some(match paint_state.stroke_detail_rect {
+                        Some(grown) => grown.union(rect),
+                        None => rect,
+                    });
+                    // This frame's disc and the last one's, not the stroke so
+                    // far: the renderer retires every tile a mark covers.
+                    let mark = match paint_state.detail_disc.replace(rect) {
+                        Some(last) => last.union(rect),
+                        None => rect,
+                    };
+                    if let Some(mut detail_dirty) = detail_dirty {
+                        detail_dirty.touch(mark);
+                    }
+                }
+            }
+            OperatorResult::Running
+        }
     }
 }
+
+/// Fraction of the detail brush held at full strength before the falloff starts.
+const DETAIL_HARDNESS: f32 = 0.5;
 
 /// Falloff a cell must clear to be written. Integer channels cannot blend,
 /// so the brush edge needs a hard cutoff; half-strength matches the visible
@@ -801,12 +931,23 @@ const PAINT_THRESHOLD: f32 = 0.5;
 fn cancel_terrain_paint(
     mut paint_state: ResMut<TerrainPaintState>,
     mut terrain_query: Query<(&jackdaw_scene_types::Terrain, &mut TerrainDirtyChunks)>,
+    mut detail_dirty: Query<&mut DetailDirty>,
     mut store: ResMut<TerrainDataStore>,
 ) {
     if !paint_state.active {
         return;
     }
     paint_state.active = false;
+    paint_state.detail_disc = None;
+
+    // What an abandoned stroke grew stands until the ground under it is
+    // marked.
+    if let Some(rect) = paint_state.stroke_detail_rect.take()
+        && let Some(target) = paint_state.target
+        && let Ok(mut dirty) = detail_dirty.get_mut(target)
+    {
+        dirty.touch(rect);
+    }
 
     if paint_state.domain == PaintDomain::Color {
         let snapshot = std::mem::take(&mut paint_state.stroke_color_snapshot);

--- a/src/terrain/panel.rs
+++ b/src/terrain/panel.rs
@@ -1,8 +1,10 @@
-//! The dockable "Terrain" panel: Textures, Scatter and Generation sections.
+//! The dockable "Terrain" panel: Textures, Scatter, Detail and Generation
+//! sections.
 //!
 //! Separate from the Components inspector so PCG and authoring parameters live
 //! with the feature they configure rather than the object they act on.
 
+use bevy::picking::hover::Hovered;
 use bevy::prelude::*;
 use bevy::ui::Checked;
 use bevy::ui_widgets::{SliderValue, ValueChange};
@@ -14,12 +16,17 @@ use jackdaw_feathers::{
     number_input::ScrubNumberInputValue,
     panel_card::PanelCardCollapseState,
     tab_strip::{self, TabStripItem, TabStripOrientation},
+    text_edit::{TextEditCommitEvent, TextEditProps, text_edit},
     tokens,
+    tooltip::Tooltip,
 };
 
 use super::autoterrain_ops::{
     TerrainAutoterrainBaseOp, TerrainAutoterrainEnableOp, TerrainAutoterrainRangeOp,
     TerrainAutoterrainSlopeOp,
+};
+use super::detail_ops::{
+    TerrainDetailAddOp, TerrainDetailRemoveOp, TerrainDetailSelectOp, TerrainDetailSetOp,
 };
 use super::ops::{TerrainErodeOp, TerrainGenerateOp};
 use super::shape_ops::{MAX_CELL_SIZE, MIN_CELL_SIZE, clamp_cell_size, commit_shape};
@@ -64,7 +71,10 @@ pub(super) fn plugin(app: &mut App) {
         .add_observer(on_material_detile_change)
         .add_observer(on_autoterrain_slider_change)
         .add_observer(on_autoterrain_checkbox_change)
-        .add_observer(on_ground_slider_change);
+        .add_observer(on_ground_slider_change)
+        .add_observer(on_detail_slider_change)
+        .add_observer(on_detail_checkbox_change)
+        .add_observer(on_detail_text_commit);
 }
 
 pub(crate) fn add_to_extension(ctx: &mut ExtensionContext) {
@@ -79,12 +89,13 @@ pub(crate) fn add_to_extension(ctx: &mut ExtensionContext) {
 #[operator(
     id = "terrain.panel.tab",
     label = "Terrain Panel Tab",
-    description = "Switch the Terrain panel between its Textures, Scatter and Generation \
-                   sections.",
+    description = "Switch the Terrain panel between its Textures, Scatter, Detail and \
+                   Generation sections.",
     params(tab(
         String,
         default = "scatter",
-        doc = "Which section to show: \"textures\", \"scatter\" or \"generation\"."
+        doc = "Which section to show: \"textures\", \"scatter\", \"detail\" or \
+               \"generation\"."
     ),),
     allows_undo = false
 )]
@@ -96,6 +107,7 @@ pub(crate) fn terrain_panel_tab(
     *tab = match tab_str {
         "textures" => TerrainPanelTab::Textures,
         "generation" => TerrainPanelTab::Generation,
+        "detail" => TerrainPanelTab::Detail,
         "scatter" => TerrainPanelTab::Scatter,
         other => {
             warn!("terrain.panel.tab: unrecognized tab \"{other}\", falling back to \"scatter\"");
@@ -118,6 +130,7 @@ enum TerrainPanelTab {
     Textures,
     #[default]
     Scatter,
+    Detail,
     Generation,
 }
 
@@ -209,6 +222,9 @@ struct PanelState {
     tab: TerrainPanelTab,
     scatter_signature: Option<super::scatter::ScatterSignature>,
     textures_signature: Option<TexturesSignature>,
+    /// The layer list, and which of them the Detail tab is showing. The dials
+    /// dragged on the selected layer are left out, as the tiling values are.
+    detail_signature: Option<DetailSignature>,
     /// The selected terrain's vertex grid. In the signature because it changes
     /// only through the Shape section's combobox, a discrete pick. The extent
     /// beside it is absent, arriving from a scrub drag that a rebuild would
@@ -322,11 +338,17 @@ fn update_terrain_panel_content(
         .flatten()
         .map(|terrain| textures_signature(&terrain.data_path, &textures));
 
+    let detail_signature = (*tab == TerrainPanelTab::Detail)
+        .then(|| terrain_entity.and_then(|e| terrain_data.get(e).ok()))
+        .flatten()
+        .map(|terrain| detail_signature(terrain, textures.paint.detail_layer));
+
     let state = PanelState {
         terrain_entity,
         tab: *tab,
         scatter_signature,
         textures_signature,
+        detail_signature,
         resolution: terrain_entity
             .and_then(|e| terrain_data.get(e).ok())
             .map(|terrain| store.grid_shape(terrain).resolution),
@@ -351,6 +373,7 @@ fn update_terrain_panel_content(
             [
                 TabStripItem::new("Textures", *tab == TerrainPanelTab::Textures, "textures"),
                 TabStripItem::new("Scatter", *tab == TerrainPanelTab::Scatter, "scatter"),
+                TabStripItem::new("Detail", *tab == TerrainPanelTab::Detail, "detail"),
                 TabStripItem::new(
                     "Generation",
                     *tab == TerrainPanelTab::Generation,
@@ -402,6 +425,16 @@ fn update_terrain_panel_content(
                         view,
                     );
                 }
+            }
+            TerrainPanelTab::Detail => {
+                let terrain = terrain_data.get(terrain_entity_id).ok().cloned();
+                spawn_detail_sections(
+                    &mut commands,
+                    body,
+                    terrain.as_ref(),
+                    textures.paint.detail_layer,
+                    &textures,
+                );
             }
             TerrainPanelTab::Generation => {
                 spawn_generation_section(&mut commands, body, &gen_state);
@@ -698,6 +731,613 @@ fn spawn_ground_section(
         FieldKind::Continuous,
         GroundField::TintStrength,
     );
+}
+
+const DETAIL_SECTION: MaterialSection =
+    MaterialSection::new("Detail", Icon::Sprout, "terrain.detail.layers", false);
+const DETAIL_WIND_SECTION: MaterialSection =
+    MaterialSection::new("Wind", Icon::Wind, "terrain.detail.wind", false);
+const DETAIL_PUSH_SECTION: MaterialSection =
+    MaterialSection::new("Bend", Icon::Waves, "terrain.detail.push", true);
+
+/// What the Detail tab rebuilds for: the layer list, which one is selected,
+/// and the two of its fields that are not dragged.
+#[derive(PartialEq, Clone, Debug)]
+struct DetailSignature {
+    layers: Vec<String>,
+    selected: usize,
+    mesh: String,
+    align_to_normal: bool,
+}
+
+fn detail_signature(terrain: &jackdaw_scene_types::Terrain, selected: usize) -> DetailSignature {
+    let selected = super::detail::selected_detail_layer(terrain, selected).unwrap_or(0);
+    let layer = terrain.detail.get(selected);
+    DetailSignature {
+        layers: terrain
+            .detail
+            .iter()
+            .map(|layer| layer.name.clone())
+            .collect(),
+        selected,
+        mesh: layer.map(mesh_text).unwrap_or_default(),
+        align_to_normal: layer.is_some_and(|layer| layer.align_to_normal),
+    }
+}
+
+/// How a layer's mesh reads in the panel, and what `terrain.detail.set` takes
+/// back.
+fn mesh_text(layer: &jackdaw_scene_types::DetailLayer) -> String {
+    match &layer.mesh {
+        jackdaw_scene_types::DetailMesh::Card => "card".to_string(),
+        jackdaw_scene_types::DetailMesh::Asset(path) => path.clone(),
+    }
+}
+
+/// Which field of the selected layer a slider row drives. A pair field has a
+/// row per component, and one row writes the pair whole.
+#[derive(Component, Clone, Copy)]
+enum DetailField {
+    HeightMin,
+    HeightMax,
+    WidthMin,
+    WidthMax,
+    DensityPerM2,
+    CullDistance,
+    WindSpeed,
+    WindStrength,
+    WindVerticalStrength,
+    WindDirectionX,
+    WindDirectionZ,
+    WindTileSize,
+    Bend,
+    PushStrength,
+    PushRadius,
+}
+
+impl DetailField {
+    /// The field name `terrain.detail.set` knows this row by.
+    fn param(self) -> &'static str {
+        match self {
+            Self::HeightMin | Self::HeightMax => "height",
+            Self::WidthMin | Self::WidthMax => "width",
+            Self::DensityPerM2 => "density_per_m2",
+            Self::CullDistance => "cull_distance",
+            Self::WindSpeed => "wind_speed",
+            Self::WindStrength => "wind_strength",
+            Self::WindVerticalStrength => "wind_vertical_strength",
+            Self::WindDirectionX | Self::WindDirectionZ => "wind_direction",
+            Self::WindTileSize => "wind_tile_size",
+            Self::Bend => "bend",
+            Self::PushStrength => "push_strength",
+            Self::PushRadius => "push_radius",
+        }
+    }
+
+    /// What this row sends, given the value it was dragged to and the layer it
+    /// is editing: a pair row keeps the component it does not drive.
+    fn value(self, dragged: f32, layer: &jackdaw_scene_types::DetailLayer) -> String {
+        match self {
+            Self::HeightMin => format!("{dragged},{}", layer.height[1]),
+            Self::HeightMax => format!("{},{dragged}", layer.height[0]),
+            Self::WidthMin => format!("{dragged},{}", layer.width[1]),
+            Self::WidthMax => format!("{},{dragged}", layer.width[0]),
+            Self::WindDirectionX => format!("{dragged},{}", layer.wind_direction[1]),
+            Self::WindDirectionZ => format!("{},{dragged}", layer.wind_direction[0]),
+            _ => dragged.to_string(),
+        }
+    }
+}
+
+/// Which text field of the selected layer a `text_edit` commits into.
+#[derive(Component, Clone, Copy)]
+struct DetailTextField(&'static str);
+
+/// Tags the Detail section's align checkbox so its commit handler can tell it
+/// from every other checkbox in the editor.
+#[derive(Component)]
+struct DetailAlignCheckbox;
+
+/// The Detail tab: the layers this terrain scatters, and what the selected one
+/// draws. Where a layer grows is painted with the paint tool's Detail brush.
+fn spawn_detail_sections(
+    commands: &mut Commands,
+    parent: Entity,
+    terrain: Option<&jackdaw_scene_types::Terrain>,
+    selected: usize,
+    refs: &TexturesTabRefs,
+) {
+    let icon_font = refs.icon_font.0.clone();
+    let section = spawn_section(commands, parent, DETAIL_SECTION, &icon_font, &refs.collapse);
+    let layers = terrain
+        .map(|terrain| terrain.detail.as_slice())
+        .unwrap_or(&[]);
+    let selected = selected.min(layers.len().saturating_sub(1));
+    spawn_action_header(
+        commands,
+        section.body,
+        ActionHeaderProps {
+            name: format!("Layers ({})", layers.len()),
+            saved: true,
+            italic_font: &refs.italic_font.0,
+            icon_font: &icon_font,
+            actions: layer_actions(selected),
+        },
+    );
+    for (index, layer) in layers.iter().enumerate() {
+        spawn_detail_layer_row(commands, section.body, index, layer, index == selected);
+    }
+
+    let Some(layer) = layers.get(selected) else {
+        spawn_hint(
+            commands,
+            section.body,
+            "Add a layer to scatter grass, flowers or pebbles over this terrain. \
+             Each layer grows from a density channel painted with the paint tool's \
+             Detail brush.",
+        );
+        return;
+    };
+    spawn_hint(
+        commands,
+        section.body,
+        &format!(
+            "Grown from the {:?} channel. Paint it with the paint tool's Detail brush.",
+            layer.density_channel
+        ),
+    );
+    spawn_detail_text_row(
+        commands,
+        section.body,
+        "Name",
+        &layer.name,
+        DetailTextField("name"),
+    );
+    spawn_detail_text_row(
+        commands,
+        section.body,
+        "Mesh",
+        &mesh_text(layer),
+        DetailTextField("mesh"),
+    );
+    spawn_hint(
+        commands,
+        section.body,
+        "\"card\" is the built-in blade; anything else is a model below the assets \
+         directory.",
+    );
+    spawn_checkbox(
+        commands,
+        section.body,
+        "Align to ground",
+        layer.align_to_normal,
+        DetailAlignCheckbox,
+    );
+
+    spawn_detail_row(
+        commands,
+        section.body,
+        "Shortest",
+        "How tall the shortest instance on this layer stands, in metres",
+        layer.height[0],
+        0.02..3.0,
+        DetailField::HeightMin,
+    );
+    spawn_detail_row(
+        commands,
+        section.body,
+        "Tallest",
+        "How tall the tallest stands. Each instance takes a height between the two \
+         from the placement noise",
+        layer.height[1],
+        0.02..3.0,
+        DetailField::HeightMax,
+    );
+    spawn_detail_row(
+        commands,
+        section.body,
+        "Narrowest",
+        "How wide the narrowest instance is drawn, over the mesh's own width",
+        layer.width[0],
+        0.005..2.0,
+        DetailField::WidthMin,
+    );
+    spawn_detail_row(
+        commands,
+        section.body,
+        "Widest",
+        "How wide the widest is drawn, over the mesh's own width",
+        layer.width[1],
+        0.005..2.0,
+        DetailField::WidthMax,
+    );
+    spawn_detail_row(
+        commands,
+        section.body,
+        "Per m2",
+        "How many instances a cell at full density grows per square metre",
+        layer.density_per_m2,
+        1.0..120.0,
+        DetailField::DensityPerM2,
+    );
+    spawn_detail_row(
+        commands,
+        section.body,
+        "Cull distance",
+        "How far from the camera this layer draws, in metres",
+        layer.cull_distance,
+        5.0..200.0,
+        DetailField::CullDistance,
+    );
+    spawn_detail_color(
+        commands,
+        section.body,
+        "Base colour",
+        "The colour at the foot of an instance, where the field reads as shadow",
+        layer.color_base,
+        "color_base",
+    );
+    spawn_detail_color(
+        commands,
+        section.body,
+        "Tip colour",
+        "The colour at the top of an instance, which is most of what the field reads as",
+        layer.color_tip,
+        "color_tip",
+    );
+
+    let wind = spawn_section(
+        commands,
+        parent,
+        DETAIL_WIND_SECTION,
+        &icon_font,
+        &refs.collapse,
+    );
+    spawn_detail_row(
+        commands,
+        wind.body,
+        "Speed",
+        "How fast the wind pattern travels across the terrain, in tiles per second",
+        layer.wind_speed,
+        0.0..2.0,
+        DetailField::WindSpeed,
+    );
+    spawn_detail_row(
+        commands,
+        wind.body,
+        "Strength",
+        "How far the wind leans a tip sideways, in metres",
+        layer.wind_strength,
+        0.0..1.0,
+        DetailField::WindStrength,
+    );
+    spawn_detail_row(
+        commands,
+        wind.body,
+        "Vertical strength",
+        "How far the wind bobs a tip up and down, in metres",
+        layer.wind_vertical_strength,
+        0.0..0.5,
+        DetailField::WindVerticalStrength,
+    );
+    spawn_detail_row(
+        commands,
+        wind.body,
+        "Direction X",
+        "Which way the wind pattern travels, along X",
+        layer.wind_direction[0],
+        -1.0..1.0,
+        DetailField::WindDirectionX,
+    );
+    spawn_detail_row(
+        commands,
+        wind.body,
+        "Direction Z",
+        "Which way the wind pattern travels, along Z",
+        layer.wind_direction[1],
+        -1.0..1.0,
+        DetailField::WindDirectionZ,
+    );
+    spawn_detail_row(
+        commands,
+        wind.body,
+        "Tile size",
+        "How many metres one tile of the wind pattern spans: large is a slow swell \
+         across the field, small a busy ripple",
+        layer.wind_tile_size,
+        1.0..60.0,
+        DetailField::WindTileSize,
+    );
+
+    let push = spawn_section(
+        commands,
+        parent,
+        DETAIL_PUSH_SECTION,
+        &icon_font,
+        &refs.collapse,
+    );
+    spawn_detail_row(
+        commands,
+        push.body,
+        "Bend",
+        "How far a tip leans from its own facing before any wind, in metres",
+        layer.bend,
+        0.0..1.0,
+        DetailField::Bend,
+    );
+    spawn_detail_row(
+        commands,
+        push.body,
+        "Push strength",
+        "How far something walking through the field shoves a tip away, in metres",
+        layer.push_strength,
+        0.0..3.0,
+        DetailField::PushStrength,
+    );
+    spawn_detail_row(
+        commands,
+        push.body,
+        "Push radius",
+        "How close it has to be to bend an instance at all, in metres",
+        layer.push_radius,
+        0.1..5.0,
+        DetailField::PushRadius,
+    );
+}
+
+/// Add a layer, and remove the one that is selected.
+fn layer_actions(selected: usize) -> Vec<HeaderAction> {
+    vec![
+        HeaderAction::new(
+            Icon::Plus,
+            "Add Layer",
+            "Add a detail layer, and the density channel it grows from.",
+            ButtonOperatorCall::new(TerrainDetailAddOp::ID),
+        ),
+        HeaderAction::new(
+            Icon::Trash2,
+            "Remove Layer",
+            "Remove the selected layer. What was painted into its density channel stays.",
+            ButtonOperatorCall::new(TerrainDetailRemoveOp::ID)
+                .with_param("layer", selected.to_string()),
+        ),
+    ]
+}
+
+/// One row of the layer list: a swatch of its tip colour, its name, and a
+/// click that selects it.
+fn spawn_detail_layer_row(
+    commands: &mut Commands,
+    parent: Entity,
+    index: usize,
+    layer: &jackdaw_scene_types::DetailLayer,
+    selected: bool,
+) {
+    let [r, g, b] = layer.color_tip;
+    let row = commands
+        .spawn((
+            Node {
+                flex_direction: FlexDirection::Row,
+                align_items: AlignItems::Center,
+                column_gap: px(tokens::SPACING_SM),
+                width: Val::Percent(100.0),
+                padding: UiRect::all(px(tokens::SPACING_XS)),
+                ..default()
+            },
+            BackgroundColor(if selected {
+                tokens::ACCENT_BLUE
+            } else {
+                Color::NONE
+            }),
+            ChildOf(parent),
+        ))
+        .id();
+    commands.spawn((
+        Node {
+            width: px(tokens::SPACING_MD),
+            height: px(tokens::SPACING_MD),
+            ..default()
+        },
+        BackgroundColor(Color::linear_rgb(r, g, b)),
+        ChildOf(row),
+    ));
+    commands.spawn((
+        Text::new(layer.name.clone()),
+        TextFont {
+            font_size: tokens::TEXT_SIZE_SM,
+            ..default()
+        },
+        TextColor(if selected {
+            tokens::TEXT_BODY_COLOR.into()
+        } else {
+            tokens::TEXT_SECONDARY
+        }),
+        ChildOf(row),
+    ));
+    commands
+        .entity(row)
+        .observe(move |_: On<Pointer<Click>>, mut commands: Commands| {
+            commands
+                .operator(TerrainDetailSelectOp::ID)
+                .param("layer", index.to_string())
+                .settings(CallOperatorSettings {
+                    creates_history_entry: false,
+                    execution_context: ExecutionContext::Invoke,
+                })
+                .call();
+        });
+}
+
+fn spawn_detail_row(
+    commands: &mut Commands,
+    parent: Entity,
+    label: &str,
+    tooltip: &str,
+    value: f32,
+    range: std::ops::Range<f32>,
+    field: DetailField,
+) {
+    spawn_slider_row(
+        commands,
+        parent,
+        label,
+        tooltip,
+        value,
+        range,
+        FieldKind::Continuous,
+        field,
+    );
+}
+
+/// One text field of the selected layer, beside its name.
+fn spawn_detail_text_row(
+    commands: &mut Commands,
+    parent: Entity,
+    label: &str,
+    value: &str,
+    field: DetailTextField,
+) {
+    let row = commands
+        .spawn((
+            Node {
+                flex_direction: FlexDirection::Row,
+                align_items: AlignItems::Center,
+                column_gap: px(tokens::SPACING_SM),
+                width: Val::Percent(100.0),
+                ..default()
+            },
+            ChildOf(parent),
+        ))
+        .id();
+    spawn_hint(commands, row, label);
+    commands.spawn((
+        text_edit(TextEditProps::default().with_default_value(value.to_string())),
+        field,
+        ChildOf(row),
+    ));
+}
+
+/// One colour of the selected layer, as a picker beside its name. The field it
+/// writes is named here rather than tagged on the entity.
+fn spawn_detail_color(
+    commands: &mut Commands,
+    parent: Entity,
+    label: &str,
+    tooltip: &str,
+    color: [f32; 3],
+    field: &'static str,
+) {
+    let row = commands
+        .spawn((
+            Node {
+                flex_direction: FlexDirection::Row,
+                align_items: AlignItems::Center,
+                column_gap: px(tokens::SPACING_SM),
+                ..default()
+            },
+            ChildOf(parent),
+        ))
+        .id();
+    spawn_hint(commands, row, label);
+    commands
+        .spawn((
+            jackdaw_feathers::color_picker::color_picker(
+                jackdaw_feathers::color_picker::ColorPickerProps::new()
+                    .with_color([color[0], color[1], color[2], 1.0]),
+            ),
+            Tooltip::title(label.to_string()).with_description(tooltip.to_string()),
+            Hovered::default(),
+            ChildOf(row),
+        ))
+        .observe(
+            move |event: On<jackdaw_feathers::color_picker::ColorPickerChangeEvent>,
+                  mut commands: Commands| {
+                let [r, g, b, _] = event.color;
+                commands
+                    .operator(TerrainDetailSetOp::ID)
+                    .param("field", field)
+                    .param("value", format!("{r},{g},{b}"))
+                    .settings(CallOperatorSettings {
+                        creates_history_entry: false,
+                        execution_context: ExecutionContext::Invoke,
+                    })
+                    .call();
+            },
+        );
+}
+
+/// Commits a Detail row on every tick of a drag: the operator writes one field
+/// of the component, and the section does not rebuild for it.
+fn on_detail_slider_change(
+    event: On<ValueChange<f32>>,
+    fields: Query<&DetailField>,
+    terrains: Query<&jackdaw_scene_types::Terrain>,
+    selection: Res<Selection>,
+    paint: Res<TerrainPaintState>,
+    mut commands: Commands,
+) {
+    let Ok(&field) = fields.get(event.event_target()) else {
+        return;
+    };
+    let Some(layer) = selection
+        .primary()
+        .and_then(|entity| terrains.get(entity).ok())
+        .and_then(|terrain| {
+            let index = super::detail::selected_detail_layer(terrain, paint.detail_layer)?;
+            terrain.detail.get(index)
+        })
+    else {
+        return;
+    };
+    commands
+        .operator(TerrainDetailSetOp::ID)
+        .param("field", field.param())
+        .param("value", field.value(event.value, layer))
+        .settings(CallOperatorSettings {
+            creates_history_entry: false,
+            execution_context: ExecutionContext::Invoke,
+        })
+        .call();
+}
+
+fn on_detail_checkbox_change(
+    event: On<ValueChange<bool>>,
+    boxes: Query<(), With<DetailAlignCheckbox>>,
+    mut commands: Commands,
+) {
+    let target = event.event_target();
+    if !boxes.contains(target) {
+        return;
+    }
+    jackdaw_feathers::utils::set_marker_if_alive::<Checked>(&mut commands, target, event.value);
+    commands
+        .operator(TerrainDetailSetOp::ID)
+        .param("field", "align_to_normal")
+        .param("value", event.value.to_string())
+        .settings(CallOperatorSettings {
+            creates_history_entry: false,
+            execution_context: ExecutionContext::Invoke,
+        })
+        .call();
+}
+
+fn on_detail_text_commit(
+    event: On<TextEditCommitEvent>,
+    fields: Query<&DetailTextField>,
+    mut commands: Commands,
+) {
+    let Ok(field) = fields.get(event.entity) else {
+        return;
+    };
+    commands
+        .operator(TerrainDetailSetOp::ID)
+        .param("field", field.0)
+        .param("value", event.text.clone())
+        .settings(CallOperatorSettings {
+            creates_history_entry: false,
+            execution_context: ExecutionContext::Invoke,
+        })
+        .call();
 }
 
 /// Every material the registry knows, in the same tile grammar the

--- a/src/terrain/sculpt.rs
+++ b/src/terrain/sculpt.rs
@@ -126,8 +126,6 @@ impl SetTerrainHeights {
         if let Some(mut dirty) = world.get_mut::<TerrainDirtyChunks>(self.entity) {
             dirty.rebuild_all = true;
         }
-        // Detail stands on the heights, so the cells this put back are owed a
-        // reseed.
         let rect = match &self.patch {
             HeightPatch::Whole { .. } => {
                 let resolution = world
@@ -345,8 +343,6 @@ pub fn terrain_sculpt(
                 Some(grown) => grown.union(rect),
                 None => rect,
             });
-            // Moving ground moves the detail on it, so the cells this frame
-            // wrote are owed a reseed.
             if let Some(detail_dirty) = detail_dirty.as_mut() {
                 detail_dirty.touch(rect);
             }

--- a/src/terrain/sculpt.rs
+++ b/src/terrain/sculpt.rs
@@ -126,6 +126,19 @@ impl SetTerrainHeights {
         if let Some(mut dirty) = world.get_mut::<TerrainDirtyChunks>(self.entity) {
             dirty.rebuild_all = true;
         }
+        // Detail stands on the heights, so the cells this put back are owed a
+        // reseed.
+        let rect = match &self.patch {
+            HeightPatch::Whole { .. } => {
+                let resolution = world
+                    .resource::<TerrainDataStore>()
+                    .grid_shape(&terrain)
+                    .resolution;
+                GridRect::whole(resolution)
+            }
+            HeightPatch::Rect { rect, .. } => *rect,
+        };
+        super::detail::mark_detail_dirty(world, self.entity, rect);
     }
 }
 
@@ -254,7 +267,11 @@ pub fn terrain_sculpt(
     edit_mode: Res<TerrainEditMode>,
     brush_settings: Res<TerrainBrushSettings>,
     mut sculpt_state: ResMut<TerrainSculptState>,
-    mut terrain_query: Query<(&jackdaw_scene_types::Terrain, &mut TerrainDirtyChunks)>,
+    mut terrain_query: Query<(
+        &jackdaw_scene_types::Terrain,
+        &mut TerrainDirtyChunks,
+        Option<&mut jackdaw_terrain::render::DetailDirty>,
+    )>,
     mut store: ResMut<TerrainDataStore>,
     mut history: ResMut<CommandHistory>,
     time: Res<Time>,
@@ -264,7 +281,7 @@ pub fn terrain_sculpt(
         return OperatorResult::Cancelled;
     };
     let target = sculpt_state.target?;
-    let (terrain, mut dirty) = terrain_query.get_mut(target)?;
+    let (terrain, mut dirty, mut detail_dirty) = terrain_query.get_mut(target)?;
     // The stroke lands on the cells the terrain holds, so the brush reaches
     // wherever ground has been allocated.
     let resolution = store.grid_shape(terrain).resolution;
@@ -328,6 +345,11 @@ pub fn terrain_sculpt(
                 Some(grown) => grown.union(rect),
                 None => rect,
             });
+            // Moving ground moves the detail on it, so the cells this frame
+            // wrote are owed a reseed.
+            if let Some(detail_dirty) = detail_dirty.as_mut() {
+                detail_dirty.touch(rect);
+            }
         }
     }
     OperatorResult::Running

--- a/src/terrain/stamp_ops.rs
+++ b/src/terrain/stamp_ops.rs
@@ -233,6 +233,8 @@ fn run_sculpt_stamp(world: &mut World, params: &OperatorParameters) {
             dirty.dirty.insert(chunk);
         }
     }
+    // Raising ground moves every instance standing on it.
+    super::detail::mark_detail_dirty(world, target, rect);
     world
         .resource_mut::<CommandHistory>()
         .push_executed(Box::new(SetTerrainHeights::stroke(

--- a/src/terrain/stamp_ops.rs
+++ b/src/terrain/stamp_ops.rs
@@ -233,7 +233,6 @@ fn run_sculpt_stamp(world: &mut World, params: &OperatorParameters) {
             dirty.dirty.insert(chunk);
         }
     }
-    // Raising ground moves every instance standing on it.
     super::detail::mark_detail_dirty(world, target, rect);
     world
         .resource_mut::<CommandHistory>()

--- a/src/terrain/texture_ops.rs
+++ b/src/terrain/texture_ops.rs
@@ -495,13 +495,14 @@ impl EditorCommand for SetTerrainMaterials {
 #[operator(
     id = "terrain.paint.target",
     label = "Paint Target",
-    description = "Switch the paint brush between scatter masks, textures and the colour layer.",
+    description = "Switch the paint brush between scatter masks, textures, the colour layer \
+                   and detail.",
     allows_undo = false,
     params(target(
         String,
         default = "channels",
         doc = "Which domain the brush paints: \"channels\" (scatter masks), \"textures\", \
-               or \"color\" (the macro tint)."
+               \"color\" (the macro tint), or \"detail\" (density)."
     ))
 )]
 pub(crate) fn terrain_paint_target(
@@ -512,6 +513,7 @@ pub(crate) fn terrain_paint_target(
     paint.domain = match target {
         "textures" => PaintDomain::Textures,
         "color" => PaintDomain::Color,
+        "detail" => PaintDomain::Detail,
         "channels" => PaintDomain::Channels,
         other => {
             warn!(

--- a/tests/scenes/jsn_to_bsn.rs
+++ b/tests/scenes/jsn_to_bsn.rs
@@ -396,9 +396,6 @@ fn inline_material_reference_and_terrain_survive_conversion() {
             channels: Vec::new(),
             data_path: String::new(),
             heights: vec![0.0, 0.5, 1.0, 0.0, 0.25, 0.75, 0.1, 0.2, 0.3],
-            // A scene this old predates quantization, the navmesh agent and
-            // detail layers. Spelled out rather than `..default()` to enumerate
-            // what it holds.
             quantization: Default::default(),
             navmesh: Default::default(),
             detail: Vec::new(),

--- a/tests/scenes/jsn_to_bsn.rs
+++ b/tests/scenes/jsn_to_bsn.rs
@@ -396,10 +396,12 @@ fn inline_material_reference_and_terrain_survive_conversion() {
             channels: Vec::new(),
             data_path: String::new(),
             heights: vec![0.0, 0.5, 1.0, 0.0, 0.25, 0.75, 0.1, 0.2, 0.3],
-            // A scene this old predates quantization and the navmesh agent.
-            // Spelled out rather than `..default()` to enumerate what it holds.
+            // A scene this old predates quantization, the navmesh agent and
+            // detail layers. Spelled out rather than `..default()` to enumerate
+            // what it holds.
             quantization: Default::default(),
             navmesh: Default::default(),
+            detail: Vec::new(),
         },
         jackdaw_scene_types::SceneRootTag,
     ));

--- a/tests/terrain/main.rs
+++ b/tests/terrain/main.rs
@@ -6,6 +6,7 @@
 #[path = "../util/mod.rs"]
 mod util;
 
+mod terrain_detail;
 mod terrain_export;
 mod terrain_reload;
 mod terrain_stamp;

--- a/tests/terrain/terrain_detail.rs
+++ b/tests/terrain/terrain_detail.rs
@@ -1,0 +1,760 @@
+//! Authoring a terrain's detail layers: adding them, what each one draws, and
+//! the density brush that decides where it grows.
+
+use std::time::Duration;
+
+use bevy::input::ButtonInput;
+use bevy::prelude::*;
+use jackdaw::selection::Selection;
+use jackdaw::terrain::{
+    PaintDomain, TerrainBrushSettings, TerrainDataStore, TerrainEditMode, TerrainPaintState,
+};
+use jackdaw_api::prelude::*;
+
+use crate::util;
+
+/// A cell well inside the footprint generating lays down.
+const AIMED: u32 = 300;
+
+#[track_caller]
+fn dispatch(app: &mut App, id: &'static str) {
+    let result = app
+        .world_mut()
+        .operator(id)
+        .call()
+        .unwrap_or_else(|err| panic!("{id} dispatch errored: {err}"));
+    assert_eq!(result, OperatorResult::Finished, "{id} did not finish");
+}
+
+fn advance_a_frame(app: &mut App) {
+    app.world_mut()
+        .resource_mut::<Time>()
+        .advance_by(Duration::from_millis(16));
+}
+
+fn settle_terrain(app: &mut App) {
+    app.world_mut()
+        .run_system_cached(jackdaw::terrain::ensure_terrain_dirty_chunks)
+        .expect("dirty-chunk tracking is installed");
+    app.world_mut()
+        .run_system_cached(jackdaw::terrain::ensure_terrain_data_path)
+        .expect("sidecar paths are minted");
+    app.update();
+}
+
+fn the_terrain(app: &mut App) -> (Entity, jackdaw_scene_types::Terrain) {
+    let mut query = app
+        .world_mut()
+        .query::<(Entity, &jackdaw_scene_types::Terrain)>();
+    let mut found: Vec<(Entity, jackdaw_scene_types::Terrain)> = query
+        .iter(app.world())
+        .map(|(entity, terrain)| (entity, terrain.clone()))
+        .collect();
+    assert_eq!(found.len(), 1, "expected exactly one terrain in the scene");
+    found.pop().expect("just checked")
+}
+
+/// A generated terrain, selected, with its sidecar in the store.
+fn terrain_app() -> App {
+    let mut app = util::editor_test_app();
+    dispatch(&mut app, "scene.new");
+    app.update();
+    dispatch(&mut app, "entity.add.terrain");
+    app.update();
+    settle_terrain(&mut app);
+
+    let (entity, _) = the_terrain(&mut app);
+    app.world_mut().resource_mut::<Selection>().entities = vec![entity];
+    dispatch(&mut app, "terrain.generate");
+    app.update();
+    advance_a_frame(&mut app);
+    app
+}
+
+/// A generated terrain that already carries one grass layer, projected into
+/// what the renderer seeds from.
+fn layered_app() -> App {
+    let mut app = terrain_app();
+    add_layer(&mut app, None);
+    project_detail(&mut app);
+    app
+}
+
+/// Fold the store and the layers into the source the renderer seeds tiles from.
+/// The editor runs this every frame in a state a headless app does not enter.
+fn project_detail(app: &mut App) {
+    app.world_mut()
+        .run_system_cached(jackdaw::terrain::detail::sync_terrain_detail)
+        .expect("the detail projection is installed");
+}
+
+#[track_caller]
+fn add_layer(app: &mut App, name: Option<&'static str>) {
+    let mut call = app.world_mut().operator("terrain.detail.add");
+    if let Some(name) = name {
+        call = call.param("name", name);
+    }
+    let result = call.call().expect("terrain.detail.add dispatches");
+    assert_eq!(result, OperatorResult::Finished);
+    app.update();
+}
+
+/// The density a named channel carries at one cell.
+fn density_at(
+    app: &App,
+    terrain: &jackdaw_scene_types::Terrain,
+    channel: &str,
+    x: u32,
+    z: u32,
+) -> u16 {
+    let index = terrain
+        .channels
+        .iter()
+        .position(|declared| declared.name == channel)
+        .unwrap_or_else(|| panic!("the terrain declares a {channel:?} channel"));
+    app.world()
+        .resource::<TerrainDataStore>()
+        .get(&terrain.data_path)
+        .expect("the terrain has a document")
+        .regions
+        .channel_at(index, x as i32, z as i32)
+}
+
+/// The terrain-local metres of grid cell `(x, z)`, which the stamp takes.
+fn metres_at(app: &App, terrain: &jackdaw_scene_types::Terrain, x: u32, z: u32) -> (f64, f64) {
+    let shape = app
+        .world()
+        .resource::<TerrainDataStore>()
+        .grid_shape(terrain);
+    let cell = shape.size / (shape.resolution - 1) as f32;
+    (
+        f64::from(shape.origin.x + cell.x * x as f32),
+        f64::from(shape.origin.y + cell.y * z as f32),
+    )
+}
+
+#[track_caller]
+fn set_field(app: &mut App, field: &'static str, value: &str) -> OperatorResult {
+    let result = app
+        .world_mut()
+        .operator("terrain.detail.set")
+        .param("field", field)
+        .param("value", value.to_string())
+        .call()
+        .expect("terrain.detail.set dispatches");
+    app.update();
+    result
+}
+
+/// Lay a full-strength stamp on one layer at the aimed cell.
+#[track_caller]
+fn stamp(app: &mut App, layer: Option<&'static str>, erase: bool) -> OperatorResult {
+    let (_, terrain) = the_terrain(app);
+    let (mx, mz) = metres_at(app, &terrain, AIMED, AIMED);
+    let mut call = app
+        .world_mut()
+        .operator("terrain.detail.stamp")
+        .param("x", mx)
+        .param("z", mz)
+        .param("radius", 12.0)
+        .param("opacity", 1.0)
+        .param("erase", erase);
+    if let Some(layer) = layer {
+        call = call.param("layer", layer);
+    }
+    let result = call.call().expect("terrain.detail.stamp dispatches");
+    app.update();
+    result
+}
+
+#[test]
+fn adding_a_layer_mints_its_density_channel_and_removing_the_layer_keeps_it() {
+    let mut app = terrain_app();
+    let (_, terrain) = the_terrain(&mut app);
+    assert!(
+        terrain.detail.is_empty(),
+        "a fresh terrain carries no layers"
+    );
+    assert!(
+        !terrain.channels.iter().any(|c| c.name == "grass"),
+        "and declares no density channel"
+    );
+
+    add_layer(&mut app, None);
+    let (_, terrain) = the_terrain(&mut app);
+    let layer = terrain
+        .detail
+        .first()
+        .cloned()
+        .expect("the layer was added");
+    assert_eq!(layer.name, "grass");
+    assert_eq!(layer.density_channel, "grass");
+    assert_eq!(
+        terrain
+            .channels
+            .iter()
+            .filter(|c| c.name == layer.density_channel)
+            .count(),
+        1,
+        "the density channel was minted exactly once"
+    );
+
+    dispatch(&mut app, "terrain.detail.remove");
+    app.update();
+    let (_, terrain) = the_terrain(&mut app);
+    assert!(terrain.detail.is_empty(), "the layer is gone");
+    assert!(
+        terrain.channels.iter().any(|c| c.name == "grass"),
+        "removing a layer must keep what was painted into its channel"
+    );
+}
+
+#[test]
+fn undoing_the_add_takes_back_both_the_layer_and_the_channel() {
+    let mut app = layered_app();
+    dispatch(&mut app, "history.undo");
+    app.update();
+
+    let (_, terrain) = the_terrain(&mut app);
+    assert!(terrain.detail.is_empty(), "one undo took the layer back");
+    assert!(
+        !terrain.channels.iter().any(|c| c.name == "grass"),
+        "the same undo took the channel it minted back"
+    );
+}
+
+#[test]
+fn a_second_layer_grows_from_a_channel_of_its_own() {
+    let mut app = layered_app();
+    add_layer(&mut app, Some("flowers"));
+
+    let (_, terrain) = the_terrain(&mut app);
+    let names: Vec<&str> = terrain
+        .detail
+        .iter()
+        .map(|layer| layer.density_channel.as_str())
+        .collect();
+    assert_eq!(names, ["grass", "flowers"]);
+    for channel in names {
+        assert!(
+            terrain.channels.iter().any(|c| c.name == channel),
+            "{channel} was minted for its layer"
+        );
+    }
+}
+
+#[test]
+fn each_stamp_reaches_only_the_layer_it_names() {
+    let mut app = layered_app();
+    add_layer(&mut app, Some("flowers"));
+
+    assert_eq!(
+        stamp(&mut app, Some("grass"), false),
+        OperatorResult::Finished
+    );
+    let (_, terrain) = the_terrain(&mut app);
+    assert!(density_at(&app, &terrain, "grass", AIMED, AIMED) > 0);
+    assert_eq!(
+        density_at(&app, &terrain, "flowers", AIMED, AIMED),
+        0,
+        "a stamp on one layer left the other layer's channel alone"
+    );
+
+    assert_eq!(
+        stamp(&mut app, Some("flowers"), false),
+        OperatorResult::Finished
+    );
+    let (_, terrain) = the_terrain(&mut app);
+    assert!(density_at(&app, &terrain, "flowers", AIMED, AIMED) > 0);
+}
+
+#[test]
+fn a_layer_is_addressed_by_name_or_by_index() {
+    let mut app = layered_app();
+    add_layer(&mut app, Some("flowers"));
+
+    assert_eq!(stamp(&mut app, Some("0"), false), OperatorResult::Finished);
+    let (_, terrain) = the_terrain(&mut app);
+    assert!(
+        density_at(&app, &terrain, "grass", AIMED, AIMED) > 0,
+        "index 0 addressed the first layer"
+    );
+
+    assert_eq!(
+        stamp(&mut app, Some("flowers"), false),
+        OperatorResult::Finished
+    );
+    let (_, terrain) = the_terrain(&mut app);
+    assert!(
+        density_at(&app, &terrain, "flowers", AIMED, AIMED) > 0,
+        "a name addressed the second layer"
+    );
+
+    assert_eq!(
+        stamp(&mut app, Some("meadow"), false),
+        OperatorResult::Cancelled,
+        "a name no layer carries is refused"
+    );
+}
+
+#[test]
+fn an_index_addresses_a_layer_before_a_name_that_reads_as_one() {
+    let mut app = layered_app();
+    add_layer(&mut app, Some("0"));
+    let (_, terrain) = the_terrain(&mut app);
+    assert_eq!(terrain.detail[1].name, "0");
+    assert_eq!(terrain.detail[1].density_channel, "0");
+
+    // Both layers exist, so "1" reads as an index and reaches the second.
+    assert_eq!(stamp(&mut app, Some("1"), false), OperatorResult::Finished);
+    let (_, terrain) = the_terrain(&mut app);
+    assert!(density_at(&app, &terrain, "0", AIMED, AIMED) > 0);
+    assert_eq!(density_at(&app, &terrain, "grass", AIMED, AIMED), 0);
+
+    // And "0" reads as an index too, so it reaches the first rather than the
+    // layer that carries that name.
+    assert_eq!(stamp(&mut app, Some("0"), false), OperatorResult::Finished);
+    let (_, terrain) = the_terrain(&mut app);
+    assert!(density_at(&app, &terrain, "grass", AIMED, AIMED) > 0);
+}
+
+#[test]
+fn two_layers_asked_for_one_name_get_names_of_their_own() {
+    let mut app = layered_app();
+    add_layer(&mut app, Some("grass"));
+
+    let (_, terrain) = the_terrain(&mut app);
+    let names: Vec<&str> = terrain
+        .detail
+        .iter()
+        .map(|layer| layer.name.as_str())
+        .collect();
+    assert_eq!(names, ["grass", "grass-1"], "a name addresses one layer");
+    assert_eq!(terrain.detail[1].density_channel, "grass-1");
+
+    assert_eq!(
+        stamp(&mut app, Some("grass-1"), false),
+        OperatorResult::Finished
+    );
+    let (_, terrain) = the_terrain(&mut app);
+    assert!(density_at(&app, &terrain, "grass-1", AIMED, AIMED) > 0);
+    assert_eq!(
+        density_at(&app, &terrain, "grass", AIMED, AIMED),
+        0,
+        "the second layer grows from a channel of its own"
+    );
+}
+
+#[test]
+fn removing_a_layer_keeps_the_selection_on_the_layer_it_was_on() {
+    let mut app = layered_app();
+    add_layer(&mut app, Some("flowers"));
+    add_layer(&mut app, Some("moss"));
+    assert_eq!(app.world().resource::<TerrainPaintState>().detail_layer, 2);
+
+    let removed = app
+        .world_mut()
+        .operator("terrain.detail.remove")
+        .param("layer", "flowers")
+        .call()
+        .expect("terrain.detail.remove dispatches");
+    assert_eq!(removed, OperatorResult::Finished);
+    app.update();
+
+    assert_eq!(
+        app.world().resource::<TerrainPaintState>().detail_layer,
+        1,
+        "the selection followed moss into the slot flowers left"
+    );
+    assert_eq!(stamp(&mut app, None, false), OperatorResult::Finished);
+    let (_, terrain) = the_terrain(&mut app);
+    assert!(
+        density_at(&app, &terrain, "moss", AIMED, AIMED) > 0,
+        "an unqualified stamp still reaches the layer that was selected"
+    );
+    assert_eq!(density_at(&app, &terrain, "grass", AIMED, AIMED), 0);
+}
+
+#[test]
+fn undoing_an_add_leaves_the_selection_inside_the_list() {
+    let mut app = layered_app();
+    add_layer(&mut app, Some("flowers"));
+    assert_eq!(app.world().resource::<TerrainPaintState>().detail_layer, 1);
+
+    dispatch(&mut app, "history.undo");
+    app.update();
+    let (_, terrain) = the_terrain(&mut app);
+    assert_eq!(terrain.detail.len(), 1, "the second layer is gone");
+    assert_eq!(
+        app.world().resource::<TerrainPaintState>().detail_layer,
+        0,
+        "the selection came back inside the list"
+    );
+
+    assert_eq!(
+        set_field(&mut app, "cull_distance", "80"),
+        OperatorResult::Finished,
+        "an operator with no layer= still finds the selected layer"
+    );
+    let (_, terrain) = the_terrain(&mut app);
+    assert_eq!(terrain.detail[0].cull_distance, 80.0);
+}
+
+#[test]
+fn a_detail_stamp_thickens_the_density_and_undoes() {
+    let mut app = layered_app();
+    let (_, terrain) = the_terrain(&mut app);
+    assert_eq!(density_at(&app, &terrain, "grass", AIMED, AIMED), 0);
+
+    assert_eq!(stamp(&mut app, None, false), OperatorResult::Finished);
+    let grown = density_at(&app, &terrain, "grass", AIMED, AIMED);
+    assert!(
+        grown > 0,
+        "the stamp grew nothing at the cell it was aimed at"
+    );
+    assert_eq!(
+        density_at(&app, &terrain, "grass", 0, 0),
+        0,
+        "and nothing well outside its radius"
+    );
+
+    dispatch(&mut app, "history.undo");
+    app.update();
+    assert_eq!(
+        density_at(&app, &terrain, "grass", AIMED, AIMED),
+        0,
+        "undo left {grown} density standing"
+    );
+}
+
+#[test]
+fn a_stamp_and_its_undo_mark_only_the_cells_they_moved() {
+    let mut app = layered_app();
+    let (entity, terrain) = the_terrain(&mut app);
+    let resolution = app
+        .world()
+        .resource::<TerrainDataStore>()
+        .grid_shape(&terrain)
+        .resolution;
+    clear_detail_mark(&mut app, entity);
+
+    let (mx, mz) = metres_at(&app, &terrain, AIMED, AIMED);
+    let stamped = app
+        .world_mut()
+        .operator("terrain.detail.stamp")
+        .param("x", mx)
+        .param("z", mz)
+        .param("radius", 12.0)
+        .param("opacity", 1.0)
+        .call()
+        .expect("terrain.detail.stamp dispatches");
+    assert_eq!(stamped, OperatorResult::Finished);
+
+    let marked = detail_mark(&app, entity).expect("the stamp marked the ground it covered");
+    assert!(
+        marked.width < resolution && marked.height < resolution,
+        "the stamp marked {}x{} of a {resolution}-cell grid",
+        marked.width,
+        marked.height
+    );
+    assert!(
+        marked.x <= AIMED && AIMED < marked.x + marked.width,
+        "the mark misses the cell the stamp was aimed at"
+    );
+
+    clear_detail_mark(&mut app, entity);
+    dispatch(&mut app, "history.undo");
+    let undone = detail_mark(&app, entity).expect("the undo marked the ground it put back");
+    assert!(
+        undone.width < resolution && undone.height < resolution,
+        "undoing one stamp reseeded the whole {resolution}-cell field"
+    );
+    assert!(
+        undone.x <= AIMED && AIMED < undone.x + undone.width,
+        "the undo's mark misses the cell the stamp was aimed at"
+    );
+}
+
+#[test]
+fn undoing_a_sculpt_marks_the_ground_the_detail_stands_on() {
+    let mut app = layered_app();
+    let (entity, terrain) = the_terrain(&mut app);
+    let (mx, mz) = metres_at(&app, &terrain, AIMED, AIMED);
+    let sculpted = app
+        .world_mut()
+        .operator("terrain.sculpt.stamp")
+        .param("x", mx)
+        .param("z", mz)
+        .param("radius", 12.0)
+        .param("strength", 4.0)
+        .call()
+        .expect("terrain.sculpt.stamp dispatches");
+    assert_eq!(sculpted, OperatorResult::Finished);
+    app.update();
+
+    clear_detail_mark(&mut app, entity);
+    dispatch(&mut app, "history.undo");
+    let undone = detail_mark(&app, entity).expect("the undo marked the ground it put back");
+    assert!(
+        undone.x <= AIMED && AIMED < undone.x + undone.width,
+        "the undo's mark misses the cell the sculpt raised"
+    );
+}
+
+/// The ground a terrain's detail has yet to catch up with.
+fn detail_mark(app: &App, entity: Entity) -> Option<jackdaw_terrain::GridRect> {
+    app.world()
+        .get::<jackdaw_terrain::render::DetailDirty>(entity)
+        .expect("a terrain that carries layers carries a mark")
+        .rect
+}
+
+fn clear_detail_mark(app: &mut App, entity: Entity) {
+    app.world_mut()
+        .get_mut::<jackdaw_terrain::render::DetailDirty>(entity)
+        .expect("a terrain that carries layers carries a mark")
+        .rect = None;
+}
+
+#[test]
+fn the_stamp_erases_what_it_grew() {
+    let mut app = layered_app();
+    assert_eq!(stamp(&mut app, None, false), OperatorResult::Finished);
+    let (_, terrain) = the_terrain(&mut app);
+    assert!(
+        density_at(&app, &terrain, "grass", AIMED, AIMED) > 0,
+        "the first stamp grew something for the second to erase"
+    );
+
+    assert_eq!(stamp(&mut app, None, true), OperatorResult::Finished);
+    let (_, terrain) = the_terrain(&mut app);
+    assert_eq!(density_at(&app, &terrain, "grass", AIMED, AIMED), 0);
+}
+
+#[test]
+fn the_brush_refuses_a_terrain_with_no_layers() {
+    let mut app = terrain_app();
+    assert_eq!(stamp(&mut app, None, false), OperatorResult::Cancelled);
+    assert_eq!(
+        set_field(&mut app, "width", "0.2,0.4"),
+        OperatorResult::Cancelled
+    );
+
+    let painted = app
+        .world_mut()
+        .operator("terrain.detail.paint")
+        .call()
+        .expect("terrain.detail.paint dispatches");
+    assert_eq!(painted, OperatorResult::Cancelled);
+    assert_ne!(
+        app.world().resource::<TerrainPaintState>().domain,
+        PaintDomain::Detail,
+        "a refused brush must not have been loaded"
+    );
+}
+
+#[test]
+fn setting_a_field_changes_the_layer_and_an_unknown_field_is_refused() {
+    let mut app = layered_app();
+    assert_eq!(
+        set_field(&mut app, "cull_distance", "80"),
+        OperatorResult::Finished
+    );
+    assert_eq!(
+        set_field(&mut app, "color_tip", "0.2,0.9,0.1"),
+        OperatorResult::Finished
+    );
+    let (_, terrain) = the_terrain(&mut app);
+    let layer = terrain.detail[0].clone();
+    assert_eq!(layer.cull_distance, 80.0);
+    assert_eq!(layer.color_tip, [0.2, 0.9, 0.1]);
+    assert_eq!(
+        layer.color_base,
+        jackdaw_scene_types::DetailLayer::default().color_base,
+        "one field at a time: the rest of the layer is untouched"
+    );
+
+    assert_eq!(
+        set_field(&mut app, "colour", "0.2,0.9,0.1"),
+        OperatorResult::Cancelled
+    );
+    assert_eq!(
+        set_field(&mut app, "cull_distance", "far"),
+        OperatorResult::Cancelled
+    );
+    let (_, terrain) = the_terrain(&mut app);
+    assert_eq!(
+        terrain.detail[0].cull_distance, 80.0,
+        "a refusal writes nothing"
+    );
+}
+
+#[test]
+fn the_mesh_field_takes_the_card_or_a_model_and_refuses_a_missing_file() {
+    let mut app = layered_app();
+    // The editor resolves an assets-relative path under the running project,
+    // which for a test is the repository's own assets directory.
+    let model = "models/dungeon.glb";
+    assert!(
+        std::path::Path::new("assets").join(model).is_file(),
+        "the fixture model is where the operator looks for it"
+    );
+
+    assert_eq!(set_field(&mut app, "mesh", model), OperatorResult::Finished);
+    let (_, terrain) = the_terrain(&mut app);
+    assert_eq!(
+        terrain.detail[0].mesh,
+        jackdaw_scene_types::DetailMesh::Asset(model.to_string())
+    );
+
+    assert_eq!(
+        set_field(&mut app, "mesh", "models/absent.gltf"),
+        OperatorResult::Cancelled
+    );
+    let (_, terrain) = the_terrain(&mut app);
+    assert_eq!(
+        terrain.detail[0].mesh,
+        jackdaw_scene_types::DetailMesh::Asset(model.to_string()),
+        "a refusal writes nothing"
+    );
+
+    assert_eq!(
+        set_field(&mut app, "mesh", "card"),
+        OperatorResult::Finished
+    );
+    let (_, terrain) = the_terrain(&mut app);
+    assert_eq!(
+        terrain.detail[0].mesh,
+        jackdaw_scene_types::DetailMesh::Card
+    );
+}
+
+#[test]
+fn the_reported_bsn_carries_the_detail_block() {
+    let mut app = layered_app();
+    assert_eq!(
+        set_field(&mut app, "cull_distance", "83"),
+        OperatorResult::Finished
+    );
+    let (entity, _) = the_terrain(&mut app);
+
+    let bsn = jackdaw_remote::bsn_methods::entity_bsn(app.world_mut(), entity)
+        .expect("the terrain reports as BSN");
+    assert!(
+        bsn.contains("DetailLayer"),
+        "the reported BSN carries no detail layer:\n{bsn}"
+    );
+    assert!(
+        bsn.contains("cull_distance: 83"),
+        "the reported BSN carries no edited cull distance:\n{bsn}"
+    );
+}
+
+#[test]
+fn a_stroke_marks_the_ground_it_is_crossing_rather_than_all_it_has_crossed() {
+    let mut app = layered_app();
+    let (entity, _) = the_terrain(&mut app);
+    load_detail_brush(&mut app, entity);
+
+    app.world_mut()
+        .resource_mut::<ButtonInput<MouseButton>>()
+        .press(MouseButton::Left);
+    advance_a_frame(&mut app);
+    let running = app
+        .world_mut()
+        .operator("terrain.paint")
+        .settings(CallOperatorSettings {
+            execution_context: ExecutionContext::Invoke,
+            creates_history_entry: false,
+        })
+        .call()
+        .expect("terrain.paint dispatches");
+    assert_eq!(running, OperatorResult::Running, "the stroke did not start");
+
+    let mut crossed = AIMED;
+    for _ in 0..3 {
+        crossed += 40;
+        clear_detail_mark(&mut app, entity);
+        app.world_mut()
+            .resource_mut::<TerrainPaintState>()
+            .brush_position = Some(Vec2::splat(crossed as f32));
+        advance_a_frame(&mut app);
+        app.update();
+    }
+
+    let marked = detail_mark(&app, entity).expect("the frame marked the ground under the brush");
+    assert!(
+        marked.x + marked.width <= crossed + 16 && marked.x + 16 >= AIMED + 40,
+        "a brush at cell {crossed} marked {}..{}, which is more than the ground it is on",
+        marked.x,
+        marked.x + marked.width
+    );
+}
+
+/// Point the paint brush at `entity`'s selected layer, in the paint tool, with
+/// a brush the viewport would give it.
+fn load_detail_brush(app: &mut App, entity: Entity) {
+    let loaded = app
+        .world_mut()
+        .operator("terrain.detail.paint")
+        .param("opacity", 1.0)
+        .param("erase", false)
+        .call()
+        .expect("terrain.detail.paint dispatches");
+    assert_eq!(loaded, OperatorResult::Finished);
+    *app.world_mut().resource_mut::<TerrainEditMode>() = TerrainEditMode::Paint;
+    app.world_mut()
+        .resource_mut::<TerrainBrushSettings>()
+        .radius = 8.0;
+    let mut paint = app.world_mut().resource_mut::<TerrainPaintState>();
+    paint.target = Some(entity);
+    paint.brush_position = Some(Vec2::splat(AIMED as f32));
+}
+
+#[test]
+fn a_detail_stroke_thickens_the_density_under_the_brush() {
+    let mut app = layered_app();
+    let (entity, terrain) = the_terrain(&mut app);
+    assert_eq!(density_at(&app, &terrain, "grass", AIMED, AIMED), 0);
+
+    load_detail_brush(&mut app, entity);
+    assert_eq!(
+        app.world().resource::<TerrainPaintState>().domain,
+        PaintDomain::Detail
+    );
+
+    app.world_mut()
+        .resource_mut::<ButtonInput<MouseButton>>()
+        .press(MouseButton::Left);
+    advance_a_frame(&mut app);
+    let running = app
+        .world_mut()
+        .operator("terrain.paint")
+        .settings(CallOperatorSettings {
+            execution_context: ExecutionContext::Invoke,
+            creates_history_entry: false,
+        })
+        .call()
+        .expect("terrain.paint dispatches");
+    assert_eq!(running, OperatorResult::Running, "the stroke did not start");
+    assert!(
+        density_at(&app, &terrain, "grass", AIMED, AIMED) > 0,
+        "the stroke grew nothing under the brush"
+    );
+
+    app.world_mut()
+        .resource_mut::<ButtonInput<MouseButton>>()
+        .release(MouseButton::Left);
+    app.update();
+    app.update();
+
+    let grown = density_at(&app, &terrain, "grass", AIMED, AIMED);
+    assert!(grown > 0, "releasing the button undid the stroke");
+    dispatch(&mut app, "history.undo");
+    app.update();
+    assert_eq!(
+        density_at(&app, &terrain, "grass", AIMED, AIMED),
+        0,
+        "one undo takes the whole stroke back"
+    );
+}

--- a/tests/terrain/terrain_detail.rs
+++ b/tests/terrain/terrain_detail.rs
@@ -305,17 +305,20 @@ fn an_index_addresses_a_layer_before_a_name_that_reads_as_one() {
     assert_eq!(terrain.detail[1].name, "0");
     assert_eq!(terrain.detail[1].density_channel, "0");
 
-    // Both layers exist, so "1" reads as an index and reaches the second.
     assert_eq!(stamp(&mut app, Some("1"), false), OperatorResult::Finished);
     let (_, terrain) = the_terrain(&mut app);
-    assert!(density_at(&app, &terrain, "0", AIMED, AIMED) > 0);
+    assert!(
+        density_at(&app, &terrain, "0", AIMED, AIMED) > 0,
+        "layer=1 reached the second layer"
+    );
     assert_eq!(density_at(&app, &terrain, "grass", AIMED, AIMED), 0);
 
-    // And "0" reads as an index too, so it reaches the first rather than the
-    // layer that carries that name.
     assert_eq!(stamp(&mut app, Some("0"), false), OperatorResult::Finished);
     let (_, terrain) = the_terrain(&mut app);
-    assert!(density_at(&app, &terrain, "grass", AIMED, AIMED) > 0);
+    assert!(
+        density_at(&app, &terrain, "grass", AIMED, AIMED) > 0,
+        "layer=0 reached the first layer, not the layer named 0"
+    );
 }
 
 #[test]
@@ -592,8 +595,6 @@ fn setting_a_field_changes_the_layer_and_an_unknown_field_is_refused() {
 #[test]
 fn the_mesh_field_takes_the_card_or_a_model_and_refuses_a_missing_file() {
     let mut app = layered_app();
-    // The editor resolves an assets-relative path under the running project,
-    // which for a test is the repository's own assets directory.
     let model = "models/dungeon.glb";
     assert!(
         std::path::Path::new("assets").join(model).is_file(),


### PR DESCRIPTION
Terrains carry a list of detail layers. Each layer has a density channel
painted with the terrain brush, a mesh (the built-in card or a glTF from
the assets root), height and width ranges, base and tip colours, wind,
bend, push settings, density and a cull distance.

Instances are placed per layer and tile around the active camera and
drawn by one instanced pipeline shared by the editor and the runtime,
with a shader that bends, sways in wind, pushes away from DetailPresser
entities and fades with distance. Tiles are excluded from the navmesh and
from saved documents.

Editor: terrain.detail.add, remove, select, set, paint and stamp, a
Detail brush domain, and a Detail tab in the Terrain panel.

LLM disclaimer: Claude Code was used to help plan and implement this
change, but all code was human reviewed by myself!