### PR TITLE
Author clip events on library clips and fire them while the Timeline previews

### DIFF
--- a/crates/jackdaw_animation/src/clip.rs
+++ b/crates/jackdaw_animation/src/clip.rs
@@ -180,13 +180,8 @@ impl AnimationTrack {
     }
 }
 
-// Keyframe components, one per value type. Named after the Bevy type
-// they hold, not the field they target. Adding a new value type is a
-// new component here plus a dispatch arm in compile.rs.
-// `compile.rs`.
-
-/// A keyframe that stores a [`Vec3`] value. Used for translation,
-/// scale, and future Vec3-valued animated fields.
+/// A keyframe holding a [`Vec3`], which is what translation and scale animate.
+/// A new value type is a component like this one plus an arm in `compile.rs`.
 #[derive(Component, Reflect, Serialize, Deserialize, Debug, Clone, Copy, Default)]
 #[reflect(Component, Serialize, Deserialize, @jackdaw_scene_types::EditorHidden)]
 pub struct Vec3Keyframe {
@@ -381,6 +376,44 @@ pub struct ImportedClipView {
     /// How many tracks the clip holds, which is what the group heading counts
     /// when the names cannot be read.
     pub curve_count: usize,
+    /// The entity holding this clip's events under the previewed entity, once
+    /// an author has put one there. `None` until the first event is added.
+    pub row: Option<Entity>,
+}
+
+/// How long an event marker stays lit after playback crosses it.
+const MARKER_LIT_SECONDS: f32 = 0.6;
+
+/// Event markers a preview has just crossed, and how long each stays lit.
+/// Not persisted.
+#[derive(Resource, Default, Debug)]
+pub struct FiredClipEvents {
+    lit: bevy::platform::collections::HashMap<Entity, f32>,
+}
+
+impl FiredClipEvents {
+    /// Light the marker standing for one event.
+    pub fn light(&mut self, event: Entity) {
+        self.lit.insert(event, MARKER_LIT_SECONDS);
+    }
+
+    /// Whether a marker is lit.
+    pub fn is_lit(&self, event: Entity) -> bool {
+        self.lit.contains_key(&event)
+    }
+
+    /// Age every lit marker, dropping the ones that have gone out.
+    pub fn fade(&mut self, delta: f32) {
+        self.lit.retain(|_, remaining| {
+            *remaining -= delta;
+            *remaining > 0.0
+        });
+    }
+
+    /// Whether anything is lit.
+    pub fn is_empty(&self) -> bool {
+        self.lit.is_empty()
+    }
 }
 
 /// Which keyframe the scrubber is snapped onto during a drag.
@@ -412,4 +445,23 @@ pub struct KeyframeClipboardEntry {
 #[derive(Resource, Default, Debug, Clone)]
 pub struct KeyframeClipboard {
     pub entries: Vec<KeyframeClipboardEntry>,
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn a_lit_marker_goes_out_once_its_time_is_up() {
+        let mut fired = FiredClipEvents::default();
+        let marker = Entity::from_raw_u32(1).expect("a valid id");
+        fired.light(marker);
+
+        fired.fade(MARKER_LIT_SECONDS * 0.5);
+        assert!(fired.is_lit(marker), "half its time is not all of it");
+
+        fired.fade(MARKER_LIT_SECONDS);
+        assert!(!fired.is_lit(marker));
+        assert!(fired.is_empty(), "and nothing is left to fade");
+    }
 }

--- a/crates/jackdaw_animation/src/lib.rs
+++ b/crates/jackdaw_animation/src/lib.rs
@@ -23,10 +23,10 @@ pub mod toolbar;
 
 pub use blend_graph::{AdditiveBlendNode, AnimationBlendGraph, BlendNode, ClipNodeRef, OutputNode};
 pub use clip::{
-    AnimationTrack, Clip, ClipRecording, F32Keyframe, GltfClipRef, ImportedClipView, Interpolation,
-    KeyframeClipboard, KeyframeClipboardEntry, KeyframeValue, LoopMode, OnionSkin, QuatKeyframe,
-    SelectedClip, SelectedKeyframes, SelectedTrack, TimelineSnap, TimelineSnapHint, TimelineView,
-    TimelineZoom, Vec3Keyframe,
+    AnimationTrack, Clip, ClipRecording, F32Keyframe, FiredClipEvents, GltfClipRef,
+    ImportedClipView, Interpolation, KeyframeClipboard, KeyframeClipboardEntry, KeyframeValue,
+    LoopMode, OnionSkin, QuatKeyframe, SelectedClip, SelectedKeyframes, SelectedTrack,
+    TimelineSnap, TimelineSnapHint, TimelineView, TimelineZoom, Vec3Keyframe,
 };
 pub use compile::{
     CompiledClip, clip_display_duration, compile_blend_graphs, compile_clips, max_keyframe_time,
@@ -47,8 +47,8 @@ pub use timeline::{
     TimelineCreateClipButton, TimelineDirty, TimelinePanelRoot, clear_snap_hint_on_drag_end,
     handle_scrubber_click, handle_scrubber_drag, handle_scrubber_drag_end,
     handle_scrubber_drag_start, mark_timeline_dirty_on_data_change, pick_tick_step,
-    rebuild_timeline, timeline_panel, update_key_readout, update_keyframe_highlight,
-    update_playhead_position,
+    rebuild_timeline, timeline_panel, update_event_marker_highlight, update_key_readout,
+    update_keyframe_highlight, update_playhead_position,
 };
 pub use toolbar::{
     TimelineClipSelector, TimelineDurationInput, TimelineFrameInput, TimelineLoopSegment,
@@ -75,6 +75,7 @@ impl Plugin for AnimationPlugin {
             .init_resource::<ClipRecording>()
             .init_resource::<OnionSkin>()
             .init_resource::<ImportedClipView>()
+            .init_resource::<FiredClipEvents>()
             .init_resource::<timeline::TimelineMarquee>()
             .init_resource::<timeline::KeyframeDragOrigin>()
             .init_resource::<ActiveClipBinding>()
@@ -130,6 +131,7 @@ impl Plugin for AnimationPlugin {
                     rebuild_timeline,
                     update_playhead_position,
                     update_keyframe_highlight,
+                    update_event_marker_highlight,
                     update_key_readout,
                     timeline::update_marquee_box,
                 )

--- a/crates/jackdaw_animation/src/sheet.rs
+++ b/crates/jackdaw_animation/src/sheet.rs
@@ -112,6 +112,8 @@ pub struct ClipContents<'w, 's> {
     pub names: Query<'w, 's, &'static Name>,
     /// Parent links, for finding the entity a clip animates.
     pub parents: Query<'w, 's, &'static ChildOf>,
+    /// Child links, for reading the events on an imported clip's row.
+    pub children: Query<'w, 's, &'static Children>,
 }
 
 impl ClipContents<'_, '_> {
@@ -139,6 +141,25 @@ impl ClipContents<'_, '_> {
         } else {
             self.f32_keyframes.get(key).ok().map(|key| key.time)
         }
+    }
+
+    /// The events on one clip-event row, which is how an imported clip's markers
+    /// are drawn: they hang under a row of the entity, not under a clip.
+    pub fn keys_of_row(&self, row: Option<Entity>) -> Vec<RowKey> {
+        let mut keys: Vec<RowKey> = row
+            .and_then(|row| self.children.get(row).ok())
+            .into_iter()
+            .flatten()
+            .filter_map(|child| {
+                self.events.get(*child).ok().map(|event| RowKey {
+                    entity: *child,
+                    time: event.time,
+                    name: Some(event.name.clone()),
+                })
+            })
+            .collect();
+        keys.sort_by(|a, b| a.time.total_cmp(&b.time));
+        keys
     }
 
     /// The rows an authored clip draws: a summary, its events, then one group
@@ -176,9 +197,6 @@ impl ClipContents<'_, '_> {
         event_row.keys = events;
 
         let mut rows = vec![summary, event_row];
-        // Tracks address the clip's parent today, so one group covers them
-        // all. The heading is drawn anyway, because that is where a track on
-        // a descendant would hang once tracks can name one.
         if !tracks.is_empty() {
             rows.push(SheetRow::plain(
                 RowKind::Group,
@@ -597,8 +615,6 @@ pub fn spawn_sheet(
         Pickable::IGNORE,
         ChildOf(sheet),
         children![(
-            // The triangle head, drawn as a square turned onto a corner so it
-            // reads as a pointer without needing a mesh.
             Node {
                 position_type: PositionType::Absolute,
                 left: Val::Px(-4.0),
@@ -612,6 +628,12 @@ pub fn spawn_sheet(
             Pickable::IGNORE,
         )],
     ));
+}
+
+/// How many frames apart the minor ticks run, thinned so that a long clip does
+/// not draw one tick per pixel.
+fn minor_tick_stride(frames: f32) -> f32 {
+    (frames / 240.0).ceil().max(1.0)
 }
 
 /// The ruler: a label every whole tick, a minor tick every frame.
@@ -637,10 +659,8 @@ fn spawn_ruler(commands: &mut Commands, sheet: Entity, layout: SheetLayout) {
         return;
     }
 
-    // Minor ticks run at the snap rate, thinned out so a long clip does not
-    // draw a tick per pixel.
     let frames = (layout.duration * layout.rate).ceil().max(1.0);
-    let every = (frames / 240.0).ceil().max(1.0);
+    let every = minor_tick_stride(frames);
     let mut frame = 0.0_f32;
     while frame <= frames {
         let percent = (frame / frames).clamp(0.0, 1.0) * 100.0;
@@ -763,9 +783,8 @@ fn spawn_diamond(
     kind: &RowKind,
     layout: SheetLayout,
 ) {
-    // A summary diamond stands for a key on some other row, so it is drawn
-    // narrower: it is a place to look, not the handle you drag.
-    let size = if matches!(kind, RowKind::Summary) {
+    let stands_for_a_key_on_another_row = matches!(kind, RowKind::Summary);
+    let size = if stands_for_a_key_on_another_row {
         7.0
     } else {
         10.0
@@ -813,6 +832,7 @@ fn spawn_event_marker(
                 column_gap: Val::Px(tokens::SPACING_XS),
                 ..default()
             },
+            BackgroundColor(Color::NONE),
             Pickable::default(),
             ChildOf(strip),
         ))
@@ -882,8 +902,8 @@ fn spawn_curves(
         return;
     };
     let span = (high - low).max(f32::EPSILON);
-    // Height runs downwards, so a high value sits near the top.
-    let height_percent = |value: f32| (1.0 - (value - low) / span).clamp(0.0, 1.0) * 100.0;
+    let percent_down_from_the_top =
+        |value: f32| (1.0 - (value - low) / span).clamp(0.0, 1.0) * 100.0;
 
     for (axis, samples) in series {
         let color = axis_color(axis);
@@ -891,7 +911,7 @@ fn spawn_curves(
         for step in 0..=CURVE_SAMPLES {
             let time = layout.duration * step as f32 / CURVE_SAMPLES as f32;
             let value = sample_at(samples, time);
-            let at = height_percent(value);
+            let at = percent_down_from_the_top(value);
             if let Some(from) = previous {
                 let top = at.min(from);
                 let height = (at - from).abs().max(0.4);
@@ -918,7 +938,7 @@ fn spawn_curves(
                 Node {
                     position_type: PositionType::Absolute,
                     left: Val::Percent(time_percent(*time, layout.duration)),
-                    top: Val::Percent(height_percent(*value)),
+                    top: Val::Percent(percent_down_from_the_top(*value)),
                     width: Val::Px(6.0),
                     height: Val::Px(6.0),
                     margin: UiRect::new(Val::Px(-3.0), Val::Px(0.0), Val::Px(-3.0), Val::Px(0.0)),

--- a/crates/jackdaw_animation/src/timeline.rs
+++ b/crates/jackdaw_animation/src/timeline.rs
@@ -23,15 +23,15 @@ use lucide_icons::Icon;
 
 use crate::blend_graph::AnimationBlendGraph;
 use crate::clip::{
-    AnimationTrack, Clip, ClipRecording, F32Keyframe, ImportedClipView, OnionSkin, QuatKeyframe,
-    SelectedClip, SelectedKeyframes, SelectedTrack, TimelineSnap, TimelineSnapHint, TimelineView,
-    TimelineZoom, Vec3Keyframe,
+    AnimationTrack, Clip, ClipRecording, F32Keyframe, FiredClipEvents, ImportedClipView, OnionSkin,
+    QuatKeyframe, SelectedClip, SelectedKeyframes, SelectedTrack, TimelineSnap, TimelineSnapHint,
+    TimelineView, TimelineZoom, Vec3Keyframe,
 };
 use crate::compile::clip_display_duration;
 use crate::player::{TimelineCursor, TimelineEngagement};
 use crate::sheet::{
-    ClipContents, RowKind, SheetLayout, SheetRow, TimelineKeyReadout, TimelineKeyframeHandle,
-    TimelinePlayheadIndicator, TimelineScrubber, TimelineSheetBody,
+    ClipContents, RowKind, SheetLayout, SheetRow, TimelineEventHandle, TimelineKeyReadout,
+    TimelineKeyframeHandle, TimelinePlayheadIndicator, TimelineScrubber, TimelineSheetBody,
 };
 use crate::toolbar::ToolbarState;
 
@@ -258,7 +258,14 @@ pub fn rebuild_timeline(
                 );
             }
             None if settings.imported.clip.is_some() => {
-                spawn_imported_clip(&mut commands, panel, &choices, &settings, &icon_font);
+                spawn_imported_clip(
+                    &mut commands,
+                    panel,
+                    &choices,
+                    &settings,
+                    &icon_font,
+                    &contents,
+                );
             }
             None => spawn_placeholder(&mut commands, panel),
         }
@@ -417,6 +424,7 @@ fn spawn_imported_clip(
     choices: &[(Entity, String)],
     settings: &TimelineSettings,
     icon_font: &IconFont,
+    contents: &ClipContents,
 ) {
     let imported = &*settings.imported;
     crate::toolbar::spawn_toolbar(
@@ -425,8 +433,11 @@ fn spawn_imported_clip(
         &toolbar_state(None, None, choices, settings, true),
         icon_font,
     );
+    let mut events = read_only_row(RowKind::Events, "Events".to_string(), 0);
+    events.keys = contents.keys_of_row(imported.row);
     let mut rows = vec![
         read_only_row(RowKind::Summary, imported.name.clone(), 0),
+        events,
         read_only_row(
             RowKind::Group,
             format!("Skeleton ({} tracks)", imported.curve_count),
@@ -618,6 +629,28 @@ pub fn update_keyframe_highlight(
         } else {
             bg.0 = tokens::ACCENT_BLUE;
             *border = BorderColor::all(Color::WHITE.with_alpha(0.4));
+        }
+    }
+}
+
+/// Light an event marker for a moment after playback crosses it, so an author
+/// scrubbing a clip can see which frame hit.
+pub fn update_event_marker_highlight(
+    time: Res<Time<Real>>,
+    mut fired: ResMut<FiredClipEvents>,
+    mut markers: Query<(&TimelineEventHandle, &mut BackgroundColor)>,
+) {
+    if !fired.is_empty() {
+        fired.fade(time.delta_secs());
+    }
+    for (marker, mut background) in &mut markers {
+        let wanted = if fired.is_lit(marker.event) {
+            tokens::TEXT_WARNING.with_alpha(0.35)
+        } else {
+            Color::NONE
+        };
+        if background.0 != wanted {
+            background.0 = wanted;
         }
     }
 }
@@ -973,9 +1006,8 @@ fn seek_for_pointer(
         clip_display_duration(clip_entity, clips)
     };
     let raw = time_for_cursor(logical_cursor_x, computed, global, duration);
-    // Shift holds snapping off for precise placement, as it does for the grid
-    // and the viewport elsewhere in the editor.
-    if keys.any_pressed([KeyCode::ShiftLeft, KeyCode::ShiftRight]) || !snap.enabled {
+    let shift_holds_snapping_off = keys.any_pressed([KeyCode::ShiftLeft, KeyCode::ShiftRight]);
+    if shift_holds_snapping_off || !snap.enabled {
         return SnapResult {
             time: raw,
             hovered_keyframe: None,
@@ -1089,13 +1121,12 @@ mod tests {
     }
 
     #[test]
-    fn dragging_a_key_snaps_to_the_rate() {
+    fn a_time_just_off_a_frame_snaps_back_onto_it() {
         let snap = snap_at(30.0);
+        let ten_frames_at_thirty = 10.0 / 30.0;
 
-        // A third of a second is ten frames at thirty, and a time just off it
-        // has to land back on the frame rather than between two.
         assert!(
-            (snap.round(0.334) - 10.0 / 30.0).abs() < 1e-5,
+            (snap.round(0.334) - ten_frames_at_thirty).abs() < 1e-5,
             "{}",
             snap.round(0.334)
         );

--- a/crates/jackdaw_animation_runtime/src/lib.rs
+++ b/crates/jackdaw_animation_runtime/src/lib.rs
@@ -178,10 +178,8 @@ impl Plugin for AnimationRuntimePlugin {
     fn build(&self, app: &mut App) {
         register_animation_set_types(app);
         graph::register_animation_graph_types(app);
-        // The graph asset and its loader need an asset server to register
-        // against; without one this stays the set half alone, which is what an
-        // app that only authors documents wants.
-        if app.is_plugin_added::<AssetPlugin>() {
+        let graph_assets_can_be_loaded = app.is_plugin_added::<AssetPlugin>();
+        if graph_assets_can_be_loaded {
             app.init_asset::<AnimationGraphAsset>()
                 .init_asset_loader::<AnimationGraphLoader>();
         }
@@ -226,9 +224,6 @@ impl Plugin for AnimationRuntimePlugin {
                     .in_set(AnimationSetSystems)
                     .after(apply_animation_state)
                     .after(graph::advance_animation_graphs)
-                    // Before a `then` writes the state it moves on to, so
-                    // the keys at the tail of the clip that ran out are still
-                    // read against that clip.
                     .before(report_finished_states),
             );
     }
@@ -401,14 +396,7 @@ fn merge_part_skeletons(
             .map_or(entity, |&ChildOf(parent)| parent);
 
         for part in candidates {
-            // A part exported beside its skeleton keeps its meshes as the
-            // skeleton's siblings, so the part is its parent's whole subtree.
-            let part_root = child_of
-                .get(part)
-                .map(|&ChildOf(parent)| parent)
-                .ok()
-                .filter(|&parent| !descendants(parent, &children).contains(&primary))
-                .unwrap_or(part);
+            let part_root = part_subtree_root(part, primary, &child_of, &children);
             let part_meshes: Vec<Entity> = descendants(part_root, &children)
                 .into_iter()
                 .filter(|&mesh| skins.contains(mesh))
@@ -431,6 +419,22 @@ fn merge_part_skeletons(
             commands.entity(part).despawn();
         }
     }
+}
+
+/// The subtree holding a part's meshes: a part exported beside its skeleton
+/// keeps them as the skeleton's siblings, so its root is the part's parent.
+fn part_subtree_root(
+    part: Entity,
+    primary: Entity,
+    child_of: &Query<&ChildOf>,
+    children: &Query<&Children>,
+) -> Entity {
+    child_of
+        .get(part)
+        .map(|&ChildOf(parent)| parent)
+        .ok()
+        .filter(|&parent| !descendants(parent, children).contains(&primary))
+        .unwrap_or(part)
 }
 
 /// Plays the state an [`AnimationState`] was changed to.
@@ -492,9 +496,9 @@ impl<'a> PlayingClip<'a> {
     }
 }
 
-/// Writes each bound entity's playhead onto the clip entity that carries
-/// that clip's events; a graph beside a set drives the entity alone.
-fn write_clip_playheads(
+/// Writes each bound entity's playhead onto the clip entity that carries that
+/// clip's events; a graph beside a set drives the entity alone.
+pub fn write_clip_playheads(
     mut commands: Commands,
     sets: Query<
         (Entity, &AnimationSet, &AnimationSetBound, &AnimationState),
@@ -502,12 +506,16 @@ fn write_clip_playheads(
     >,
     graphs: Query<(Entity, &AnimationGraphBound, &graph::AnimationGraphPlayback)>,
     players: Query<&AnimationPlayer>,
+    installed: Query<&AnimationGraphHandle>,
     children: Query<&Children>,
     names: Query<&Name>,
     marked: Query<(), With<ClipEvent>>,
     mut playheads: Query<&mut ClipPlayhead>,
 ) {
     for (owner, set, bound, state) in &sets {
+        if !plays_its_own_graph(bound.player, &bound.graph, &installed) {
+            continue;
+        }
         let playing = resolve_state(set, &bound.nodes, &state.0).and_then(|(def, node)| {
             let active = players.get(bound.player).ok()?.animation(node)?;
             let source = set.sources.get(def.source).map_or("", String::as_str);
@@ -524,6 +532,9 @@ fn write_clip_playheads(
         );
     }
     for (owner, bound, playback) in &graphs {
+        if !plays_its_own_graph(bound.player, &bound.graph, &installed) {
+            continue;
+        }
         let playing = players.get(bound.player).ok().and_then(|player| {
             let (source, clip, node) = bound.leading_clip_of(player, &playback.state)?;
             Some(PlayingClip::read(source, clip, player.animation(node)?))
@@ -538,6 +549,18 @@ fn write_clip_playheads(
             &mut playheads,
         );
     }
+}
+
+/// Whether a player is still wearing the graph its binding built, rather than
+/// one an editor swapped in to preview a clip through it.
+fn plays_its_own_graph(
+    player: Entity,
+    graph: &Handle<AnimationGraph>,
+    installed: &Query<&AnimationGraphHandle>,
+) -> bool {
+    installed
+        .get(player)
+        .is_ok_and(|handle| handle.0.id() == graph.id())
 }
 
 /// Moves the playhead of the clip entity directly under `owner` that stands
@@ -582,7 +605,7 @@ fn write_playheads_under(
 
 /// Whether a clip entity name stands for `clip` out of `source`: a bare
 /// clip name, or `<file>#<clip>` when the file matters.
-fn stands_for_clip(name: &str, source: &str, clip: &str) -> bool {
+pub fn stands_for_clip(name: &str, source: &str, clip: &str) -> bool {
     match name.split_once('#') {
         Some((file, named)) => file == source && named == clip,
         None => name == clip,
@@ -614,12 +637,10 @@ fn report_finished_states(
         if transitions.get_main_animation() != Some(node) {
             continue;
         }
-        // `just_completed` holds for the one frame the clip ran out on, which
-        // is what keeps a state with no `then` from reporting forever.
-        let ran_out = player
+        let ran_out_this_frame = player
             .animation(node)
             .is_some_and(|active| active.just_completed() && active.is_finished());
-        if !ran_out {
+        if !ran_out_this_frame {
             continue;
         }
         finished.write(AnimationStateFinished {
@@ -650,12 +671,11 @@ fn play_state(
     player: &mut AnimationPlayer,
     transitions: &mut AnimationTransitions,
 ) {
-    // Asking again for the state already running would restart its fade.
-    if transitions.get_main_animation() == Some(node)
+    let already_running = transitions.get_main_animation() == Some(node)
         && player
             .animation(node)
-            .is_some_and(|active| !active.is_finished())
-    {
+            .is_some_and(|active| !active.is_finished());
+    if already_running {
         return;
     }
     let repeat = if def.looped {

--- a/src/animation/markers.rs
+++ b/src/animation/markers.rs
@@ -1,0 +1,236 @@
+//! Clip event markers away from an authored clip: the row an imported clip's
+//! events hang under, and the events the editor's own playback crosses.
+//!
+//! A glTF clip is not an entity the document holds, so its markers cannot hang
+//! under it. They hang under a named child of the entity the clip plays on,
+//! which is the same row [`jackdaw_animation_runtime`] looks for in a running
+//! game.
+
+use bevy::prelude::*;
+use jackdaw_animation::{
+    AnimationStop, ClipEvent, FiredClipEvents, ImportedClipView, SelectedClip, TimelineCursor,
+    TimelineEngagement,
+};
+use jackdaw_animation_runtime::{AnimationEvent, ClipPass, ClipPlayhead, stands_for_clip};
+
+use super::preview::AnimationPreview;
+use crate::status_bar::StatusNotice;
+
+/// The clip-event row the Timeline is driving, so a fired event can be traced
+/// back to the marker that stands for it.
+#[derive(Resource, Default, Debug)]
+struct DrivenClipRow(Option<Entity>);
+
+/// What a row holding a library clip's events is called, which is the spelling
+/// the runtime reads back when two files hold the same clip name.
+pub(super) fn clip_event_row_name(file: &str, clip: &str) -> String {
+    format!("{file}#{clip}")
+}
+
+/// The child of `owner` carrying `clip`'s events: named for the clip and, unlike
+/// a bone or a prefab part, holding no place in the scene and so no `Transform`.
+pub(super) fn clip_event_row(
+    owner: Entity,
+    file: &str,
+    clip: &str,
+    children: &Query<&Children>,
+    names: &Query<&Name>,
+    placed: &Query<(), With<Transform>>,
+) -> Option<Entity> {
+    children
+        .get(owner)
+        .into_iter()
+        .flatten()
+        .copied()
+        .find(|child| {
+            !placed.contains(*child)
+                && names
+                    .get(*child)
+                    .is_ok_and(|name| stands_for_clip(name.as_str(), file, clip))
+        })
+}
+
+/// The same, read off a world rather than a query.
+pub(super) fn clip_event_row_in(
+    world: &World,
+    owner: Entity,
+    file: &str,
+    clip: &str,
+) -> Option<Entity> {
+    world
+        .get::<Children>(owner)
+        .into_iter()
+        .flatten()
+        .copied()
+        .find(|child| {
+            world.get::<Transform>(*child).is_none()
+                && world
+                    .get::<Name>(*child)
+                    .is_some_and(|name| stands_for_clip(name.as_str(), file, clip))
+        })
+}
+
+/// Move the playhead of the row the Timeline is showing, so its events fire in
+/// the editor as they would in a game, and only where the runtime writes none.
+fn write_shown_clip_playhead(
+    selected: Res<SelectedClip>,
+    engagement: Res<TimelineEngagement>,
+    imported: Res<ImportedClipView>,
+    cursor: Res<TimelineCursor>,
+    preview: Res<AnimationPreview>,
+    mut rewinds: MessageReader<AnimationStop>,
+    mut driven: ResMut<DrivenClipRow>,
+    marked: Query<(), With<ClipEvent>>,
+    children: Query<&Children>,
+    mut playheads: Query<&mut ClipPlayhead>,
+    mut commands: Commands,
+) {
+    let rewound = rewinds.read().last().is_some();
+    let transport_holds_the_player = *engagement == TimelineEngagement::Active;
+    let row = selected
+        .0
+        .filter(|_| transport_holds_the_player)
+        .or(imported.row)
+        .filter(|row| {
+            children
+                .get(*row)
+                .is_ok_and(|keys| keys.iter().any(|key| marked.contains(key)))
+        });
+    let row_left_behind = driven.0.filter(|left| Some(*left) != row);
+    if let Some(left) = row_left_behind
+        && let Ok(mut held) = commands.get_entity(left)
+    {
+        held.try_remove::<ClipPlayhead>();
+    }
+    let Some(row) = row else {
+        driven.0 = None;
+        return;
+    };
+
+    let seek = cursor.seek_time.max(0.0);
+    let taken_up_this_frame = rewound || driven.0 != Some(row);
+    driven.0 = Some(row);
+    let seeded = ClipPlayhead {
+        last: seek,
+        now: seek,
+        pass: ClipPass::Forward,
+    };
+    match playheads.get_mut(row) {
+        Err(_) => {
+            commands.entity(row).insert(seeded);
+        }
+        Ok(mut playhead) if taken_up_this_frame => *playhead = seeded,
+        Ok(mut playhead) => {
+            let playing = cursor.is_playing || preview.is_playing();
+            let pass = pass_between(playhead.now, seek, playing);
+            playhead.advance_to(seek, pass);
+        }
+    }
+}
+
+/// How the playhead travelled between two readings: playback runs forward, so a
+/// reading behind the last one wrapped, while a parked one was scrubbed back.
+fn pass_between(previous: f32, now: f32, playing: bool) -> ClipPass {
+    match (now < previous, playing) {
+        (true, true) => ClipPass::ForwardWrapped,
+        (true, false) => ClipPass::Backward,
+        (false, _) => ClipPass::Forward,
+    }
+}
+
+/// Light the marker of every event the shown clip has just crossed, and say
+/// which one it was.
+fn report_fired_clip_events(
+    mut fired: MessageReader<AnimationEvent>,
+    driven: Res<DrivenClipRow>,
+    children: Query<&Children>,
+    parents: Query<&ChildOf>,
+    events: Query<&ClipEvent>,
+    mut lit: ResMut<FiredClipEvents>,
+    mut notice: ResMut<StatusNotice>,
+) {
+    let Some(row) = driven.0 else {
+        fired.clear();
+        return;
+    };
+    let animated = parents.get(row).map_or(row, ChildOf::parent);
+    for message in fired.read().filter(|message| message.entity == animated) {
+        let crossed: Vec<(Entity, f32)> = children
+            .get(row)
+            .into_iter()
+            .flatten()
+            .filter_map(|child| {
+                events
+                    .get(*child)
+                    .ok()
+                    .filter(|event| event.name == message.name)
+                    .map(|event| (*child, event.time))
+            })
+            .collect();
+        for (event, _) in &crossed {
+            lit.light(*event);
+        }
+        if let Some((_, time)) = crossed.first() {
+            notice.show(format!("{} at {time:.2} s", message.name));
+        }
+    }
+}
+
+pub(super) fn plugin(app: &mut App) {
+    app.init_resource::<DrivenClipRow>().add_systems(
+        Update,
+        (
+            write_shown_clip_playhead
+                .after(jackdaw_animation::sync_cursor_from_player)
+                .after(super::preview::drive_preview_player)
+                .after(jackdaw_animation_runtime::write_clip_playheads)
+                .before(jackdaw_animation_runtime::fire_clip_events),
+            report_fired_clip_events.after(jackdaw_animation_runtime::fire_clip_events),
+        )
+            .run_if(in_state(crate::AppState::Editor)),
+    );
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn a_playing_clip_that_reads_back_has_wrapped() {
+        assert_eq!(pass_between(0.9, 0.1, true), ClipPass::ForwardWrapped);
+        assert_eq!(pass_between(0.1, 0.9, true), ClipPass::Forward);
+    }
+
+    #[test]
+    fn a_parked_clip_that_reads_back_was_scrubbed_back() {
+        assert_eq!(pass_between(0.9, 0.1, false), ClipPass::Backward);
+        assert_eq!(pass_between(0.1, 0.9, false), ClipPass::Forward);
+    }
+
+    #[test]
+    fn a_playhead_that_did_not_move_reads_as_a_forward_step() {
+        assert_eq!(pass_between(0.5, 0.5, true), ClipPass::Forward);
+        assert_eq!(pass_between(0.5, 0.5, false), ClipPass::Forward);
+    }
+
+    #[test]
+    fn a_row_name_tells_two_files_holding_the_same_clip_apart() {
+        let row = clip_event_row_name("jan/jan.gltf", "run");
+        assert!(stands_for_clip(&row, "jan/jan.gltf", "run"));
+        assert!(!stands_for_clip(&row, "other/other.gltf", "run"));
+    }
+
+    #[test]
+    fn a_bone_named_like_the_clip_is_not_the_event_row() {
+        let mut world = World::new();
+        let rig = world.spawn(Name::new("Rig")).id();
+        world.spawn((Name::new("run"), Transform::default(), ChildOf(rig)));
+        assert_eq!(clip_event_row_in(&world, rig, "jan/jan.gltf", "run"), None);
+
+        let row = world.spawn((Name::new("run"), ChildOf(rig))).id();
+        assert_eq!(
+            clip_event_row_in(&world, rig, "jan/jan.gltf", "run"),
+            Some(row)
+        );
+    }
+}

--- a/src/animation/mod.rs
+++ b/src/animation/mod.rs
@@ -1,6 +1,7 @@
 //! The Animation panel and the clip library behind it.
 
 pub mod library;
+pub mod markers;
 pub mod panel;
 pub mod preview;
 pub mod timeline_glue;
@@ -16,6 +17,7 @@ use jackdaw_api::prelude::*;
 pub(crate) fn plugin(app: &mut App) {
     app.add_plugins((
         library::plugin,
+        markers::plugin,
         panel::plugin,
         preview::plugin,
         timeline_glue::plugin,

--- a/src/animation/preview.rs
+++ b/src/animation/preview.rs
@@ -13,7 +13,7 @@ use bevy::gltf::Gltf;
 use bevy::prelude::*;
 use bevy::world_serialization::{WorldAsset, WorldAssetRoot};
 use jackdaw_animation::graph_owner::{LoanedPlayer, PlayerLoan, lend_player, return_player};
-use jackdaw_animation_runtime::{AnimationSet, AnimationSetBound, AnimationState};
+use jackdaw_animation_runtime::{AnimationSet, AnimationSetBound, AnimationState, ClipPlayhead};
 use jackdaw_api::prelude::*;
 
 use super::panel::AnimationPanelState;
@@ -47,6 +47,9 @@ const MANNEQUIN_PATIENCE_FRAMES: u32 = 600;
 #[derive(Debug)]
 struct Active {
     target: Entity,
+    /// The document entity the clip plays on, which is what an event added to
+    /// it hangs under. `None` when the clip is playing on a mannequin.
+    owner: Option<Entity>,
     mannequin: Option<Entity>,
     file: String,
     clip: String,
@@ -74,6 +77,11 @@ impl AnimationPreview {
     /// The entity whose player is borrowed.
     pub fn target(&self) -> Option<Entity> {
         self.active.as_ref().map(|active| active.target)
+    }
+
+    /// The document entity a clip event added now would hang under.
+    pub fn owner(&self) -> Option<Entity> {
+        self.active.as_ref().and_then(|active| active.owner)
     }
 
     /// Whether the clip is running rather than held on a frame.
@@ -120,8 +128,6 @@ pub(crate) fn animation_preview(
     mut panel: ResMut<AnimationPanelState>,
 ) -> OperatorResult {
     let Some(spec) = params.as_str("clip").filter(|spec| !spec.is_empty()) else {
-        // The transport's play button carries no clip: it means the one that
-        // is up, held on a frame by a pause.
         let Some(active) = preview.active.as_mut() else {
             return OperatorResult::Cancelled;
         };
@@ -133,8 +139,6 @@ pub(crate) fn animation_preview(
     panel.clip = Some(clip.to_string());
 
     let entity = params.as_entity("entity").or_else(|| selection.primary());
-    // Asking again for the clip already up resumes it rather than restarting,
-    // which is what the panel's play button means after a pause.
     if let Some(active) = preview.active.as_mut()
         && active.file == file
         && active.clip == clip
@@ -201,10 +205,29 @@ pub fn stop_preview(world: &mut World) {
         return;
     };
     return_player(world, active.target);
+    clear_clip_playheads_under(world, active.owner);
     if let Some(mannequin) = active.mannequin
         && let Ok(mannequin) = world.get_entity_mut(mannequin)
     {
         mannequin.despawn();
+    }
+}
+
+/// Take the playheads off a returned entity's clip-event rows, so whatever
+/// drives it next seeds them rather than reading a span nothing played.
+fn clear_clip_playheads_under(world: &mut World, owner: Option<Entity>) {
+    let Some(owner) = owner else {
+        return;
+    };
+    let rows: Vec<Entity> = world
+        .get::<Children>(owner)
+        .into_iter()
+        .flatten()
+        .copied()
+        .filter(|row| world.get::<ClipPlayhead>(*row).is_some())
+        .collect();
+    for row in rows {
+        world.entity_mut(row).remove::<ClipPlayhead>();
     }
 }
 
@@ -249,11 +272,10 @@ fn start_requested_preview(world: &mut World) {
     };
     let first_scene = gltf.scenes.first().cloned();
 
-    let Some(target) = resolve_target(world, &mut request, first_scene) else {
-        // Either a model is still spawning, or there is nothing to play on and
-        // `resolve_target` has already said so.
+    let Some(found) = resolve_target(world, &mut request, first_scene) else {
         return;
     };
+    let PreviewTarget { player, owner } = found;
 
     stop_preview(world);
 
@@ -262,12 +284,12 @@ fn start_requested_preview(world: &mut World) {
         .get(&clip_handle)
         .map_or(0.0, AnimationClip::duration);
     let repeat = super::library::looped_hint(&request.clip);
-    let tagged = jackdaw_animation_runtime::tag_animation_targets(world, target);
+    let tagged = jackdaw_animation_runtime::tag_animation_targets(world, player);
     let (graph, node) = AnimationGraph::from_clip(clip_handle);
     let graph = world.resource_mut::<Assets<AnimationGraph>>().add(graph);
     lend_player(
         world,
-        target,
+        player,
         PlayerLoan::new(graph, node)
             .at(0.0, true)
             .repeating(repeat)
@@ -277,7 +299,8 @@ fn start_requested_preview(world: &mut World) {
     let mut preview = world.resource_mut::<AnimationPreview>();
     preview.wanted = None;
     preview.active = Some(Active {
-        target,
+        target: player,
+        owner,
         mannequin: request.mannequin,
         file: request.file,
         clip: request.clip,
@@ -286,6 +309,13 @@ fn start_requested_preview(world: &mut World) {
         elapsed_secs: 0.0,
         playing: true,
     });
+}
+
+/// The player a preview drives, and the document entity it plays on.
+struct PreviewTarget {
+    player: Entity,
+    /// `None` for a mannequin, which no document entity owns.
+    owner: Option<Entity>,
 }
 
 /// The entity whose player the clip should drive.
@@ -302,12 +332,13 @@ fn resolve_target(
     world: &mut World,
     request: &mut Request,
     first_scene: Option<Handle<WorldAsset>>,
-) -> Option<Entity> {
+) -> Option<PreviewTarget> {
     if let Some(mannequin) = request.mannequin {
-        // The model spawns over a few frames; keep the request until its
-        // skeleton is there.
         if let Some(player) = player_descendant(world, mannequin) {
-            return Some(player);
+            return Some(PreviewTarget {
+                player,
+                owner: None,
+            });
         }
         request.waited += 1;
         if request.waited > MANNEQUIN_PATIENCE_FRAMES {
@@ -327,32 +358,40 @@ fn resolve_target(
         .filter(|&entity| world.entities().contains(entity))
     {
         let under = descendants(world, entity);
-        let mut names_a_skeleton = false;
+        let mut skeleton_is_built_elsewhere = false;
         for &candidate in &under {
             if let Some(bound) = world.get::<AnimationSetBound>(candidate) {
-                return Some(bound.player);
+                return Some(PreviewTarget {
+                    player: bound.player,
+                    owner: Some(candidate),
+                });
             }
             let Some(set) = world.get::<AnimationSet>(candidate) else {
                 continue;
             };
-            names_a_skeleton = true;
+            skeleton_is_built_elsewhere = true;
             let wanted = set.skeleton_root.clone();
             if let Some(root) = descendant_named(world, candidate, &wanted) {
-                return Some(root);
+                return Some(PreviewTarget {
+                    player: root,
+                    owner: Some(candidate),
+                });
             }
         }
         if let Some(player) = player_descendant(world, entity) {
-            return Some(player);
+            return Some(PreviewTarget {
+                player,
+                owner: Some(entity),
+            });
         }
-        // A set whose skeleton is nowhere under it is worn by something the
-        // game builds, not by anything in the open scene, so it has no bones
-        // here to drive.
-        if !names_a_skeleton && world.get::<Children>(entity).is_some() {
-            return Some(entity);
+        if !skeleton_is_built_elsewhere && world.get::<Children>(entity).is_some() {
+            return Some(PreviewTarget {
+                player: entity,
+                owner: Some(entity),
+            });
         }
     }
 
-    // Nothing selected wears a skeleton, so give the clip a body of its own.
     let Some(scene) = first_scene else {
         warn!(
             "animation.preview: nothing selected has a skeleton, and {} holds no scene to \
@@ -409,11 +448,20 @@ fn descendants(world: &World, root: Entity) -> Vec<Entity> {
     found
 }
 
-/// Keep the preview's transport in step with the player it borrowed.
-fn drive_preview_player(
+/// Keep the preview's transport in step with the player it borrowed, and the
+/// Timeline's playhead in step with both; a ruler seek reaches the player here.
+pub(super) fn drive_preview_player(
     mut preview: ResMut<AnimationPreview>,
+    selected: Res<jackdaw_animation::SelectedClip>,
+    mut cursor: ResMut<jackdaw_animation::TimelineCursor>,
+    mut seeks: MessageReader<jackdaw_animation::AnimationSeek>,
+    mut stops: MessageReader<jackdaw_animation::AnimationStop>,
     mut players: Query<&mut AnimationPlayer>,
 ) {
+    let showing_the_preview = selected.0.is_none();
+    let seeking = seeks.read().last().map(|seek| seek.0);
+    let rewound = stops.read().last().is_some();
+    let sought = if rewound { Some(0.0) } else { seeking };
     let Some(active) = preview.active.as_mut() else {
         return;
     };
@@ -430,7 +478,13 @@ fn drive_preview_player(
             animation.pause();
         }
     }
+    if let Some(time) = sought.filter(|_| showing_the_preview) {
+        animation.seek_to(time.max(0.0));
+    }
     active.elapsed_secs = animation.seek_time();
+    if showing_the_preview && cursor.seek_time != active.elapsed_secs {
+        cursor.seek_time = active.elapsed_secs;
+    }
 }
 
 /// Play a bound set's state again once the editor hands its player back.

--- a/src/animation/timeline_glue.rs
+++ b/src/animation/timeline_glue.rs
@@ -381,6 +381,9 @@ pub(super) fn describe_previewed_clip(
     asset_server: Res<AssetServer>,
     clips: Res<Assets<AnimationClip>>,
     targets: Query<(&AnimationTargetId, &Name)>,
+    children: Query<&Children>,
+    names: Query<&Name>,
+    placed: Query<(), With<Transform>>,
 ) {
     let wanted = preview
         .clip()
@@ -393,8 +396,15 @@ pub(super) fn describe_previewed_clip(
         }
         return;
     };
+    let row = preview.owner().and_then(|owner| {
+        super::markers::clip_event_row(owner, &file, &name, &children, &names, &placed)
+    });
     let spec = format!("{file}#{name}");
     if view.clip.as_deref() == Some(spec.as_str()) {
+        if view.row != row {
+            view.row = row;
+            dirty.0 = true;
+        }
         return;
     }
 
@@ -407,10 +417,7 @@ pub(super) fn describe_previewed_clip(
         return;
     };
 
-    // A clip addresses its bones by a hash of the name path, so a name can be
-    // read back only where a skeleton wearing those ids is in the scene. Where
-    // it is not, the count is all there is to say.
-    let mut bones: Vec<String> = clip
+    let mut bones_a_skeleton_in_the_scene_can_name: Vec<String> = clip
         .curves()
         .keys()
         .filter_map(|wanted| {
@@ -420,15 +427,16 @@ pub(super) fn describe_previewed_clip(
                 .map(|(_, name)| name.as_str().to_string())
         })
         .collect();
-    bones.sort_unstable();
-    bones.dedup();
+    bones_a_skeleton_in_the_scene_can_name.sort_unstable();
+    bones_a_skeleton_in_the_scene_can_name.dedup();
 
     *view = ImportedClipView {
         clip: Some(spec),
         name,
         duration: clip.duration(),
-        bones,
+        bones: bones_a_skeleton_in_the_scene_can_name,
         curve_count: clip.curves().len(),
+        row,
     };
     dirty.0 = true;
 }

--- a/src/animation/timeline_ops.rs
+++ b/src/animation/timeline_ops.rs
@@ -5,13 +5,15 @@
 
 use bevy::prelude::*;
 use jackdaw_animation::{
-    AnimationTrack, Clip, ClipEvent, ClipRecording, Interpolation, LoopMode, OnionSkin,
-    SelectedClip, SelectedTrack, TimelineCursor, TimelineDirty, TimelineSnap, TimelineView,
-    TimelineZoom,
+    AnimationTrack, Clip, ClipEvent, ClipRecording, ImportedClipView, Interpolation, LoopMode,
+    OnionSkin, SelectedClip, SelectedTrack, TimelineCursor, TimelineDirty, TimelineSnap,
+    TimelineView, TimelineZoom,
 };
 use jackdaw_api::prelude::*;
 use jackdaw_commands::{CommandHistory, EditorCommand};
 
+use super::markers::{clip_event_row, clip_event_row_in, clip_event_row_name};
+use super::preview::AnimationPreview;
 use crate::selection::Selection;
 
 /// The reflected type path of the authored clip, which is what a field edit
@@ -86,7 +88,7 @@ pub(crate) fn clip_loop_mode(
     label = "Add Clip Event",
     description = "Put a named moment on the clip, which sends an animation event as playback \
                    crosses it.",
-    is_available = a_clip_is_up,
+    is_available = an_event_can_be_placed,
     params(
         time(f64, doc = "Seconds from the start of the clip. Defaults to the playhead."),
         name(String, doc = "What the message the event sends is called."),
@@ -95,11 +97,13 @@ pub(crate) fn clip_loop_mode(
 pub(crate) fn clip_event_add(
     params: In<OperatorParameters>,
     selected: Res<SelectedClip>,
+    imported: Res<ImportedClipView>,
+    preview: Res<AnimationPreview>,
     cursor: Res<TimelineCursor>,
     snap: Res<TimelineSnap>,
     mut commands: Commands,
 ) -> OperatorResult {
-    let clip = selected.0?;
+    let row = event_row(&selected, &imported, &preview)?;
     let time = params
         .as_float("time")
         .map_or_else(|| snap.round(cursor.seek_time), |time| time as f32)
@@ -110,7 +114,7 @@ pub(crate) fn clip_event_add(
         .unwrap_or("Event")
         .to_string();
     commands.queue(move |world: &mut World| {
-        run_event_edit(world, ClipEventEdit::adding(clip, time, name));
+        run_event_edit(world, ClipEventEdit::adding(row, time, name));
     });
     OperatorResult::Finished
 }
@@ -120,19 +124,29 @@ pub(crate) fn clip_event_add(
     id = "clip.event.remove",
     label = "Remove Clip Event",
     description = "Take away the clip event nearest the playhead.",
-    is_available = a_clip_is_up
+    is_available = an_event_can_be_placed
 )]
 pub(crate) fn clip_event_remove(
     _: In<OperatorParameters>,
     selected: Res<SelectedClip>,
+    imported: Res<ImportedClipView>,
+    preview: Res<AnimationPreview>,
     cursor: Res<TimelineCursor>,
     children: Query<&Children>,
+    names: Query<&Name>,
+    placed: Query<(), With<Transform>>,
     events: Query<&ClipEvent>,
     mut commands: Commands,
 ) -> OperatorResult {
-    let clip = selected.0?;
+    let row = event_row(&selected, &imported, &preview)?;
+    let holder = match &row {
+        EventRow::Authored(clip) => *clip,
+        EventRow::Named { owner, file, clip } => {
+            clip_event_row(*owner, file, clip, &children, &names, &placed)?
+        }
+    };
     let nearest = children
-        .get(clip)
+        .get(holder)
         .into_iter()
         .flatten()
         .filter_map(|child| events.get(*child).ok().map(|event| (*child, event.time)))
@@ -149,7 +163,9 @@ pub(crate) fn clip_event_remove(
         run_event_edit(
             world,
             ClipEventEdit {
-                clip,
+                row,
+                on: None,
+                made_row: false,
                 event: Some(nearest),
                 time: held.time,
                 name: held.name,
@@ -158,6 +174,32 @@ pub(crate) fn clip_event_remove(
         );
     });
     OperatorResult::Finished
+}
+
+/// Where an event placed now would go, which is nowhere while a library clip
+/// plays on a preview model that goes away with the preview.
+fn event_row(
+    selected: &SelectedClip,
+    imported: &ImportedClipView,
+    preview: &AnimationPreview,
+) -> Option<EventRow> {
+    if let Some(clip) = selected.0 {
+        return Some(EventRow::Authored(clip));
+    }
+    let (file, clip) = imported.clip.as_deref()?.rsplit_once('#')?;
+    Some(EventRow::Named {
+        owner: preview.owner()?,
+        file: file.to_string(),
+        clip: clip.to_string(),
+    })
+}
+
+fn an_event_can_be_placed(
+    selected: Res<SelectedClip>,
+    imported: Res<ImportedClipView>,
+    preview: Res<AnimationPreview>,
+) -> bool {
+    event_row(&selected, &imported, &preview).is_some()
 }
 
 /// Take a track out of the compiled clip, or put it back.
@@ -404,12 +446,29 @@ fn set_field(
     mark_dirty(world);
 }
 
+/// What a clip event hangs under: a library clip is no entity, so its events
+/// hang under a child of the entity playing it, named for the clip.
+enum EventRow {
+    /// An authored clip, which holds its own events.
+    Authored(Entity),
+    /// A row named for a library clip, under the entity playing it.
+    Named {
+        owner: Entity,
+        file: String,
+        clip: String,
+    },
+}
+
 /// Adding or removing one clip event, as a step undo can take back.
 ///
 /// The event is respawned rather than restored by id: an id handed back is
 /// free to be someone else's by the time undo reaches for it.
 struct ClipEventEdit {
-    clip: Entity,
+    row: EventRow,
+    /// The row the event hangs under, once it exists.
+    on: Option<Entity>,
+    /// Whether this edit made that row, so undo takes it back away.
+    made_row: bool,
     /// The live event, once one exists. Rewritten on every undo and redo.
     event: Option<Entity>,
     time: f32,
@@ -419,9 +478,11 @@ struct ClipEventEdit {
 }
 
 impl ClipEventEdit {
-    fn adding(clip: Entity, time: f32, name: String) -> Self {
+    fn adding(row: EventRow, time: f32, name: String) -> Self {
         Self {
-            clip,
+            row,
+            on: None,
+            made_row: false,
             event: None,
             time,
             name,
@@ -429,7 +490,33 @@ impl ClipEventEdit {
         }
     }
 
+    /// The row to hang the event under, made and put in the document when a
+    /// library clip has none yet.
+    fn open_row(&mut self, world: &mut World) -> Option<Entity> {
+        self.made_row = false;
+        let (owner, file, clip) = match &self.row {
+            EventRow::Authored(clip) => return world.entities().contains(*clip).then_some(*clip),
+            EventRow::Named { owner, file, clip } => (*owner, file.clone(), clip.clone()),
+        };
+        if !world.entities().contains(owner) {
+            return None;
+        }
+        if let Some(row) = clip_event_row_in(world, owner, &file, &clip) {
+            return Some(row);
+        }
+        let row = world
+            .spawn((Name::new(clip_event_row_name(&file, &clip)), ChildOf(owner)))
+            .id();
+        crate::scene_io::register_entity_in_ast(world, row);
+        self.made_row = true;
+        Some(row)
+    }
+
     fn spawn(&mut self, world: &mut World) {
+        let Some(row) = self.open_row(world) else {
+            return;
+        };
+        self.on = Some(row);
         let event = world
             .spawn((
                 ClipEvent {
@@ -437,18 +524,25 @@ impl ClipEventEdit {
                     name: self.name.clone(),
                 },
                 Name::new(self.name.clone()),
-                ChildOf(self.clip),
+                ChildOf(row),
             ))
             .id();
         crate::scene_io::register_entity_in_ast(world, event);
         self.event = Some(event);
     }
 
+    /// Take the event away, and the row with it when this edit made it; a row an
+    /// earlier event made stays, being where the next event goes.
     fn despawn(&mut self, world: &mut World) {
-        if let Some(event) = self.event.take()
-            && let Ok(held) = world.get_entity_mut(event)
-        {
-            held.despawn();
+        if let Some(event) = self.event.take() {
+            crate::commands::despawn_scene_entity(world, event);
+        }
+        if !self.made_row {
+            return;
+        }
+        self.made_row = false;
+        if let Some(row) = self.on.take() {
+            crate::commands::despawn_scene_entity(world, row);
         }
     }
 }

--- a/src/status_bar.rs
+++ b/src/status_bar.rs
@@ -48,6 +48,11 @@ impl StatusNotice {
     pub fn text(&self) -> &str {
         &self.text
     }
+
+    /// Put a line about something the editor did in front of the user.
+    pub fn show(&mut self, text: impl Into<String>) {
+        self.set(text.into(), false);
+    }
 }
 
 /// Put a refusal in front of the user: the editor did not do what was asked.

--- a/tests/stage/animation_markers.rs
+++ b/tests/stage/animation_markers.rs
@@ -37,6 +37,7 @@ fn call(app: &mut App, id: &'static str, params: &[(&'static str, PropertyValue)
 
 fn editor_on_the_test_project() -> App {
     let mut app = util::editor_test_app();
+    util::fixed_frame_clock(&mut app);
     app.init_resource::<FiredEvents>();
     app.add_systems(Last, record_fired_events);
     app.world_mut()
@@ -60,6 +61,19 @@ fn settle_until(app: &mut App, what: &str, ready: impl Fn(&App) -> bool) {
         std::thread::sleep(std::time::Duration::from_millis(2));
     }
     panic!("{what} never happened");
+}
+
+/// The step [`util::fixed_frame_clock`] gives every frame, so a count of frames
+/// stands for a span of the previewed clip's own time.
+const FRAME_SECS: f64 = 0.016;
+
+/// Carry the preview `seconds` further into its clip, in whole frames of the
+/// fixed clock. The clip is 0.67 s long and does not loop, so spans stay under it.
+fn play_seconds(app: &mut App, seconds: f64) {
+    let frames = (seconds / FRAME_SECS).ceil() as u32;
+    for _ in 0..frames {
+        app.update();
+    }
 }
 
 /// A selected entity with a skeleton, holding one library clip on the
@@ -257,18 +271,14 @@ fn playing_past_a_marker_sends_an_animation_event_naming_the_entity() {
     add_event(&mut app, "hit", 0.1);
 
     call(&mut app, "animation.preview", &[]);
-    settle_until(&mut app, "the preview crossed the marker", |app| {
-        !fired(app).is_empty()
-    });
+    play_seconds(&mut app, 0.2);
 
     assert_eq!(
         fired(&app),
         vec![(rig, "hit".to_string())],
         "the event names the entity the clip is playing on"
     );
-    for _ in 0..30 {
-        app.update();
-    }
+    play_seconds(&mut app, 0.2);
     assert_eq!(
         fired(&app).len(),
         1,

--- a/tests/stage/animation_markers.rs
+++ b/tests/stage/animation_markers.rs
@@ -1,0 +1,442 @@
+//! Markers on a library clip: the row the first one makes under the entity
+//! playing it, what a save carries, and what the editor's own playback fires.
+
+use crate::util;
+
+use bevy::prelude::*;
+use jackdaw_animation::{ImportedClipView, SelectedClip};
+use jackdaw_animation_runtime::{AnimationEvent, ClipEvent};
+use jackdaw_api::prelude::*;
+use jackdaw_commands::CommandHistory;
+use jackdaw_scene_types::PropertyValue;
+
+const ANIMATED_FILE: &str = "jan/jan.gltf";
+const CLIP: &str = "run";
+/// What the row holding the clip's events answers to, spelled so two files
+/// holding a clip of the same name cannot share one row.
+const ROW: &str = "jan/jan.gltf#run";
+
+/// Every animation event the editor sent, kept because a message outlives the
+/// frame it was written on by one tick only.
+#[derive(Resource, Default)]
+struct FiredEvents(Vec<(Entity, String)>);
+
+fn record_fired_events(mut fired: MessageReader<AnimationEvent>, mut seen: ResMut<FiredEvents>) {
+    seen.0
+        .extend(fired.read().map(|event| (event.entity, event.name.clone())));
+}
+
+fn call(app: &mut App, id: &'static str, params: &[(&'static str, PropertyValue)]) {
+    let mut call = app.world_mut().operator(id);
+    for (key, value) in params {
+        call = call.param(*key, value.clone());
+    }
+    let result = call.call().expect("the operator dispatched");
+    assert_eq!(result, OperatorResult::Finished, "{id} did not finish");
+}
+
+fn editor_on_the_test_project() -> App {
+    let mut app = util::editor_test_app();
+    app.init_resource::<FiredEvents>();
+    app.add_systems(Last, record_fired_events);
+    app.world_mut()
+        .insert_resource(jackdaw::project::ProjectRoot {
+            root: std::path::PathBuf::from(env!("CARGO_MANIFEST_DIR")),
+            config: default(),
+        });
+    app.world_mut()
+        .resource_mut::<NextState<jackdaw::AppState>>()
+        .set(jackdaw::AppState::Editor);
+    app
+}
+
+#[track_caller]
+fn settle_until(app: &mut App, what: &str, ready: impl Fn(&App) -> bool) {
+    for _ in 0..600 {
+        if ready(app) {
+            return;
+        }
+        app.update();
+        std::thread::sleep(std::time::Duration::from_millis(2));
+    }
+    panic!("{what} never happened");
+}
+
+/// A selected entity with a skeleton, holding one library clip on the
+/// Timeline, paused on its first frame.
+fn previewing_a_library_clip(app: &mut App) -> Entity {
+    let rig = app
+        .world_mut()
+        .spawn((Name::new("Rig"), Transform::default()))
+        .id();
+    app.world_mut()
+        .spawn((Name::new("Bone"), Transform::default(), ChildOf(rig)));
+    jackdaw::scene_io::register_entity_in_ast(app.world_mut(), rig);
+    jackdaw::selection::select_only(app.world_mut(), rig);
+
+    call(
+        app,
+        "animation.preview",
+        &[
+            ("clip", format!("{ANIMATED_FILE}#{CLIP}").into()),
+            ("entity", rig.into()),
+        ],
+    );
+    settle_until(app, "the timeline described the imported clip", |app| {
+        app.world().resource::<ImportedClipView>().clip.is_some()
+    });
+    call(app, "animation.preview.pause", &[]);
+    seek(app, 0.0);
+    rig
+}
+
+fn seek(app: &mut App, time: f64) {
+    call(app, "clip.seek", &[("time", time.into())]);
+    app.update();
+    app.update();
+}
+
+fn add_event(app: &mut App, name: &'static str, time: f64) {
+    call(
+        app,
+        "clip.event.add",
+        &[("name", name.into()), ("time", time.into())],
+    );
+    app.update();
+    app.update();
+}
+
+/// The child of `owner` the clip's markers hang under.
+fn clip_row(app: &App, owner: Entity) -> Option<Entity> {
+    app.world()
+        .get::<Children>(owner)
+        .into_iter()
+        .flatten()
+        .copied()
+        .find(|child| {
+            app.world()
+                .get::<Name>(*child)
+                .is_some_and(|name| name.as_str() == ROW)
+        })
+}
+
+/// Every `ClipEvent` the document would write, read off the emitted text
+/// rather than off the world, so an undone edit left in the AST is caught.
+fn saved_document(app: &mut App) -> String {
+    jackdaw::scene_io::emit_bsn_scene_with_inline_assets(app.world_mut(), std::path::Path::new("."))
+}
+
+/// The `(time, name)` of every event under a row.
+fn events_on(app: &App, row: Entity) -> Vec<(f32, String)> {
+    let mut held: Vec<(f32, String)> = app
+        .world()
+        .get::<Children>(row)
+        .into_iter()
+        .flatten()
+        .filter_map(|child| app.world().get::<ClipEvent>(*child))
+        .map(|event| (event.time, event.name.clone()))
+        .collect();
+    held.sort_by(|a, b| a.0.total_cmp(&b.0));
+    held
+}
+
+fn fired(app: &App) -> Vec<(Entity, String)> {
+    app.world().resource::<FiredEvents>().0.clone()
+}
+
+#[test]
+fn an_event_on_a_library_clip_makes_a_row_under_the_entity() {
+    let mut app = editor_on_the_test_project();
+    let rig = previewing_a_library_clip(&mut app);
+    assert!(
+        app.world().resource::<SelectedClip>().0.is_none(),
+        "the test means nothing unless the clip on the timeline is the imported one"
+    );
+
+    add_event(&mut app, "hit", 0.2);
+
+    let row = clip_row(&app, rig).expect("the first event makes the row");
+    assert_eq!(
+        events_on(&app, row),
+        vec![(0.2, "hit".to_string())],
+        "the event hangs under the row, not under the entity"
+    );
+    assert!(
+        app.world().get::<jackdaw::EditorEntity>(row).is_none()
+            && app.world().get::<jackdaw::EditorHidden>(row).is_none(),
+        "the row belongs to the document, so the outliner has to show it"
+    );
+    assert_eq!(
+        app.world().resource::<ImportedClipView>().row,
+        Some(row),
+        "the Events row of the read-only sheet draws off the same row"
+    );
+
+    add_event(&mut app, "step", 0.4);
+    assert_eq!(
+        clip_row(&app, rig),
+        Some(row),
+        "a second event joins the row the first one made"
+    );
+    assert_eq!(
+        events_on(&app, row),
+        vec![(0.2, "hit".to_string()), (0.4, "step".to_string())]
+    );
+}
+
+#[test]
+fn a_library_clip_row_comes_back_when_the_document_is_reopened() {
+    let mut app = editor_on_the_test_project();
+    let rig = previewing_a_library_clip(&mut app);
+    add_event(&mut app, "hit", 0.2);
+    let saved = clip_row(&app, rig).expect("the row the event made");
+    call(&mut app, "animation.preview.stop", &[]);
+    app.update();
+
+    let text = saved_document(&mut app);
+    assert!(
+        text.contains("ClipEvent"),
+        "the marker has to reach the document:\n{text}"
+    );
+    jackdaw::prefab::watcher::respawn_from_sparse_text(app.world_mut(), &text);
+    app.update();
+
+    let reopened = app
+        .world_mut()
+        .query_filtered::<Entity, With<Name>>()
+        .iter(app.world())
+        .find(|entity| {
+            app.world()
+                .get::<Name>(*entity)
+                .is_some_and(|name| name.as_str() == "Rig")
+        })
+        .expect("the entity came back");
+    let row = clip_row(&app, reopened).expect("and so did its clip row");
+    assert_ne!(row, saved, "the reopened scene is spawned afresh");
+    assert_eq!(
+        events_on(&app, row),
+        vec![(0.2, "hit".to_string())],
+        "with the marker still on it"
+    );
+}
+
+#[test]
+fn one_undo_takes_back_the_event_and_the_row_it_made() {
+    let mut app = editor_on_the_test_project();
+    let rig = previewing_a_library_clip(&mut app);
+    add_event(&mut app, "hit", 0.2);
+    add_event(&mut app, "step", 0.4);
+
+    undo(&mut app);
+    let row = clip_row(&app, rig).expect("the row outlives the event that joined it");
+    assert_eq!(
+        events_on(&app, row),
+        vec![(0.2, "hit".to_string())],
+        "undoing the second event takes back only that event"
+    );
+
+    undo(&mut app);
+    assert!(
+        clip_row(&app, rig).is_none(),
+        "undoing the first event takes back the row it made"
+    );
+    assert_eq!(
+        app.world_mut()
+            .query::<&ClipEvent>()
+            .iter(app.world())
+            .count(),
+        0,
+        "and nothing of the edit is left behind"
+    );
+}
+
+#[test]
+fn playing_past_a_marker_sends_an_animation_event_naming_the_entity() {
+    let mut app = editor_on_the_test_project();
+    let rig = previewing_a_library_clip(&mut app);
+    add_event(&mut app, "hit", 0.1);
+
+    call(&mut app, "animation.preview", &[]);
+    settle_until(&mut app, "the preview crossed the marker", |app| {
+        !fired(app).is_empty()
+    });
+
+    assert_eq!(
+        fired(&app),
+        vec![(rig, "hit".to_string())],
+        "the event names the entity the clip is playing on"
+    );
+    for _ in 0..30 {
+        app.update();
+    }
+    assert_eq!(
+        fired(&app).len(),
+        1,
+        "one pass over the marker is one event: {:?}",
+        fired(&app)
+    );
+}
+
+#[test]
+fn scrubbing_back_over_a_marker_sends_it_once_per_pass() {
+    let mut app = editor_on_the_test_project();
+    let rig = previewing_a_library_clip(&mut app);
+    add_event(&mut app, "hit", 0.2);
+
+    seek(&mut app, 0.1);
+    assert!(
+        fired(&app).is_empty(),
+        "a playhead short of the marker says nothing: {:?}",
+        fired(&app)
+    );
+
+    seek(&mut app, 0.3);
+    assert_eq!(fired(&app), vec![(rig, "hit".to_string())]);
+
+    seek(&mut app, 0.1);
+    assert_eq!(
+        fired(&app),
+        vec![(rig, "hit".to_string()), (rig, "hit".to_string())],
+        "scrubbing back over the marker crosses it once more, not twice"
+    );
+
+    seek(&mut app, 0.05);
+    assert_eq!(
+        fired(&app).len(),
+        2,
+        "and moving on past it says nothing again: {:?}",
+        fired(&app)
+    );
+    let cursor = app.world().resource::<jackdaw_animation::TimelineCursor>();
+    assert!(
+        (cursor.seek_time - 0.05).abs() < 1e-3,
+        "the transport must leave the playhead where the scrub put it, not drag \
+         it back to the borrowed player's own time: {}",
+        cursor.seek_time
+    );
+}
+
+#[test]
+fn an_undone_event_leaves_nothing_behind_for_a_save_to_write() {
+    let mut app = editor_on_the_test_project();
+    let rig = previewing_a_library_clip(&mut app);
+    add_event(&mut app, "hit", 0.2);
+    assert!(saved_document(&mut app).contains("ClipEvent"));
+
+    undo(&mut app);
+
+    let text = saved_document(&mut app);
+    assert!(
+        !text.contains("ClipEvent"),
+        "an undone event must leave the document as well as the world:\n{text}"
+    );
+    assert!(!text.contains(ROW), "and so must the row it made:\n{text}");
+    assert_eq!(clip_row(&app, rig), None);
+}
+
+#[test]
+fn a_removed_event_goes_out_of_the_document_too() {
+    let mut app = editor_on_the_test_project();
+    let rig = previewing_a_library_clip(&mut app);
+    add_event(&mut app, "hit", 0.2);
+    add_event(&mut app, "step", 0.4);
+
+    seek(&mut app, 0.4);
+    call(&mut app, "clip.event.remove", &[]);
+    app.update();
+    app.update();
+
+    let row = clip_row(&app, rig).expect("the row stays behind its last event");
+    assert_eq!(events_on(&app, row), vec![(0.2, "hit".to_string())]);
+    let text = saved_document(&mut app);
+    assert!(
+        !text.contains("step"),
+        "a removed event must go out of the document, not only the world:\n{text}"
+    );
+}
+
+#[test]
+fn redoing_an_undone_event_puts_the_row_and_the_marker_back() {
+    let mut app = editor_on_the_test_project();
+    let rig = previewing_a_library_clip(&mut app);
+    add_event(&mut app, "hit", 0.2);
+    undo(&mut app);
+    redo(&mut app);
+
+    let row = clip_row(&app, rig).expect("redo makes the row again");
+    assert_eq!(events_on(&app, row), vec![(0.2, "hit".to_string())]);
+
+    add_event(&mut app, "step", 0.4);
+    assert_eq!(
+        clip_row(&app, rig),
+        Some(row),
+        "and the next event joins that row rather than making a second one"
+    );
+    assert_eq!(
+        app.world().get::<Children>(rig).map_or(0, |kids| kids
+            .iter()
+            .filter(|child| app
+                .world()
+                .get::<Name>(*child)
+                .is_some_and(|name| name.as_str() == ROW))
+            .count()),
+        1,
+        "one row per clip"
+    );
+}
+
+#[test]
+fn a_clip_previewed_on_a_mannequin_takes_no_events() {
+    let mut app = editor_on_the_test_project();
+    let bare = app.world_mut().spawn(Name::new("Bare")).id();
+    jackdaw::scene_io::register_entity_in_ast(app.world_mut(), bare);
+    jackdaw::selection::select_only(app.world_mut(), bare);
+    call(
+        &mut app,
+        "animation.preview",
+        &[("clip", format!("{ANIMATED_FILE}#{CLIP}").into())],
+    );
+    settle_until(&mut app, "the clip came up on a preview model", |app| {
+        app.world().resource::<ImportedClipView>().clip.is_some()
+    });
+
+    let refused = app
+        .world_mut()
+        .operator("clip.event.add")
+        .param("name", "hit")
+        .call();
+
+    assert!(
+        matches!(
+            refused,
+            Ok(OperatorResult::Cancelled) | Err(CallOperatorError::NotAvailable)
+        ),
+        "a preview model goes away with the preview, so it can hold no marker: {refused:?}"
+    );
+    assert_eq!(
+        app.world_mut()
+            .query::<&ClipEvent>()
+            .iter(app.world())
+            .count(),
+        0,
+        "and nothing was put anywhere else instead"
+    );
+    assert!(
+        app.world().get::<Children>(bare).is_none(),
+        "least of all under the selection"
+    );
+}
+
+fn undo(app: &mut App) {
+    app.world_mut()
+        .resource_scope(|world, mut history: Mut<CommandHistory>| history.undo(world));
+    app.update();
+    app.update();
+}
+
+fn redo(app: &mut App) {
+    app.world_mut()
+        .resource_scope(|world, mut history: Mut<CommandHistory>| history.redo(world));
+    app.update();
+    app.update();
+}

--- a/tests/stage/main.rs
+++ b/tests/stage/main.rs
@@ -8,6 +8,7 @@
 mod util;
 
 mod animation_library;
+mod animation_markers;
 mod animation_timeline;
 mod brush_ops;
 mod canvas_guides;


### PR DESCRIPTION
clip.event.add and clip.event.remove work on a library clip shown in the Timeline. The first event makes a row under the previewed entity named <file>#<clip>, kept in the document, and undo takes the row back with the event that made it. The transport drives the preview player, the shown row's playhead follows its seek, so events fire while scrubbing: the marker lights and the status bar names the event and its time.

LLM disclaimer: Claude Code was used to help plan and implement this change, but all code was human reviewed by myself!