### PR TITLE
Edit animation graphs on a node canvas in their own window

### DIFF
--- a/crates/jackdaw_animation_runtime/src/graph.rs
+++ b/crates/jackdaw_animation_runtime/src/graph.rs
@@ -102,6 +102,9 @@ pub struct AnimationGraphState {
     pub looped: bool,
     /// Playback rate, as a multiple of the clips' authored speed.
     pub speed: f32,
+    /// Where the state's node sits on the editor's canvas. The evaluator never
+    /// reads it, and a file that leaves it out is laid out when it is opened.
+    pub position: Vec2,
 }
 
 impl Default for AnimationGraphState {
@@ -111,6 +114,7 @@ impl Default for AnimationGraphState {
             motion: AnimationMotion::default(),
             looped: true,
             speed: 1.0,
+            position: Vec2::ZERO,
         }
     }
 }
@@ -547,6 +551,7 @@ impl AnimationSet {
                 }),
                 looped: def.looped,
                 speed: def.speed,
+                ..AnimationGraphState::default()
             })
             .collect();
         let transitions = self

--- a/src/animation/graph_doc.rs
+++ b/src/animation/graph_doc.rs
@@ -1,0 +1,1060 @@
+//! The animation graph the Graph window is editing.
+//!
+//! One graph is open at a time: the file it came from, the canvas entities
+//! that show it, and the edits that write it back. The definition in
+//! [`AnimationGraphDoc`] is what saving writes, and the canvas is kept in step
+//! with it in both directions -- an operator writes the definition and the
+//! canvas follows, while a drag, a delete or a wire drawn on the canvas is
+//! read back into the definition under whatever the node canvas already put in
+//! the undo history.
+
+use std::collections::HashMap;
+use std::path::{Path, PathBuf};
+
+use bevy::prelude::*;
+use bevy::reflect::TypeRegistry;
+use jackdaw_animation_runtime::{
+    AnimationClipRef, AnimationGraphDef, AnimationGraphState, AnimationMotion,
+    AnimationParameterDef, AnimationTransitionDef, parse_animation_graph,
+};
+use jackdaw_bsn::{BsnPatches, SceneBsnAst, component_to_bsn_patch, emit_scene};
+use jackdaw_commands::{CommandHistory, EditorCommand};
+use jackdaw_node_graph::{
+    Connection, GraphCanvasView, GraphNode, NodeGraph, Terminal, TerminalDirection,
+};
+
+use crate::project::ProjectRoot;
+
+/// Directory under `assets/` holding graph files.
+pub const GRAPH_DIR: &str = "animation";
+
+/// Suffix identifying a graph file. The name is the stem before it.
+pub const GRAPH_FILE_SUFFIX: &str = ".animgraph.bsn";
+
+/// Registry key of the node one state is drawn as.
+pub const STATE_NODE_TYPE: &str = "anim.state";
+
+/// Registry key of the node every "from any state" transition leaves.
+pub const ANY_STATE_NODE_TYPE: &str = "anim.any_state";
+
+/// Where the first node of a laid-out graph sits.
+const LAYOUT_ORIGIN: Vec2 = Vec2::new(60.0, 60.0);
+
+/// How far apart laid-out nodes stand.
+const LAYOUT_STEP: Vec2 = Vec2::new(260.0, 150.0);
+
+/// Nodes per column of a laid-out graph.
+const LAYOUT_ROWS: usize = 4;
+
+/// How much of an undone edit is kept, so a state or a transition the canvas
+/// took away comes back with what it held rather than with defaults.
+const RETIRED_LIMIT: usize = 128;
+
+/// The graph the Graph window is editing.
+#[derive(Resource, Default, Debug)]
+pub struct AnimationGraphDoc {
+    /// Assets-relative path of the open file, or `None` when nothing is open.
+    pub path: Option<String>,
+    /// The states, transitions and parameters saving writes.
+    pub def: AnimationGraphDef,
+    /// The [`NodeGraph`] entity the canvas draws.
+    pub graph: Option<Entity>,
+    /// Whether the definition has moved on from the file.
+    pub dirty: bool,
+    /// Where the "Any State" node sits, which no state owns.
+    pub any_state_position: Vec2,
+    /// The node entity showing each state, by state name.
+    nodes: HashMap<String, Entity>,
+    /// The wire entity showing each transition, in `def.transitions` order.
+    wires: Vec<Entity>,
+    /// States the canvas took away, which an undo brings back.
+    retired_states: Vec<AnimationGraphState>,
+    /// Transitions the canvas took away, matched back by their ends.
+    retired_transitions: Vec<AnimationTransitionDef>,
+}
+
+impl AnimationGraphDoc {
+    /// The state of this name, if the graph holds one.
+    pub fn state(&self, name: &str) -> Option<&AnimationGraphState> {
+        self.def.states.iter().find(|state| state.name == name)
+    }
+
+    /// The wire drawing the transition at `at`, while one is on the canvas.
+    pub fn wire(&self, at: usize) -> Option<Entity> {
+        self.wires.get(at).copied()
+    }
+
+    /// A state name the graph does not already use.
+    pub fn unused_state_name(&self, wanted: &str) -> String {
+        let wanted = if wanted.is_empty() { "State" } else { wanted };
+        if self.state(wanted).is_none() {
+            return wanted.to_string();
+        }
+        (2..)
+            .map(|n| format!("{wanted} {n}"))
+            .find(|name| self.state(name).is_none())
+            .unwrap_or_else(|| wanted.to_string())
+    }
+
+    /// Where a node added now should sit, clear of the ones already placed.
+    pub fn free_position(&self) -> Vec2 {
+        layout_position(self.def.states.len())
+    }
+
+    fn retire_state(&mut self, state: AnimationGraphState) {
+        if self.retired_states.len() >= RETIRED_LIMIT {
+            self.retired_states.remove(0);
+        }
+        self.retired_states.push(state);
+    }
+
+    fn retire_transition(&mut self, transition: AnimationTransitionDef) {
+        if self.retired_transitions.len() >= RETIRED_LIMIT {
+            self.retired_transitions.remove(0);
+        }
+        self.retired_transitions.push(transition);
+    }
+
+    /// The state a node standing at `position` was, when the canvas took one
+    /// away from there. Undo respawns a node at the position it held, which is
+    /// what carries a restored state's name and clip back to it.
+    fn reclaim_state(&mut self, position: Vec2) -> Option<AnimationGraphState> {
+        let at = self
+            .retired_states
+            .iter()
+            .rposition(|state| state.position == position)?;
+        Some(self.retired_states.remove(at))
+    }
+
+    fn reclaim_transition(&mut self, from: &str, to: &str) -> Option<AnimationTransitionDef> {
+        let at = self
+            .retired_transitions
+            .iter()
+            .rposition(|held| held.from == from && held.to == to)?;
+        Some(self.retired_transitions.remove(at))
+    }
+}
+
+/// The state a canvas node stands for.
+#[derive(Component, Debug, Clone)]
+pub struct GraphStateNode(pub String);
+
+/// The node every "from any state" transition leaves.
+#[derive(Component, Debug)]
+pub struct GraphAnyStateNode;
+
+/// Marker on everything the Graph window spawns onto the canvas.
+#[derive(Component, Debug)]
+pub struct GraphCanvasPart;
+
+/// `<project>/assets/animation`.
+pub fn graphs_dir(project: &ProjectRoot) -> PathBuf {
+    project.assets_dir().join(GRAPH_DIR)
+}
+
+/// The file an assets-relative graph path names, refusing one that climbs out
+/// of the project.
+pub fn graph_file_path(project: &ProjectRoot, path: &str) -> Option<PathBuf> {
+    match crate::project::path_within(&project.assets_dir(), Path::new(path)) {
+        Ok(file) => Some(file),
+        Err(err) => {
+            warn!("{err}");
+            None
+        }
+    }
+}
+
+/// The assets-relative path a graph of this name saves to.
+pub fn graph_path_for_name(name: &str) -> String {
+    format!(
+        "{GRAPH_DIR}/{}{GRAPH_FILE_SUFFIX}",
+        sanitize_graph_name(name)
+    )
+}
+
+/// A file stem out of whatever the operator was given.
+pub fn sanitize_graph_name(name: &str) -> String {
+    let cleaned: String = name
+        .chars()
+        .map(|c| {
+            if c.is_ascii_alphanumeric() || c == '-' || c == '_' {
+                c
+            } else {
+                '_'
+            }
+        })
+        .collect();
+    let cleaned = cleaned.trim_matches('_').to_string();
+    if cleaned.is_empty() {
+        "graph".to_string()
+    } else {
+        cleaned
+    }
+}
+
+/// Every `assets/animation/*.animgraph.bsn` as an assets-relative path, sorted.
+pub fn graph_files(world: &World) -> Vec<String> {
+    let Some(project) = world.get_resource::<ProjectRoot>() else {
+        return Vec::new();
+    };
+    graph_files_in(project)
+}
+
+/// Every `assets/animation/*.animgraph.bsn` of a project, sorted.
+pub fn graph_files_in(project: &ProjectRoot) -> Vec<String> {
+    let Ok(entries) = std::fs::read_dir(graphs_dir(project)) else {
+        return Vec::new();
+    };
+    let mut paths: Vec<String> = entries
+        .flatten()
+        .map(|entry| entry.path())
+        .filter_map(|path| {
+            let name = path.file_name()?.to_str()?;
+            name.ends_with(GRAPH_FILE_SUFFIX)
+                .then(|| format!("{GRAPH_DIR}/{name}"))
+        })
+        .collect();
+    paths.sort();
+    paths
+}
+
+/// The graph text of a definition, in the shape the loader reads back.
+pub fn graph_to_bsn(def: &AnimationGraphDef, registry: &TypeRegistry) -> String {
+    let mut ast = SceneBsnAst::default();
+    let patch = component_to_bsn_patch(def.as_partial_reflect(), registry);
+    let patch_entity = ast.world.spawn(patch).id();
+    let root = ast.world.spawn(BsnPatches(vec![patch_entity])).id();
+    ast.add_to_roots(root);
+    emit_scene(&ast)
+}
+
+/// Read a graph file into a definition.
+pub fn read_graph_file(world: &World, path: &str) -> Option<AnimationGraphDef> {
+    let file = graph_file_path(world.get_resource::<ProjectRoot>()?, path)?;
+    let text = match std::fs::read_to_string(&file) {
+        Ok(text) => text,
+        Err(err) => {
+            warn!("could not read {}: {err}", file.display());
+            return None;
+        }
+    };
+    let registry = world.resource::<AppTypeRegistry>().read();
+    match parse_animation_graph(&text, &registry) {
+        Ok(def) => Some(def),
+        Err(err) => {
+            warn!("could not read {}: {err}", file.display());
+            None
+        }
+    }
+}
+
+/// Write the open graph back to its file.
+pub fn write_graph_file(world: &mut World) -> Option<PathBuf> {
+    let path = world.resource::<AnimationGraphDoc>().path.clone()?;
+    let file = graph_file_path(world.get_resource::<ProjectRoot>()?, &path)?;
+    let text = {
+        let registry = world.resource::<AppTypeRegistry>().read();
+        graph_to_bsn(&world.resource::<AnimationGraphDoc>().def, &registry)
+    };
+    if let Some(parent) = file.parent()
+        && let Err(err) = std::fs::create_dir_all(parent)
+    {
+        warn!("could not make {}: {err}", parent.display());
+        return None;
+    }
+    if let Err(err) = crate::scene_io::save::write_atomic(&file, text.as_bytes()) {
+        warn!("could not write {}: {err}", file.display());
+        return None;
+    }
+    world.resource_mut::<AnimationGraphDoc>().dirty = false;
+    Some(file)
+}
+
+/// Open a graph file on the canvas.
+pub fn open_graph(world: &mut World, path: &str) -> bool {
+    let Some(def) = read_graph_file(world, path) else {
+        return false;
+    };
+    install_graph(world, path, def, false);
+    true
+}
+
+/// Start a graph of this name, and write the empty file it saves to.
+pub fn new_graph(world: &mut World, name: &str) -> Option<String> {
+    let path = graph_path_for_name(name);
+    install_graph(world, &path, AnimationGraphDef::default(), true);
+    write_graph_file(world)?;
+    Some(path)
+}
+
+/// Put a definition on the canvas as the open graph.
+pub fn install_graph(world: &mut World, path: &str, mut def: AnimationGraphDef, dirty: bool) {
+    let held = world.resource::<AnimationGraphDoc>();
+    if held.dirty
+        && let Some(open) = held.path.clone()
+    {
+        warn!("{open} had edits that were not saved, and is being closed");
+    }
+    lay_out_unplaced_states(&mut def);
+    clear_canvas(world);
+    let graph = spawn_graph_root(world, path);
+    let mut doc = world.resource_mut::<AnimationGraphDoc>();
+    doc.path = Some(path.to_string());
+    doc.def = def;
+    doc.graph = Some(graph);
+    doc.dirty = dirty;
+    doc.any_state_position = LAYOUT_ORIGIN - Vec2::new(0.0, LAYOUT_STEP.y);
+    doc.nodes.clear();
+    doc.wires.clear();
+    doc.retired_states.clear();
+    doc.retired_transitions.clear();
+}
+
+/// The entity the canvas draws one graph's nodes and wires under.
+fn spawn_graph_root(world: &mut World, path: &str) -> Entity {
+    let title = path
+        .rsplit('/')
+        .next()
+        .unwrap_or(path)
+        .trim_end_matches(GRAPH_FILE_SUFFIX)
+        .to_string();
+    world
+        .spawn((
+            NodeGraph { title },
+            GraphCanvasView::default(),
+            GraphCanvasPart,
+            Name::new(format!("Animation Graph {path}")),
+            crate::EditorEntity,
+        ))
+        .id()
+}
+
+/// Take the open graph and everything it drew off the canvas.
+pub fn clear_canvas(world: &mut World) {
+    let held: Vec<Entity> = {
+        let mut query = world.query_filtered::<Entity, With<GraphCanvasPart>>();
+        query.iter(world).collect()
+    };
+    for entity in held {
+        if let Ok(entity) = world.get_entity_mut(entity) {
+            entity.despawn();
+        }
+    }
+    let mut doc = world.resource_mut::<AnimationGraphDoc>();
+    doc.graph = None;
+    doc.nodes.clear();
+    doc.wires.clear();
+}
+
+/// Where the `index`th node of a laid-out graph sits.
+fn layout_position(index: usize) -> Vec2 {
+    LAYOUT_ORIGIN
+        + Vec2::new(
+            (index / LAYOUT_ROWS) as f32 * LAYOUT_STEP.x,
+            (index % LAYOUT_ROWS) as f32 * LAYOUT_STEP.y,
+        )
+}
+
+/// Place the states of a file that carries no layout, so a graph authored
+/// before the canvas existed does not open as one stack of nodes.
+fn lay_out_unplaced_states(def: &mut AnimationGraphDef) {
+    if def.states.iter().any(|state| state.position != Vec2::ZERO) {
+        return;
+    }
+    for (index, state) in def.states.iter_mut().enumerate() {
+        state.position = layout_position(index);
+    }
+}
+
+/// Change the open graph as one step of undo.
+///
+/// The edit is refused when nothing is open, and dropped when it leaves the
+/// definition as it found it, so a control that writes what is already there
+/// puts nothing on the history.
+pub fn commit_graph_edit(
+    world: &mut World,
+    label: &'static str,
+    edit: impl FnOnce(&mut AnimationGraphDef),
+) -> bool {
+    let doc = world.resource::<AnimationGraphDoc>();
+    if doc.path.is_none() {
+        return false;
+    }
+    let before = doc.def.clone();
+    let mut after = before.clone();
+    edit(&mut after);
+    if after == before {
+        return false;
+    }
+    world.resource_scope(|world, mut history: Mut<CommandHistory>| {
+        history.execute(
+            Box::new(GraphDefEdit {
+                before,
+                after,
+                label,
+            }),
+            world,
+        );
+    });
+    true
+}
+
+/// One edit of the open graph's definition.
+struct GraphDefEdit {
+    before: AnimationGraphDef,
+    after: AnimationGraphDef,
+    label: &'static str,
+}
+
+impl GraphDefEdit {
+    fn write(world: &mut World, def: &AnimationGraphDef) {
+        {
+            let mut doc = world.resource_mut::<AnimationGraphDoc>();
+            doc.def = def.clone();
+            doc.dirty = true;
+        }
+        resync_views(world);
+    }
+}
+
+/// Match the canvas back to a definition that changed under it.
+///
+/// A node or a wire the definition no longer holds is taken off the canvas,
+/// and what it does hold is claimed by whatever is already drawing it, so a
+/// rename or an undo neither doubles a wire nor loses where a node stood.
+fn resync_views(world: &mut World) {
+    if world.resource::<AnimationGraphDoc>().graph.is_none() {
+        return;
+    }
+    let names: Vec<String> = world
+        .resource::<AnimationGraphDoc>()
+        .def
+        .states
+        .iter()
+        .map(|state| state.name.clone())
+        .collect();
+    let drawn: Vec<(Entity, String)> = {
+        let mut query = world.query::<(Entity, &GraphStateNode)>();
+        query
+            .iter(world)
+            .map(|(entity, state)| (entity, state.0.clone()))
+            .collect()
+    };
+    let mut nodes: HashMap<String, Entity> = HashMap::new();
+    for (entity, name) in drawn {
+        if names.contains(&name) && !nodes.contains_key(&name) {
+            nodes.insert(name, entity);
+            continue;
+        }
+        if let Ok(entity) = world.get_entity_mut(entity) {
+            entity.despawn();
+        }
+    }
+    world.resource_mut::<AnimationGraphDoc>().nodes = nodes;
+
+    let drawn_wires = wire_ends(world);
+    let transitions: Vec<(String, String)> = world
+        .resource::<AnimationGraphDoc>()
+        .def
+        .transitions
+        .iter()
+        .map(|transition| (transition.from.clone(), transition.to.clone()))
+        .collect();
+    let mut claimed: Vec<Entity> = Vec::new();
+    let mut taken: Vec<Entity> = Vec::new();
+    for (from, to) in transitions {
+        let found = drawn_wires
+            .iter()
+            .find(|(entity, ends)| ends.0 == from && ends.1 == to && !taken.contains(entity))
+            .map(|(entity, _)| *entity);
+        match found {
+            Some(entity) => {
+                taken.push(entity);
+                claimed.push(entity);
+            }
+            None => claimed.push(Entity::PLACEHOLDER),
+        }
+    }
+    for (entity, _) in &drawn_wires {
+        if taken.contains(entity) {
+            continue;
+        }
+        if let Ok(entity) = world.get_entity_mut(*entity) {
+            entity.despawn();
+        }
+    }
+    world.resource_mut::<AnimationGraphDoc>().wires = claimed;
+}
+
+/// Every wire on the canvas and the state names its ends carry. A wire out of
+/// the any-state node reads as leaving no state at all, which is how the
+/// runtime spells a transition taken from everywhere.
+fn wire_ends(world: &mut World) -> Vec<(Entity, (String, String))> {
+    let Some(graph) = world.resource::<AnimationGraphDoc>().graph else {
+        return Vec::new();
+    };
+    let named: HashMap<Entity, String> = {
+        let mut query = world.query::<(Entity, &GraphStateNode)>();
+        query
+            .iter(world)
+            .map(|(entity, state)| (entity, state.0.clone()))
+            .collect()
+    };
+    let any_state: Vec<Entity> = {
+        let mut query = world.query_filtered::<Entity, With<GraphAnyStateNode>>();
+        query.iter(world).collect()
+    };
+    let mut wires = world.query::<(Entity, &Connection, &ChildOf)>();
+    wires
+        .iter(world)
+        .filter(|(_, _, parent)| parent.parent() == graph)
+        .filter_map(|(entity, connection, _)| {
+            let from = match named.get(&connection.source_node) {
+                Some(name) => name.clone(),
+                None if any_state.contains(&connection.source_node) => String::new(),
+                None => return None,
+            };
+            let to = named.get(&connection.target_node)?.clone();
+            Some((entity, (from, to)))
+        })
+        .collect()
+}
+
+impl EditorCommand for GraphDefEdit {
+    fn execute(&mut self, world: &mut World) {
+        Self::write(world, &self.after);
+    }
+
+    fn undo(&mut self, world: &mut World) {
+        Self::write(world, &self.before);
+    }
+
+    fn description(&self) -> &str {
+        self.label
+    }
+}
+
+/// Read what the canvas did back into the definition.
+///
+/// A node dragged, deleted or added and a wire drawn or cut all land on the
+/// canvas first, under the node canvas's own undo entry. This follows them, so
+/// the definition saving writes is what the canvas shows and one undo takes
+/// back one edit. A canvas whose root went away is given a new one, which the
+/// reconcile then draws the definition into again.
+pub(super) fn read_canvas_back(world: &mut World) {
+    let doc = world.resource::<AnimationGraphDoc>();
+    let (Some(path), Some(graph)) = (doc.path.clone(), doc.graph) else {
+        return;
+    };
+    if !world.entities().contains(graph) {
+        clear_canvas(world);
+        let graph = spawn_graph_root(world, &path);
+        world.resource_mut::<AnimationGraphDoc>().graph = Some(graph);
+        return;
+    }
+    read_states_back(world, graph);
+    read_transitions_back(world);
+}
+
+fn read_states_back(world: &mut World, graph: Entity) {
+    let mut live: HashMap<String, Entity> = HashMap::new();
+    let mut positions: HashMap<Entity, Vec2> = HashMap::new();
+    let mut unnamed: Vec<(Entity, Vec2)> = Vec::new();
+    {
+        let mut query = world.query::<(Entity, &GraphNode, &ChildOf, Option<&GraphStateNode>)>();
+        for (entity, node, parent, state) in query.iter(world) {
+            if parent.parent() != graph || node.node_type != STATE_NODE_TYPE {
+                continue;
+            }
+            positions.insert(entity, node.position);
+            match state {
+                Some(state) => {
+                    live.insert(state.0.clone(), entity);
+                }
+                None => unnamed.push((entity, node.position)),
+            }
+        }
+    }
+
+    let gone: Vec<String> = world
+        .resource::<AnimationGraphDoc>()
+        .nodes
+        .iter()
+        .filter(|(name, entity)| {
+            !live.contains_key(name.as_str()) && !world.entities().contains(**entity)
+        })
+        .map(|(name, _)| name.clone())
+        .collect();
+
+    let mut doc = world.resource_mut::<AnimationGraphDoc>();
+    let mut changed = false;
+    for state in &mut doc.def.states {
+        let Some(entity) = live.get(&state.name) else {
+            continue;
+        };
+        let Some(&position) = positions.get(entity) else {
+            continue;
+        };
+        if state.position != position {
+            state.position = position;
+            changed = true;
+        }
+    }
+
+    for name in gone {
+        doc.nodes.remove(&name);
+        let Some(at) = doc.def.states.iter().position(|state| state.name == name) else {
+            continue;
+        };
+        let state = doc.def.states.remove(at);
+        doc.retire_state(state);
+        let dropped: Vec<AnimationTransitionDef> = doc
+            .def
+            .transitions
+            .iter()
+            .filter(|transition| transition.from == name || transition.to == name)
+            .cloned()
+            .collect();
+        doc.def
+            .transitions
+            .retain(|transition| transition.from != name && transition.to != name);
+        for transition in dropped {
+            doc.retire_transition(transition);
+        }
+        changed = true;
+    }
+
+    let mut adopted: Vec<(Entity, String)> = Vec::new();
+    for (entity, position) in unnamed {
+        let state = doc.reclaim_state(position).unwrap_or_else(|| {
+            let name = doc.unused_state_name("State");
+            AnimationGraphState {
+                name,
+                position,
+                ..AnimationGraphState::default()
+            }
+        });
+        adopted.push((entity, state.name.clone()));
+        doc.nodes.insert(state.name.clone(), entity);
+        doc.def.states.push(state);
+        changed = true;
+    }
+    if changed {
+        doc.dirty = true;
+    }
+    for (entity, name) in adopted {
+        world.entity_mut(entity).insert(GraphStateNode(name));
+    }
+    if changed {
+        resync_views(world);
+    }
+}
+
+fn read_transitions_back(world: &mut World) {
+    let drawn = wire_ends(world);
+    let mut unclaimed: Vec<Entity> = drawn.iter().map(|(entity, _)| *entity).collect();
+
+    let mut doc = world.resource_mut::<AnimationGraphDoc>();
+    let mut changed = false;
+    let mut kept: Vec<Entity> = Vec::new();
+    let mut at = 0;
+    while at < doc.def.transitions.len() {
+        let wire = doc.wires.get(at).copied().unwrap_or(Entity::PLACEHOLDER);
+        if wire == Entity::PLACEHOLDER {
+            kept.push(wire);
+            at += 1;
+            continue;
+        }
+        if unclaimed.contains(&wire) {
+            unclaimed.retain(|entity| *entity != wire);
+            kept.push(wire);
+            at += 1;
+            continue;
+        }
+        let transition = doc.def.transitions.remove(at);
+        doc.retire_transition(transition);
+        changed = true;
+    }
+    doc.wires = kept;
+
+    for entity in unclaimed {
+        let Some((from, to)) = drawn
+            .iter()
+            .find(|(held, _)| *held == entity)
+            .map(|(_, ends)| ends.clone())
+        else {
+            continue;
+        };
+        let transition =
+            doc.reclaim_transition(&from, &to)
+                .unwrap_or_else(|| AnimationTransitionDef {
+                    from,
+                    to,
+                    ..AnimationTransitionDef::default()
+                });
+        doc.def.transitions.push(transition);
+        doc.wires.push(entity);
+        changed = true;
+    }
+    if changed {
+        doc.dirty = true;
+    }
+}
+
+/// Draw whatever the definition holds and the canvas does not.
+pub(super) fn reconcile_canvas(world: &mut World) {
+    let Some(graph) = world.resource::<AnimationGraphDoc>().graph else {
+        return;
+    };
+    if !world.entities().contains(graph) {
+        return;
+    }
+    reconcile_state_nodes(world, graph);
+    reconcile_any_state_node(world, graph);
+    reconcile_wires(world, graph);
+}
+
+fn reconcile_state_nodes(world: &mut World, graph: Entity) {
+    let live: HashMap<String, Entity> = {
+        let mut query = world.query::<(Entity, &GraphStateNode)>();
+        query
+            .iter(world)
+            .map(|(entity, state)| (state.0.clone(), entity))
+            .collect()
+    };
+    let wanted: Vec<(String, Vec2)> = world
+        .resource::<AnimationGraphDoc>()
+        .def
+        .states
+        .iter()
+        .map(|state| (state.name.clone(), state.position))
+        .collect();
+
+    for (name, entity) in &live {
+        if wanted.iter().any(|(held, _)| held == name) {
+            continue;
+        }
+        if let Ok(entity) = world.get_entity_mut(*entity) {
+            entity.despawn();
+        }
+    }
+    for (name, position) in wanted {
+        if live.contains_key(&name) {
+            continue;
+        }
+        let entity = spawn_canvas_node(world, graph, STATE_NODE_TYPE, position, true);
+        world
+            .entity_mut(entity)
+            .insert(GraphStateNode(name.clone()));
+        world
+            .resource_mut::<AnimationGraphDoc>()
+            .nodes
+            .insert(name, entity);
+    }
+}
+
+fn reconcile_any_state_node(world: &mut World, graph: Entity) {
+    let wanted = world
+        .resource::<AnimationGraphDoc>()
+        .def
+        .transitions
+        .iter()
+        .any(|transition| transition.from.is_empty());
+    let held: Vec<Entity> = {
+        let mut query = world.query_filtered::<Entity, With<GraphAnyStateNode>>();
+        query.iter(world).collect()
+    };
+    let drawn = !held.is_empty();
+    if wanted == drawn {
+        return;
+    }
+    if !wanted {
+        for entity in held {
+            if let Ok(entity) = world.get_entity_mut(entity) {
+                entity.despawn();
+            }
+        }
+        return;
+    }
+    let position = world.resource::<AnimationGraphDoc>().any_state_position;
+    let entity = spawn_canvas_node(world, graph, ANY_STATE_NODE_TYPE, position, false);
+    world.entity_mut(entity).insert(GraphAnyStateNode);
+}
+
+fn reconcile_wires(world: &mut World, graph: Entity) {
+    let named: HashMap<String, Entity> = {
+        let mut query = world.query::<(Entity, &GraphStateNode)>();
+        query
+            .iter(world)
+            .map(|(entity, state)| (state.0.clone(), entity))
+            .collect()
+    };
+    let any_state = {
+        let mut query = world.query_filtered::<Entity, With<GraphAnyStateNode>>();
+        query.iter(world).next()
+    };
+    let count = world.resource::<AnimationGraphDoc>().def.transitions.len();
+    for at in 0..count {
+        let held = world.resource::<AnimationGraphDoc>().wires.get(at).copied();
+        if held.is_some_and(|wire| world.entities().contains(wire)) {
+            continue;
+        }
+        let transition = world.resource::<AnimationGraphDoc>().def.transitions[at].clone();
+        let source = if transition.from.is_empty() {
+            any_state
+        } else {
+            named.get(&transition.from).copied()
+        };
+        let (Some(source), Some(&target)) = (source, named.get(&transition.to)) else {
+            continue;
+        };
+        let wire = world
+            .spawn((
+                Connection {
+                    source_node: source,
+                    source_terminal: 0,
+                    target_node: target,
+                    target_terminal: 0,
+                },
+                GraphCanvasPart,
+                ChildOf(graph),
+            ))
+            .id();
+        let mut doc = world.resource_mut::<AnimationGraphDoc>();
+        while doc.wires.len() <= at {
+            doc.wires.push(Entity::PLACEHOLDER);
+        }
+        doc.wires[at] = wire;
+    }
+}
+
+/// Spawn one canvas node with the terminals its type carries.
+fn spawn_canvas_node(
+    world: &mut World,
+    graph: Entity,
+    node_type: &str,
+    position: Vec2,
+    takes_input: bool,
+) -> Entity {
+    let entity = world
+        .spawn((
+            GraphNode {
+                node_type: node_type.to_string(),
+                position,
+            },
+            GraphCanvasPart,
+            ChildOf(graph),
+        ))
+        .id();
+    if takes_input {
+        world.spawn((
+            Terminal {
+                direction: TerminalDirection::Input,
+                data_type: STATE_TERMINAL.to_string(),
+                label: "in".to_string(),
+                index: 0,
+            },
+            ChildOf(entity),
+        ));
+    }
+    world.spawn((
+        Terminal {
+            direction: TerminalDirection::Output,
+            data_type: STATE_TERMINAL.to_string(),
+            label: "out".to_string(),
+            index: 0,
+        },
+        ChildOf(entity),
+    ));
+    entity
+}
+
+/// The terminal type a transition connects, which only another state accepts.
+pub const STATE_TERMINAL: &str = "anim.state_flow";
+
+/// Register the node types the graph canvas draws.
+pub(super) fn register_graph_node_types(
+    mut registry: ResMut<jackdaw_node_graph::NodeTypeRegistry>,
+) {
+    use jackdaw_node_graph::{NodeTypeDescriptor, TerminalDescriptor};
+
+    let color = Color::srgb(0.55, 0.80, 0.95);
+    let flow = |label: &str| TerminalDescriptor {
+        label: label.into(),
+        data_type: STATE_TERMINAL.into(),
+        color,
+    };
+    registry.register(NodeTypeDescriptor {
+        id: STATE_NODE_TYPE.into(),
+        display_name: "State".into(),
+        category: "Animation Graph".into(),
+        accent_color: Color::srgb(0.38, 0.72, 1.0),
+        inputs: vec![flow("in")],
+        outputs: vec![flow("out")],
+        body_components: Vec::new(),
+    });
+    registry.register(NodeTypeDescriptor {
+        id: ANY_STATE_NODE_TYPE.into(),
+        display_name: "Any State".into(),
+        category: "Animation Graph".into(),
+        accent_color: Color::srgb(0.95, 0.65, 0.35),
+        inputs: Vec::new(),
+        outputs: vec![flow("out")],
+        body_components: Vec::new(),
+    });
+}
+
+/// What a state's node says about the clip it plays.
+pub fn motion_summary(motion: &AnimationMotion) -> String {
+    match motion {
+        AnimationMotion::Clip(clip) if clip.clip.is_empty() => "no clip".to_string(),
+        AnimationMotion::Clip(clip) => clip.clip.clone(),
+        AnimationMotion::Blend1d { parameter, points } => {
+            format!("blend on {parameter}, {} clips", points.len())
+        }
+    }
+}
+
+/// A clip named as `<assets-relative file>#<clip name>`.
+pub fn parse_clip_ref(spec: &str) -> Option<AnimationClipRef> {
+    let (source, clip) = spec.rsplit_once('#')?;
+    (!source.is_empty() && !clip.is_empty()).then(|| AnimationClipRef {
+        source: source.to_string(),
+        clip: clip.to_string(),
+    })
+}
+
+/// What a wire says about the transition it draws.
+pub fn transition_summary(transition: &AnimationTransitionDef) -> String {
+    let mut parts: Vec<String> = transition
+        .conditions
+        .iter()
+        .map(|condition| {
+            format!(
+                "{} {} {}",
+                condition.parameter,
+                condition_op_name(condition.op),
+                trim_float(condition.value)
+            )
+        })
+        .collect();
+    if let Some(exit) = transition.exit_time {
+        parts.push(format!("at {}", trim_float(exit)));
+    }
+    if parts.is_empty() {
+        parts.push("always".to_string());
+    }
+    format!(
+        "{} ({}s)",
+        parts.join(if transition.require_all {
+            " and "
+        } else {
+            " or "
+        }),
+        trim_float(transition.crossfade_secs)
+    )
+}
+
+/// The spelling of an operator a condition is written with.
+pub fn condition_op_name(op: jackdaw_animation_runtime::AnimationConditionOp) -> &'static str {
+    use jackdaw_animation_runtime::AnimationConditionOp as Op;
+    match op {
+        Op::Greater => ">",
+        Op::GreaterOrEqual => ">=",
+        Op::Less => "<",
+        Op::LessOrEqual => "<=",
+        Op::Equal => "==",
+        Op::NotEqual => "!=",
+    }
+}
+
+/// The operator an authored condition spells.
+pub fn condition_op_from_name(
+    name: &str,
+) -> Option<jackdaw_animation_runtime::AnimationConditionOp> {
+    use jackdaw_animation_runtime::AnimationConditionOp as Op;
+    Some(match name {
+        ">" => Op::Greater,
+        ">=" => Op::GreaterOrEqual,
+        "<" => Op::Less,
+        "<=" => Op::LessOrEqual,
+        "==" | "=" => Op::Equal,
+        "!=" => Op::NotEqual,
+        _ => return None,
+    })
+}
+
+/// A number with no trailing zeroes, which is what a node has room for.
+fn trim_float(value: f32) -> String {
+    let text = format!("{value:.2}");
+    let text = text.trim_end_matches('0').trim_end_matches('.');
+    if text.is_empty() { "0" } else { text }.to_string()
+}
+
+/// The parameter kind an operator names.
+pub fn parameter_kind_from_name(
+    name: &str,
+) -> Option<jackdaw_animation_runtime::AnimationParameterKind> {
+    use jackdaw_animation_runtime::AnimationParameterKind as Kind;
+    Some(match name {
+        "float" => Kind::Float,
+        "bool" => Kind::Bool,
+        "trigger" => Kind::Trigger,
+        _ => return None,
+    })
+}
+
+/// The parameter of this name, if the graph declares one.
+pub fn parameter<'a>(def: &'a AnimationGraphDef, name: &str) -> Option<&'a AnimationParameterDef> {
+    def.parameters
+        .iter()
+        .find(|parameter| parameter.name == name)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn a_graph_name_becomes_a_file_stem_that_can_be_written() {
+        assert_eq!(
+            graph_path_for_name("Player Locomotion"),
+            "animation/Player_Locomotion.animgraph.bsn"
+        );
+        assert_eq!(graph_path_for_name("///"), "animation/graph.animgraph.bsn");
+    }
+
+    #[test]
+    fn a_file_with_no_layout_opens_as_a_grid_rather_than_a_stack() {
+        let mut def = AnimationGraphDef {
+            states: vec![
+                AnimationGraphState {
+                    name: "idle".into(),
+                    ..AnimationGraphState::default()
+                },
+                AnimationGraphState {
+                    name: "run".into(),
+                    ..AnimationGraphState::default()
+                },
+            ],
+            ..AnimationGraphDef::default()
+        };
+        lay_out_unplaced_states(&mut def);
+        assert_ne!(def.states[0].position, def.states[1].position);
+    }
+
+    #[test]
+    fn a_placed_file_keeps_the_layout_it_was_saved_with() {
+        let placed = Vec2::new(12.0, 34.0);
+        let mut def = AnimationGraphDef {
+            states: vec![AnimationGraphState {
+                name: "idle".into(),
+                position: placed,
+                ..AnimationGraphState::default()
+            }],
+            ..AnimationGraphDef::default()
+        };
+        lay_out_unplaced_states(&mut def);
+        assert_eq!(def.states[0].position, placed);
+    }
+}

--- a/src/animation/graph_ops.rs
+++ b/src/animation/graph_ops.rs
@@ -1,0 +1,684 @@
+//! Operators for everything the Graph window offers.
+//!
+//! Every control in the window dispatches one of these, so a graph can be
+//! authored from a script, from the remote or from the canvas by the same
+//! path.
+
+use bevy::prelude::*;
+use jackdaw_animation_runtime::{
+    AnimationCondition, AnimationGraphRef, AnimationGraphState, AnimationMotion,
+    AnimationParameterDef, AnimationParameterKind, AnimationParams, AnimationTransitionDef,
+};
+use jackdaw_api::prelude::*;
+
+use super::graph_doc::{
+    AnimationGraphDoc, commit_graph_edit, condition_op_from_name, graph_path_for_name, new_graph,
+    open_graph, parameter, parameter_kind_from_name, parse_clip_ref, write_graph_file,
+};
+use super::graph_window::graph_preview_target;
+
+pub(crate) fn add_to_extension(ctx: &mut ExtensionContext) {
+    ctx.register_operator::<AnimationGraphNewOp>()
+        .register_operator::<AnimationGraphOpenOp>()
+        .register_operator::<AnimationGraphSaveOp>()
+        .register_operator::<AnimationGraphAddStateOp>()
+        .register_operator::<AnimationGraphSetStateOp>()
+        .register_operator::<AnimationGraphRemoveStateOp>()
+        .register_operator::<AnimationGraphAddTransitionOp>()
+        .register_operator::<AnimationGraphRemoveTransitionOp>()
+        .register_operator::<AnimationGraphSetEntryOp>()
+        .register_operator::<AnimationGraphAddParamOp>()
+        .register_operator::<AnimationGraphSetParamOp>()
+        .register_operator::<AnimationGraphConvertSetOp>()
+        .register_operator::<AnimationGraphAssignOp>();
+}
+
+/// Start a graph of this name and open it on the canvas.
+#[operator(
+    id = "animation.graph.new",
+    label = "New Animation Graph",
+    description = "Start an empty animation graph in assets/animation and open it in the Graph \
+                   window.",
+    allows_undo = false,
+    params(name(String, doc = "What the graph is called, which is also its file stem."))
+)]
+pub(crate) fn animation_graph_new(
+    params: In<OperatorParameters>,
+    mut commands: Commands,
+) -> OperatorResult {
+    let named = params
+        .as_str("name")
+        .filter(|name| !name.is_empty())
+        .map(str::to_string);
+    commands.queue(move |world: &mut World| {
+        let name = named.clone().unwrap_or_else(|| {
+            let typed = world
+                .resource::<super::AnimationPanelState>()
+                .graph_name
+                .clone();
+            if typed.is_empty() {
+                "graph".to_string()
+            } else {
+                typed
+            }
+        });
+        if new_graph(world, &name).is_none() {
+            warn!("animation.graph.new: {name} could not be written");
+            return;
+        }
+        crate::open_window_in_default_area_if_absent(world, super::graph_window::GRAPH_WINDOW_ID);
+    });
+    OperatorResult::Finished
+}
+
+/// Open a graph file on the canvas.
+#[operator(
+    id = "animation.graph.open",
+    label = "Open Animation Graph",
+    description = "Show an existing .animgraph.bsn file in the Graph window.",
+    allows_undo = false,
+    params(path(String, doc = "Assets-relative path of the graph file to open."))
+)]
+pub(crate) fn animation_graph_open(
+    params: In<OperatorParameters>,
+    mut commands: Commands,
+) -> OperatorResult {
+    let path = params.as_str("path").map(str::to_string)?;
+    commands.queue(move |world: &mut World| {
+        if !open_graph(world, &path) {
+            return;
+        }
+        crate::open_window_in_default_area_if_absent(world, super::graph_window::GRAPH_WINDOW_ID);
+    });
+    OperatorResult::Finished
+}
+
+/// Write the open graph back to its file.
+#[operator(
+    id = "animation.graph.save",
+    label = "Save Animation Graph",
+    description = "Write the open graph back to the file it came from.",
+    is_available = a_graph_is_open,
+    allows_undo = false
+)]
+pub(crate) fn animation_graph_save(
+    _: In<OperatorParameters>,
+    mut commands: Commands,
+) -> OperatorResult {
+    commands.queue(|world: &mut World| {
+        if let Some(file) = write_graph_file(world) {
+            info!("Wrote {}", file.display());
+        }
+    });
+    OperatorResult::Finished
+}
+
+/// Put a state on the open graph.
+#[operator(
+    id = "animation.graph.add_state",
+    label = "Add State",
+    description = "Add a state to the open graph, playing one clip. The first state added \
+                   becomes the entry state.",
+    is_available = a_graph_is_open,
+    allows_undo = false,
+    params(
+        name(String, doc = "What the state is called. Defaults to the clip's name."),
+        clip(
+            String,
+            doc = "The clip it plays, as \"<assets-relative file>#<clip name>\"."
+        ),
+        r#loop(bool, default = true, doc = "Whether the state runs forever or once."),
+        speed(f64, default = 1.0, doc = "Playback rate, as a multiple of the clip's own."),
+    ),
+)]
+pub(crate) fn animation_graph_add_state(
+    params: In<OperatorParameters>,
+    mut commands: Commands,
+) -> OperatorResult {
+    let clip = params
+        .as_str("clip")
+        .filter(|spec| !spec.is_empty())
+        .map(str::to_string);
+    let wanted = params.as_str("name").map(str::to_string);
+    let looped = params.as_bool("loop").unwrap_or(true);
+    let speed = params.as_float("speed").unwrap_or(1.0) as f32;
+    commands.queue(move |world: &mut World| {
+        let motion = match clip.as_deref().map(parse_clip_ref) {
+            Some(Some(clip)) => AnimationMotion::Clip(clip),
+            Some(None) => {
+                warn!("animation.graph.add_state: `clip` reads <file>#<clip name>");
+                return;
+            }
+            None => AnimationMotion::default(),
+        };
+        let named = wanted.clone().unwrap_or_else(|| match &motion {
+            AnimationMotion::Clip(clip) => clip.clip.clone(),
+            AnimationMotion::Blend1d { parameter, .. } => parameter.clone(),
+        });
+        let doc = world.resource::<AnimationGraphDoc>();
+        let name = doc.unused_state_name(&named);
+        let position = doc.free_position();
+        commit_graph_edit(world, "Add state", |def| {
+            def.states.push(AnimationGraphState {
+                name: name.clone(),
+                motion,
+                looped,
+                speed,
+                position,
+            });
+            if def.entry.is_empty() {
+                def.entry = name;
+            }
+        });
+    });
+    OperatorResult::Finished
+}
+
+/// Change what a state is called or what it plays.
+#[operator(
+    id = "animation.graph.set_state",
+    label = "Set State",
+    description = "Change a state of the open graph: what it is called, the clip it plays, \
+                   whether it loops and how fast it runs.",
+    is_available = a_graph_is_open,
+    allows_undo = false,
+    params(
+        name(String, doc = "The state to change."),
+        rename(String, doc = "What to call it instead. Transitions follow the new name."),
+        clip(
+            String,
+            doc = "The clip it plays, as \"<assets-relative file>#<clip name>\"."
+        ),
+        r#loop(bool, doc = "Whether the state runs forever or once."),
+        speed(f64, doc = "Playback rate, as a multiple of the clip's own."),
+    ),
+)]
+pub(crate) fn animation_graph_set_state(
+    params: In<OperatorParameters>,
+    mut commands: Commands,
+) -> OperatorResult {
+    let name = params.as_str("name").map(str::to_string)?;
+    let rename = params
+        .as_str("rename")
+        .filter(|wanted| !wanted.is_empty())
+        .map(str::to_string);
+    let clip = params
+        .as_str("clip")
+        .filter(|spec| !spec.is_empty())
+        .map(str::to_string);
+    let looped = params.as_bool("loop");
+    let speed = params.as_float("speed").map(|speed| speed as f32);
+    commands.queue(move |world: &mut World| {
+        let doc = world.resource::<AnimationGraphDoc>();
+        if doc.state(&name).is_none() {
+            warn!("animation.graph.set_state: no state is called `{name}`");
+            return;
+        }
+        let renamed = rename.as_ref().map(|wanted| doc.unused_state_name(wanted));
+        let motion = match clip.as_deref().map(parse_clip_ref) {
+            Some(Some(clip)) => Some(AnimationMotion::Clip(clip)),
+            Some(None) => {
+                warn!("animation.graph.set_state: `clip` reads <file>#<clip name>");
+                return;
+            }
+            None => None,
+        };
+        commit_graph_edit(world, "Set state", |def| {
+            let Some(state) = def.states.iter_mut().find(|state| state.name == name) else {
+                return;
+            };
+            if let Some(motion) = motion {
+                state.motion = motion;
+            }
+            if let Some(looped) = looped {
+                state.looped = looped;
+            }
+            if let Some(speed) = speed {
+                state.speed = speed;
+            }
+            let Some(renamed) = renamed else {
+                return;
+            };
+            state.name = renamed.clone();
+            for transition in &mut def.transitions {
+                if transition.from == name {
+                    transition.from = renamed.clone();
+                }
+                if transition.to == name {
+                    transition.to = renamed.clone();
+                }
+            }
+            if def.entry == name {
+                def.entry = renamed;
+            }
+        });
+    });
+    OperatorResult::Finished
+}
+
+/// Take a state off the open graph.
+#[operator(
+    id = "animation.graph.remove_state",
+    label = "Remove State",
+    description = "Take a state and every transition touching it off the open graph.",
+    is_available = a_graph_is_open,
+    allows_undo = false,
+    params(name(String, doc = "The state to take away.")),
+)]
+pub(crate) fn animation_graph_remove_state(
+    params: In<OperatorParameters>,
+    mut commands: Commands,
+) -> OperatorResult {
+    let name = params.as_str("name").map(str::to_string)?;
+    commands.queue(move |world: &mut World| {
+        commit_graph_edit(world, "Remove state", |def| {
+            def.states.retain(|state| state.name != name);
+            def.transitions
+                .retain(|transition| transition.from != name && transition.to != name);
+            if def.entry == name {
+                def.entry = def
+                    .states
+                    .first()
+                    .map(|state| state.name.clone())
+                    .unwrap_or_default();
+            }
+        });
+    });
+    OperatorResult::Finished
+}
+
+/// Put a transition on the open graph.
+#[operator(
+    id = "animation.graph.add_transition",
+    label = "Add Transition",
+    description = "Move the graph from one state to another once its conditions hold.",
+    is_available = a_graph_is_open,
+    allows_undo = false,
+    params(
+        from(
+            String,
+            doc = "The state it leaves. Left out, it is taken from every state."
+        ),
+        to(String, doc = "The state it arrives at."),
+        when(
+            String,
+            doc = "Conditions, comma separated, each \"<parameter> <op> <value>\" with an op of \
+                   >, >=, <, <=, == or !=. A trigger parameter is named on its own."
+        ),
+        fade(f64, default = 0.15, doc = "Seconds the state it leaves fades out over."),
+        exit_time(
+            f64,
+            doc = "How far through its clip the state it leaves must be, from zero to one."
+        ),
+    ),
+)]
+pub(crate) fn animation_graph_add_transition(
+    params: In<OperatorParameters>,
+    mut commands: Commands,
+) -> OperatorResult {
+    let from = params.as_str("from").unwrap_or_default().to_string();
+    let to = params.as_str("to").map(str::to_string)?;
+    let when = params.as_str("when").unwrap_or_default().to_string();
+    let fade = params.as_float("fade").unwrap_or(0.15) as f32;
+    let exit_time = params.as_float("exit_time").map(|time| time as f32);
+    commands.queue(move |world: &mut World| {
+        let doc = world.resource::<AnimationGraphDoc>();
+        if doc.state(&to).is_none() {
+            warn!("animation.graph.add_transition: no state is called `{to}`");
+            return;
+        }
+        if !from.is_empty() && doc.state(&from).is_none() {
+            warn!("animation.graph.add_transition: no state is called `{from}`");
+            return;
+        }
+        let Some(conditions) = parse_conditions(&when) else {
+            warn!("animation.graph.add_transition: `when` reads <parameter> <op> <value>");
+            return;
+        };
+        commit_graph_edit(world, "Add transition", |def| {
+            def.transitions.push(AnimationTransitionDef {
+                from: from.clone(),
+                to: to.clone(),
+                conditions,
+                exit_time,
+                crossfade_secs: fade,
+                ..AnimationTransitionDef::default()
+            });
+        });
+    });
+    OperatorResult::Finished
+}
+
+/// Take a transition off the open graph.
+#[operator(
+    id = "animation.graph.remove_transition",
+    label = "Remove Transition",
+    description = "Take the transition between two states off the open graph.",
+    is_available = a_graph_is_open,
+    allows_undo = false,
+    params(
+        from(String, doc = "The state it leaves. Left out, an any-state transition."),
+        to(String, doc = "The state it arrives at."),
+    ),
+)]
+pub(crate) fn animation_graph_remove_transition(
+    params: In<OperatorParameters>,
+    mut commands: Commands,
+) -> OperatorResult {
+    let from = params.as_str("from").unwrap_or_default().to_string();
+    let to = params.as_str("to").map(str::to_string)?;
+    commands.queue(move |world: &mut World| {
+        commit_graph_edit(world, "Remove transition", |def| {
+            if let Some(at) = def
+                .transitions
+                .iter()
+                .position(|held| held.from == from && held.to == to)
+            {
+                def.transitions.remove(at);
+            }
+        });
+    });
+    OperatorResult::Finished
+}
+
+/// Say which state the graph starts in.
+#[operator(
+    id = "animation.graph.set_entry",
+    label = "Set Entry State",
+    description = "Say which state the graph starts in.",
+    is_available = a_graph_is_open,
+    allows_undo = false,
+    params(name(String, doc = "The state to start in.")),
+)]
+pub(crate) fn animation_graph_set_entry(
+    params: In<OperatorParameters>,
+    mut commands: Commands,
+) -> OperatorResult {
+    let name = params.as_str("name").map(str::to_string)?;
+    commands.queue(move |world: &mut World| {
+        if world.resource::<AnimationGraphDoc>().state(&name).is_none() {
+            warn!("animation.graph.set_entry: no state is called `{name}`");
+            return;
+        }
+        commit_graph_edit(world, "Set entry state", |def| def.entry = name.clone());
+    });
+    OperatorResult::Finished
+}
+
+/// Declare a parameter the game writes.
+#[operator(
+    id = "animation.graph.add_param",
+    label = "Add Parameter",
+    description = "Declare a parameter the game writes to steer the graph.",
+    is_available = a_graph_is_open,
+    allows_undo = false,
+    params(
+        name(
+            String,
+            doc = "What the parameter is called. Left out, the next unused \"Parameter\" name."
+        ),
+        kind(
+            String,
+            default = "float",
+            doc = "What it holds: \"float\", \"bool\" or \"trigger\"."
+        ),
+        default(f64, doc = "The value it starts at."),
+    ),
+)]
+pub(crate) fn animation_graph_add_param(
+    params: In<OperatorParameters>,
+    mut commands: Commands,
+) -> OperatorResult {
+    let wanted = params
+        .as_str("name")
+        .filter(|name| !name.is_empty())
+        .map(str::to_string);
+    let kind = params.as_str("kind").unwrap_or("float").to_string();
+    let start = params.as_float("default").unwrap_or_default() as f32;
+    commands.queue(move |world: &mut World| {
+        let Some(kind) = parameter_kind_from_name(&kind) else {
+            warn!("animation.graph.add_param: `kind` is float, bool or trigger");
+            return;
+        };
+        let def = &world.resource::<AnimationGraphDoc>().def;
+        let name = match wanted.clone() {
+            Some(name) if parameter(def, &name).is_some() => {
+                warn!("animation.graph.add_param: a parameter is already called `{name}`");
+                return;
+            }
+            Some(name) => name,
+            None => (1..)
+                .map(|n| format!("Parameter {n}"))
+                .find(|name| parameter(def, name).is_none())
+                .unwrap_or_else(|| "Parameter".to_string()),
+        };
+        commit_graph_edit(world, "Add parameter", |def| {
+            def.parameters.push(AnimationParameterDef {
+                name: name.clone(),
+                kind,
+                default: start,
+            });
+        });
+    });
+    OperatorResult::Finished
+}
+
+/// Write a parameter on whatever the graph is previewing.
+#[operator(
+    id = "animation.graph.set_param",
+    label = "Set Parameter",
+    description = "Write a parameter on the entity the open graph is previewing, so the \
+                   viewport shows what it steers.",
+    is_available = a_graph_is_open,
+    allows_undo = false,
+    params(
+        name(String, doc = "The parameter to write."),
+        value(f64, default = 1.0, doc = "What to write. A bool reads zero as false."),
+    ),
+)]
+pub(crate) fn animation_graph_set_param(
+    params: In<OperatorParameters>,
+    mut commands: Commands,
+) -> OperatorResult {
+    let name = params.as_str("name").map(str::to_string)?;
+    let value = params.as_float("value").unwrap_or(1.0) as f32;
+    commands.queue(move |world: &mut World| {
+        let Some(kind) = parameter(&world.resource::<AnimationGraphDoc>().def, &name)
+            .map(|parameter| parameter.kind)
+        else {
+            warn!("animation.graph.set_param: the graph declares no parameter `{name}`");
+            return;
+        };
+        let Some(target) = graph_preview_target(world) else {
+            warn!("animation.graph.set_param: nothing in the scene is playing this graph");
+            return;
+        };
+        if world.get::<AnimationParams>(target).is_none() {
+            world.entity_mut(target).insert(AnimationParams::default());
+        }
+        let Some(mut written) = world.get_mut::<AnimationParams>(target) else {
+            return;
+        };
+        match kind {
+            AnimationParameterKind::Float => written.set_float(&name, value),
+            AnimationParameterKind::Bool => written.set_bool(&name, value != 0.0),
+            AnimationParameterKind::Trigger if value != 0.0 => written.trigger(&name),
+            AnimationParameterKind::Trigger => written.clear_trigger(&name),
+        }
+    });
+    OperatorResult::Finished
+}
+
+/// Point the selected entity at a graph file.
+#[operator(
+    id = "animation.graph.assign",
+    label = "Use Animation Graph",
+    description = "Point the selected entity's graph reference at a graph file, and open that \
+                   graph in the Graph window.",
+    allows_undo = false,
+    params(path(String, doc = "Assets-relative path of the graph file to play."))
+)]
+pub(crate) fn animation_graph_assign(
+    params: In<OperatorParameters>,
+    mut commands: Commands,
+) -> OperatorResult {
+    let path = params.as_str("path").map(str::to_string)?;
+    commands.queue(move |world: &mut World| {
+        let Some(entity) = world.resource::<crate::selection::Selection>().primary() else {
+            return;
+        };
+        if !crate::commands::field_edit_commit_on(
+            world,
+            entity,
+            <AnimationGraphRef as bevy::reflect::TypePath>::type_path(),
+            "path",
+            &serde_json::json!(path),
+        ) {
+            warn!("animation.graph.assign: the entity refused the graph path");
+            return;
+        }
+        if open_graph(world, &path) {
+            crate::open_window_in_default_area_if_absent(
+                world,
+                super::graph_window::GRAPH_WINDOW_ID,
+            );
+        }
+    });
+    OperatorResult::Finished
+}
+
+/// Write a selected animation set out as a graph and open it.
+#[operator(
+    id = "animation.graph.convert_set",
+    label = "Convert To Graph",
+    description = "Write the selected entity's animation set out as a graph file, and point \
+                   the entity at it.",
+    is_available = a_set_without_a_graph_is_selected,
+    allows_undo = false
+)]
+pub(crate) fn animation_graph_convert_set(
+    _: In<OperatorParameters>,
+    mut commands: Commands,
+) -> OperatorResult {
+    commands.queue(convert_selected_set);
+    OperatorResult::Finished
+}
+
+/// Turn the selected set into a graph file, and give the entity a reference to
+/// it so the rig plays the graph rather than the set.
+fn convert_selected_set(world: &mut World) {
+    let Some(entity) = world.resource::<crate::selection::Selection>().primary() else {
+        return;
+    };
+    let Some(set) = world
+        .get::<jackdaw_animation_runtime::AnimationSet>(entity)
+        .cloned()
+    else {
+        return;
+    };
+    let name = world
+        .get::<Name>(entity)
+        .map(|name| name.as_str().to_string())
+        .unwrap_or_else(|| "graph".to_string());
+    let path = graph_path_for_name(&name);
+    super::graph_doc::install_graph(world, &path, set.to_graph(), true);
+    if write_graph_file(world).is_none() {
+        return;
+    }
+    let reference = AnimationGraphRef {
+        path: path.clone(),
+        skeleton_root: set.skeleton_root.clone(),
+    };
+    let registry = world.resource::<AppTypeRegistry>().clone();
+    let value = {
+        let registry = registry.read();
+        crate::inspector::reflect_fields::reflect_to_json(&reference, &registry)
+    };
+    let Some(value) = value else {
+        warn!("animation.graph.convert_set: the reference did not convert to a value to author");
+        return;
+    };
+    if !crate::commands::field_edit_commit_on(
+        world,
+        entity,
+        <AnimationGraphRef as bevy::reflect::TypePath>::type_path(),
+        "",
+        &value,
+    ) {
+        warn!("animation.graph.convert_set: the entity refused the graph reference");
+    }
+    crate::open_window_in_default_area_if_absent(world, super::graph_window::GRAPH_WINDOW_ID);
+}
+
+fn a_graph_is_open(doc: Res<AnimationGraphDoc>) -> bool {
+    doc.path.is_some()
+}
+
+fn a_set_without_a_graph_is_selected(
+    selection: Res<crate::selection::Selection>,
+    sets: Query<
+        (),
+        (
+            With<jackdaw_animation_runtime::AnimationSet>,
+            Without<AnimationGraphRef>,
+        ),
+    >,
+) -> bool {
+    selection
+        .primary()
+        .is_some_and(|entity| sets.contains(entity))
+}
+
+/// Read the conditions a transition is authored with.
+///
+/// An empty text is no condition at all, which is a transition taken as soon
+/// as its exit time allows.
+fn parse_conditions(when: &str) -> Option<Vec<AnimationCondition>> {
+    let mut conditions = Vec::new();
+    for clause in when.split(',').map(str::trim).filter(|c| !c.is_empty()) {
+        let words: Vec<&str> = clause.split_whitespace().collect();
+        let condition = match words.as_slice() {
+            [parameter] => AnimationCondition {
+                parameter: (*parameter).to_string(),
+                ..AnimationCondition::default()
+            },
+            [parameter, op, value] => AnimationCondition {
+                parameter: (*parameter).to_string(),
+                op: condition_op_from_name(op)?,
+                value: value.parse().ok()?,
+            },
+            _ => return None,
+        };
+        conditions.push(condition);
+    }
+    Some(conditions)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use jackdaw_animation_runtime::AnimationConditionOp;
+
+    #[test]
+    fn a_condition_reads_its_parameter_operator_and_value() {
+        let conditions = parse_conditions("speed >= 2.5").expect("the clause reads");
+        assert_eq!(conditions.len(), 1);
+        assert_eq!(conditions[0].parameter, "speed");
+        assert_eq!(conditions[0].op, AnimationConditionOp::GreaterOrEqual);
+        assert_eq!(conditions[0].value, 2.5);
+    }
+
+    #[test]
+    fn a_trigger_condition_is_named_on_its_own() {
+        let conditions = parse_conditions("attack, speed < 1").expect("the clauses read");
+        assert_eq!(conditions.len(), 2);
+        assert_eq!(conditions[0].parameter, "attack");
+        assert_eq!(conditions[1].op, AnimationConditionOp::Less);
+    }
+
+    #[test]
+    fn a_clause_with_no_operator_is_refused() {
+        assert!(parse_conditions("speed 2.5").is_none());
+        assert!(parse_conditions("speed ~ 2.5").is_none());
+    }
+}

--- a/src/animation/graph_window.rs
+++ b/src/animation/graph_window.rs
@@ -1,0 +1,830 @@
+//! The Graph window: the open animation graph drawn on the node canvas.
+//!
+//! The canvas itself comes from [`jackdaw_node_graph`]; this module hosts it,
+//! puts the graph's parameters and its selected state beside it, and lights
+//! whichever state the rig is actually in.
+
+use bevy::feathers::controls::FeathersCheckbox;
+use bevy::feathers::theme::ThemedText;
+use bevy::prelude::*;
+use bevy::ui::Checked;
+use bevy::ui_widgets::{SliderValue, ValueChange};
+use jackdaw_animation_runtime::{
+    AnimationGraphPlayback, AnimationGraphRef, AnimationParameterKind,
+};
+use jackdaw_api::op::OperatorCommandsExt as _;
+use jackdaw_api::prelude::*;
+use jackdaw_feathers::{
+    button::{ButtonOperatorCall, ButtonProps, ButtonSize, ButtonVariant, button},
+    slider_row::{SliderRowProps, spawn_slider_row},
+    text_edit::{TextEditCommitEvent, TextEditProps, text_edit},
+    tokens,
+};
+use jackdaw_node_graph::{
+    Connection, GraphCanvasWorld, GraphNode, GraphNodeBody, GraphNodeView, GraphSelection,
+};
+
+use super::graph_doc::{
+    AnimationGraphDoc, GraphAnyStateNode, GraphStateNode, motion_summary, transition_summary,
+};
+use super::graph_ops::{
+    AnimationGraphAddParamOp, AnimationGraphAddStateOp, AnimationGraphRemoveStateOp,
+    AnimationGraphSaveOp, AnimationGraphSetEntryOp, AnimationGraphSetParamOp,
+    AnimationGraphSetStateOp,
+};
+
+/// Catalog id of the dock window this module builds.
+pub const GRAPH_WINDOW_ID: &str = "jackdaw.animation_graph";
+
+/// How far a wire's annotation sits from the ends it joins.
+const NODE_CENTRE: Vec2 = Vec2::new(80.0, 40.0);
+
+/// Colour of the state the rig is in.
+const RUNNING_STATE_BG: Color = Color::srgb(0.16, 0.34, 0.24);
+
+/// Colour of a state standing still.
+const IDLE_STATE_BG: Color = Color::srgb(0.14, 0.15, 0.17);
+
+/// Colour of the annotation on a transition that is running.
+const RUNNING_WIRE_BG: Color = Color::srgba(0.30, 0.65, 0.45, 0.85);
+
+/// Colour of the annotation on a transition standing still.
+const IDLE_WIRE_BG: Color = Color::srgba(0.0, 0.0, 0.0, 0.55);
+
+/// Marker for the window's toolbar row.
+#[derive(Component)]
+struct GraphToolbar;
+
+/// Marker for the window's parameter strip.
+#[derive(Component)]
+struct GraphParameterStrip;
+
+/// Marker for the strip showing whichever state is selected.
+#[derive(Component)]
+struct GraphStateStrip;
+
+/// Marker for the container the canvas is built into.
+#[derive(Component)]
+struct GraphCanvasHost;
+
+/// Marker on everything this window spawns, so a part left with no parent when
+/// the dock rebuilt the window is dropped rather than drawn over the editor.
+#[derive(Component)]
+struct GraphWindowPart;
+
+/// The state name a rename field is editing.
+#[derive(Component)]
+struct StateNameField(String);
+
+/// The parameter a control writes.
+#[derive(Component)]
+struct ParameterControl {
+    name: String,
+    kind: AnimationParameterKind,
+}
+
+/// The label drawn beside one wire.
+#[derive(Component)]
+struct TransitionLabel(Entity);
+
+/// What one node's body was last filled with.
+#[derive(Component)]
+struct StateBodySummary(String);
+
+/// What the graph is doing, as the canvas draws it.
+#[derive(Debug, Default, PartialEq)]
+pub struct GraphHighlight {
+    /// The state driving the rig.
+    pub state: String,
+    /// The state being faded out, while a transition is still running.
+    pub fading_from: Option<String>,
+}
+
+/// What a playback says the canvas should light.
+pub fn highlight_of(playback: &AnimationGraphPlayback) -> GraphHighlight {
+    GraphHighlight {
+        state: playback.state.clone(),
+        fading_from: playback
+            .transition
+            .as_ref()
+            .filter(|transition| transition.remaining_secs > 0.0)
+            .map(|transition| transition.from.clone()),
+    }
+}
+
+/// The entity the open graph previews on.
+///
+/// The selection wins when it plays this graph, so a scene holding several
+/// rigs follows the one being worked on; otherwise the first entity playing it
+/// stands in, which is what a scene with one rig wants.
+pub fn graph_preview_target(world: &mut World) -> Option<Entity> {
+    let path = world.resource::<AnimationGraphDoc>().path.clone()?;
+    let selected = world.resource::<crate::selection::Selection>().primary();
+    let mut playing = world.query::<(Entity, &AnimationGraphRef)>();
+    let mut first = None;
+    for (entity, reference) in playing.iter(world) {
+        if reference.path != path {
+            continue;
+        }
+        if Some(entity) == selected {
+            return Some(entity);
+        }
+        first.get_or_insert(entity);
+    }
+    first
+}
+
+/// Builds the Graph window: a toolbar over a parameter strip, a state strip
+/// and the canvas. The systems in this module fill all four.
+pub fn animation_graph_window_content() -> impl Bundle {
+    (
+        Node {
+            width: percent(100),
+            height: percent(100),
+            flex_direction: FlexDirection::Column,
+            ..default()
+        },
+        BackgroundColor(tokens::PANEL_BG),
+        children![
+            (GraphToolbar, strip_node()),
+            (GraphParameterStrip, strip_node()),
+            (GraphStateStrip, strip_node()),
+            (
+                GraphCanvasHost,
+                Node {
+                    width: percent(100),
+                    flex_grow: 1.0,
+                    min_height: px(0),
+                    ..default()
+                },
+            ),
+        ],
+    )
+}
+
+fn strip_node() -> Node {
+    Node {
+        flex_direction: FlexDirection::Row,
+        align_items: AlignItems::Center,
+        column_gap: px(tokens::SPACING_SM),
+        padding: UiRect::axes(px(tokens::SPACING_SM), px(tokens::SPACING_XS)),
+        width: percent(100),
+        flex_shrink: 0.0,
+        flex_wrap: FlexWrap::Wrap,
+        row_gap: px(tokens::SPACING_XS),
+        ..default()
+    }
+}
+
+fn despawn_children(commands: &mut Commands, children: Option<&Children>) {
+    for child in children.into_iter().flatten() {
+        commands.entity(*child).despawn();
+    }
+}
+
+fn hint(commands: &mut Commands, parent: Entity, text: &str) {
+    commands.spawn((
+        GraphWindowPart,
+        Text::new(text.to_string()),
+        TextFont {
+            font_size: tokens::TEXT_SIZE_SM,
+            ..default()
+        },
+        TextColor(tokens::TEXT_SECONDARY),
+        ChildOf(parent),
+    ));
+}
+
+/// Build the canvas into the window body once a graph is open.
+fn build_graph_canvas(
+    mut commands: Commands,
+    doc: Res<AnimationGraphDoc>,
+    hosts: Query<(Entity, Option<&Children>), With<GraphCanvasHost>>,
+    worlds: Query<&GraphCanvasWorld>,
+) {
+    let showing = worlds.iter().any(|world| Some(world.graph) == doc.graph);
+    for (host, children) in &hosts {
+        match doc.graph {
+            Some(graph) if !showing => {
+                despawn_children(&mut commands, children);
+                let canvas = commands
+                    .spawn((
+                        GraphWindowPart,
+                        jackdaw_node_graph::canvas(graph),
+                        ChildOf(host),
+                    ))
+                    .id();
+                commands.spawn((
+                    GraphWindowPart,
+                    jackdaw_node_graph::canvas_world(graph),
+                    ChildOf(canvas),
+                ));
+            }
+            None if children.is_some_and(|kids| !kids.is_empty()) => {
+                despawn_children(&mut commands, children);
+                hint(
+                    &mut commands,
+                    host,
+                    "No graph is open. Pick one in the Animation panel's Graph tab.",
+                );
+            }
+            _ => {}
+        }
+    }
+}
+
+/// What the toolbar was last drawn for.
+#[derive(PartialEq)]
+struct ToolbarSignature {
+    path: Option<String>,
+    entry: String,
+    dirty: bool,
+    states: usize,
+}
+
+fn update_graph_toolbar(
+    mut commands: Commands,
+    doc: Res<AnimationGraphDoc>,
+    bars: Query<(Entity, Option<&Children>), With<GraphToolbar>>,
+    mut last: Local<Option<ToolbarSignature>>,
+) {
+    let signature = ToolbarSignature {
+        path: doc.path.clone(),
+        entry: doc.def.entry.clone(),
+        dirty: doc.dirty,
+        states: doc.def.states.len(),
+    };
+    if last.as_ref() == Some(&signature) && bars.iter().all(|(_, kids)| filled(kids)) {
+        return;
+    }
+    *last = Some(signature);
+
+    for (bar, children) in &bars {
+        despawn_children(&mut commands, children);
+        let title = match &doc.path {
+            Some(path) if doc.dirty => format!("{path} (unsaved)"),
+            Some(path) => path.clone(),
+            None => "No graph open".to_string(),
+        };
+        commands.spawn((
+            GraphWindowPart,
+            Text::new(title),
+            TextFont {
+                font_size: tokens::TEXT_SIZE_SM,
+                ..default()
+            },
+            TextColor(tokens::TEXT_SECONDARY),
+            ChildOf(bar),
+        ));
+        if doc.path.is_none() {
+            continue;
+        }
+        commands.spawn((
+            GraphWindowPart,
+            button(ButtonProps::new("Add state").with_size(ButtonSize::MD)),
+            ButtonOperatorCall::new(AnimationGraphAddStateOp::ID),
+            ChildOf(bar),
+        ));
+        commands.spawn((
+            GraphWindowPart,
+            button(
+                ButtonProps::new("Save")
+                    .with_size(ButtonSize::MD)
+                    .with_variant(ButtonVariant::Default),
+            ),
+            ButtonOperatorCall::new(AnimationGraphSaveOp::ID),
+            ChildOf(bar),
+        ));
+        commands.spawn((
+            GraphWindowPart,
+            button(ButtonProps::new("Add parameter").with_size(ButtonSize::MD)),
+            ButtonOperatorCall::new(AnimationGraphAddParamOp::ID),
+            ChildOf(bar),
+        ));
+        let entry = if doc.def.entry.is_empty() {
+            "no entry state".to_string()
+        } else {
+            format!("entry: {}", doc.def.entry)
+        };
+        commands.spawn((
+            GraphWindowPart,
+            Text::new(entry),
+            TextFont {
+                font_size: tokens::TEXT_SIZE_XS,
+                ..default()
+            },
+            TextColor(tokens::TEXT_MUTED_COLOR.into()),
+            ChildOf(bar),
+        ));
+    }
+}
+
+fn filled(children: Option<&Children>) -> bool {
+    children.is_some_and(|kids| !kids.is_empty())
+}
+
+/// What the parameter strip was last drawn for.
+#[derive(PartialEq)]
+struct ParameterSignature {
+    path: Option<String>,
+    parameters: Vec<(String, AnimationParameterKind)>,
+}
+
+fn update_parameter_strip(
+    mut commands: Commands,
+    doc: Res<AnimationGraphDoc>,
+    strips: Query<(Entity, Option<&Children>), With<GraphParameterStrip>>,
+    mut last: Local<Option<ParameterSignature>>,
+) {
+    let signature = ParameterSignature {
+        path: doc.path.clone(),
+        parameters: doc
+            .def
+            .parameters
+            .iter()
+            .map(|parameter| (parameter.name.clone(), parameter.kind))
+            .collect(),
+    };
+    if last.as_ref() == Some(&signature) && strips.iter().all(|(_, kids)| filled(kids)) {
+        return;
+    }
+    *last = Some(signature);
+
+    for (strip, children) in &strips {
+        despawn_children(&mut commands, children);
+        if doc.path.is_none() {
+            continue;
+        }
+        if doc.def.parameters.is_empty() {
+            hint(
+                &mut commands,
+                strip,
+                "This graph declares no parameters yet.",
+            );
+            continue;
+        }
+        for parameter in &doc.def.parameters {
+            let control = ParameterControl {
+                name: parameter.name.clone(),
+                kind: parameter.kind,
+            };
+            match parameter.kind {
+                AnimationParameterKind::Trigger => {
+                    commands.spawn((
+                        GraphWindowPart,
+                        button(ButtonProps::new(parameter.name.clone()).with_size(ButtonSize::MD)),
+                        ButtonOperatorCall::new(AnimationGraphSetParamOp::ID)
+                            .with_param("name", parameter.name.clone())
+                            .with_param("value", 1.0),
+                        ChildOf(strip),
+                    ));
+                }
+                AnimationParameterKind::Bool => {
+                    let caption = parameter.name.clone();
+                    let mut checkbox = commands.spawn_scene(bsn! {
+                        @FeathersCheckbox {
+                            @caption: bsn! { Text(caption) ThemedText }
+                        }
+                    });
+                    checkbox.insert((GraphWindowPart, control, ChildOf(strip)));
+                    if parameter.default != 0.0 {
+                        checkbox.insert(Checked);
+                    }
+                }
+                AnimationParameterKind::Float => {
+                    let row = commands
+                        .spawn((
+                            GraphWindowPart,
+                            Node {
+                                width: px(220.0),
+                                ..default()
+                            },
+                            ChildOf(strip),
+                        ))
+                        .id();
+                    spawn_slider_row(
+                        &mut commands,
+                        row,
+                        SliderRowProps::new(
+                            parameter.name.clone(),
+                            parameter.default,
+                            0.0..parameter.default.abs().max(1.0) * 10.0,
+                        ),
+                        control,
+                    );
+                }
+            }
+        }
+    }
+}
+
+/// Write a bool parameter as its checkbox is clicked.
+fn on_parameter_toggle(
+    change: On<ValueChange<bool>>,
+    controls: Query<&ParameterControl>,
+    mut commands: Commands,
+) {
+    let Ok(control) = controls.get(change.source) else {
+        return;
+    };
+    jackdaw_feathers::utils::set_marker_if_alive::<Checked>(
+        &mut commands,
+        change.source,
+        change.value,
+    );
+    commands
+        .operator(AnimationGraphSetParamOp::ID)
+        .param("name", control.name.clone())
+        .param("value", if change.value { 1.0 } else { 0.0 })
+        .call();
+}
+
+/// Write a float parameter as its slider moves.
+fn on_parameter_slide(
+    change: On<ValueChange<f32>>,
+    controls: Query<&ParameterControl>,
+    mut commands: Commands,
+) {
+    let Ok(control) = controls.get(change.source) else {
+        return;
+    };
+    if control.kind != AnimationParameterKind::Float {
+        return;
+    }
+    commands
+        .entity(change.source)
+        .insert(SliderValue(change.value));
+    commands
+        .operator(AnimationGraphSetParamOp::ID)
+        .param("name", control.name.clone())
+        .param("value", f64::from(change.value))
+        .call();
+}
+
+/// The state the canvas selection names, if it names one.
+fn selected_state(selection: &GraphSelection, nodes: &Query<&GraphStateNode>) -> Option<String> {
+    selection
+        .entities
+        .iter()
+        .find_map(|entity| nodes.get(*entity).ok())
+        .map(|state| state.0.clone())
+}
+
+fn update_state_strip(
+    mut commands: Commands,
+    doc: Res<AnimationGraphDoc>,
+    panel: Res<super::AnimationPanelState>,
+    selection: Res<GraphSelection>,
+    nodes: Query<&GraphStateNode>,
+    strips: Query<(Entity, Option<&Children>), With<GraphStateStrip>>,
+    mut last: Local<Option<(Option<String>, Option<String>)>>,
+) {
+    let chosen = selected_state(&selection, &nodes);
+    let shown = chosen
+        .as_ref()
+        .and_then(|name| doc.state(name))
+        .map(|state| {
+            (
+                state.name.clone(),
+                motion_summary(&state.motion),
+                state.looped,
+                state.speed,
+            )
+        });
+    let library_clip = match (&panel.file, &panel.clip) {
+        (Some(file), Some(clip)) => Some(format!("{file}#{clip}")),
+        _ => None,
+    };
+    let signature = (
+        shown.as_ref().map(|(name, ..)| name.clone()),
+        library_clip.clone(),
+    );
+    if last.as_ref() == Some(&signature) && strips.iter().all(|(_, kids)| filled(kids)) {
+        return;
+    }
+    *last = Some(signature);
+
+    for (strip, children) in &strips {
+        despawn_children(&mut commands, children);
+        let Some((name, clip, looped, speed)) = shown.clone() else {
+            hint(&mut commands, strip, "Select a state to edit it.");
+            continue;
+        };
+        commands.spawn((
+            GraphWindowPart,
+            StateNameField(name.clone()),
+            text_edit(TextEditProps::default().with_default_value(name.clone())),
+            ChildOf(strip),
+        ));
+        hint(&mut commands, strip, &format!("{clip}, x{speed:.2}"));
+        commands.spawn((
+            GraphWindowPart,
+            button(
+                ButtonProps::new(if looped { "Looping" } else { "Once" }).with_size(ButtonSize::MD),
+            ),
+            ButtonOperatorCall::new(AnimationGraphSetStateOp::ID)
+                .with_param("name", name.clone())
+                .with_param("loop", !looped),
+            ChildOf(strip),
+        ));
+        if let Some(spec) = library_clip.clone() {
+            let clip = spec
+                .rsplit_once('#')
+                .map_or(spec.clone(), |(_, clip)| clip.to_string());
+            commands.spawn((
+                GraphWindowPart,
+                button(ButtonProps::new(format!("Play {clip}")).with_size(ButtonSize::MD)),
+                ButtonOperatorCall::new(AnimationGraphSetStateOp::ID)
+                    .with_param("name", name.clone())
+                    .with_param("clip", spec),
+                ChildOf(strip),
+            ));
+        }
+        commands.spawn((
+            GraphWindowPart,
+            button(ButtonProps::new("Make entry").with_size(ButtonSize::MD)),
+            ButtonOperatorCall::new(AnimationGraphSetEntryOp::ID).with_param("name", name.clone()),
+            ChildOf(strip),
+        ));
+        commands.spawn((
+            GraphWindowPart,
+            button(
+                ButtonProps::new("Remove")
+                    .with_size(ButtonSize::MD)
+                    .with_variant(ButtonVariant::Ghost),
+            ),
+            ButtonOperatorCall::new(AnimationGraphRemoveStateOp::ID).with_param("name", name),
+            ChildOf(strip),
+        ));
+    }
+}
+
+/// Rename a state once its field is committed, rather than as it is typed:
+/// a rename per keystroke would leave one undo entry per letter.
+fn on_state_name_commit(
+    event: On<TextEditCommitEvent>,
+    fields: Query<&StateNameField>,
+    mut commands: Commands,
+) {
+    let Ok(field) = fields.get(event.entity) else {
+        return;
+    };
+    if event.text.is_empty() || event.text == field.0 {
+        return;
+    }
+    commands
+        .operator(AnimationGraphSetStateOp::ID)
+        .param("name", field.0.clone())
+        .param("rename", event.text.clone())
+        .call();
+}
+
+/// Say on each node what its state plays.
+fn fill_state_node_bodies(
+    mut commands: Commands,
+    doc: Res<AnimationGraphDoc>,
+    bodies: Query<(
+        Entity,
+        &GraphNodeBody,
+        Option<&Children>,
+        Option<&StateBodySummary>,
+    )>,
+    states: Query<&GraphStateNode>,
+    any_state: Query<(), With<GraphAnyStateNode>>,
+) {
+    for (body, owner, children, summary) in &bodies {
+        let wanted = if any_state.contains(owner.node) {
+            "every state".to_string()
+        } else {
+            let Ok(state) = states.get(owner.node) else {
+                continue;
+            };
+            let Some(held) = doc.state(&state.0) else {
+                continue;
+            };
+            let entry = if doc.def.entry == held.name {
+                "entry, "
+            } else {
+                ""
+            };
+            format!(
+                "{}\n{entry}{}{}, x{:.2}",
+                held.name,
+                motion_summary(&held.motion),
+                if held.looped { ", loop" } else { "" },
+                held.speed
+            )
+        };
+        if summary.is_some_and(|summary| summary.0 == wanted) {
+            continue;
+        }
+        despawn_children(&mut commands, children);
+        commands
+            .entity(body)
+            .insert(StateBodySummary(wanted.clone()));
+        commands.spawn((
+            GraphWindowPart,
+            jackdaw_node_graph::body_label(wanted),
+            ChildOf(body),
+        ));
+    }
+}
+
+/// Draw each wire's conditions and crossfade beside it.
+fn update_transition_labels(
+    mut commands: Commands,
+    doc: Res<AnimationGraphDoc>,
+    wires: Query<(Entity, &Connection)>,
+    nodes: Query<&GraphNode>,
+    worlds: Query<(Entity, &GraphCanvasWorld)>,
+    mut labels: Query<(Entity, &TransitionLabel, &mut Node, &mut Text)>,
+) {
+    let Some(graph) = doc.graph else {
+        return;
+    };
+    let Some((canvas, _)) = worlds.iter().find(|(_, world)| world.graph == graph) else {
+        return;
+    };
+    for (label, owner, _, _) in &labels {
+        if !wires.contains(owner.0) {
+            commands.entity(label).despawn();
+        }
+    }
+    for (at, transition) in doc.def.transitions.iter().enumerate() {
+        let Some(wire) = doc.wire(at) else {
+            continue;
+        };
+        let Ok((_, connection)) = wires.get(wire) else {
+            continue;
+        };
+        let (Ok(source), Ok(target)) = (
+            nodes.get(connection.source_node),
+            nodes.get(connection.target_node),
+        ) else {
+            continue;
+        };
+        let at_position = (source.position + target.position) / 2.0 + NODE_CENTRE;
+        let wanted = transition_summary(transition);
+        match labels.iter_mut().find(|(_, owner, _, _)| owner.0 == wire) {
+            Some((_, _, mut node, mut text)) => {
+                node.left = px(at_position.x);
+                node.top = px(at_position.y);
+                if text.0 != wanted {
+                    text.0 = wanted;
+                }
+            }
+            None => {
+                commands.spawn((
+                    GraphWindowPart,
+                    TransitionLabel(wire),
+                    Text::new(wanted),
+                    TextFont {
+                        font_size: tokens::TEXT_SIZE_XS,
+                        ..default()
+                    },
+                    TextColor(tokens::TEXT_SECONDARY),
+                    BackgroundColor(IDLE_WIRE_BG),
+                    Node {
+                        position_type: PositionType::Absolute,
+                        left: px(at_position.x),
+                        top: px(at_position.y),
+                        padding: UiRect::axes(px(4.0), px(1.0)),
+                        ..default()
+                    },
+                    Pickable::IGNORE,
+                    ChildOf(canvas),
+                ));
+            }
+        }
+    }
+}
+
+/// Light the state the rig is in and the transition still running.
+fn light_running_state(
+    doc: Res<AnimationGraphDoc>,
+    playbacks: Query<(&AnimationGraphRef, &AnimationGraphPlayback)>,
+    states: Query<&GraphStateNode>,
+    mut views: Query<(&GraphNodeView, &mut BackgroundColor)>,
+    wires: Query<&Connection>,
+    mut labels: Query<(&TransitionLabel, &mut BackgroundColor), Without<GraphNodeView>>,
+) {
+    let Some(path) = doc.path.clone() else {
+        return;
+    };
+    let running = playbacks
+        .iter()
+        .find(|(reference, _)| reference.path == path)
+        .map(|(_, playback)| highlight_of(playback))
+        .unwrap_or_default();
+    for (view, mut background) in &mut views {
+        let lit = states
+            .get(view.0)
+            .is_ok_and(|state| state.0 == running.state);
+        let wanted = if lit { RUNNING_STATE_BG } else { IDLE_STATE_BG };
+        if background.0 != wanted {
+            background.0 = wanted;
+        }
+    }
+    for (label, mut background) in &mut labels {
+        let lit = wires.get(label.0).is_ok_and(|wire| {
+            let from = states
+                .get(wire.source_node)
+                .ok()
+                .map(|state| state.0.clone());
+            let to = states
+                .get(wire.target_node)
+                .ok()
+                .map(|state| state.0.clone());
+            to.is_some_and(|to| to == running.state)
+                && running.fading_from.is_some()
+                && running.fading_from == from
+        });
+        let wanted = if lit { RUNNING_WIRE_BG } else { IDLE_WIRE_BG };
+        if background.0 != wanted {
+            background.0 = wanted;
+        }
+    }
+}
+
+/// Drop anything this window spawned that ended up with no parent.
+fn drop_orphaned_window_parts(
+    orphans: Query<Entity, (With<GraphWindowPart>, Without<ChildOf>)>,
+    mut commands: Commands,
+) {
+    for orphan in &orphans {
+        commands.entity(orphan).despawn();
+    }
+}
+
+pub(super) fn plugin(app: &mut App) {
+    app.init_resource::<AnimationGraphDoc>()
+        .add_systems(Startup, super::graph_doc::register_graph_node_types)
+        .add_observer(on_parameter_toggle)
+        .add_observer(on_parameter_slide)
+        .add_observer(on_state_name_commit)
+        .add_systems(
+            Update,
+            (
+                super::graph_doc::read_canvas_back,
+                super::graph_doc::reconcile_canvas,
+                build_graph_canvas,
+                update_graph_toolbar,
+                update_parameter_strip,
+                update_state_strip,
+                fill_state_node_bodies,
+                update_transition_labels,
+                light_running_state,
+                drop_orphaned_window_parts,
+            )
+                .chain()
+                .run_if(in_state(crate::AppState::Editor)),
+        );
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use jackdaw_animation_runtime::AnimationGraphTransition;
+
+    #[test]
+    fn the_highlight_names_the_state_the_rig_is_in() {
+        let playback = AnimationGraphPlayback {
+            state: "run".into(),
+            since_secs: 0.2,
+            transition: None,
+        };
+        assert_eq!(
+            highlight_of(&playback),
+            GraphHighlight {
+                state: "run".into(),
+                fading_from: None,
+            }
+        );
+    }
+
+    #[test]
+    fn a_crossfade_still_running_lights_the_state_it_leaves() {
+        let playback = AnimationGraphPlayback {
+            state: "run".into(),
+            since_secs: 0.05,
+            transition: Some(AnimationGraphTransition {
+                from: "idle".into(),
+                remaining_secs: 0.1,
+            }),
+        };
+        assert_eq!(highlight_of(&playback).fading_from.as_deref(), Some("idle"));
+    }
+
+    #[test]
+    fn a_crossfade_that_has_run_out_lights_nothing_behind_it() {
+        let playback = AnimationGraphPlayback {
+            state: "run".into(),
+            since_secs: 0.3,
+            transition: Some(AnimationGraphTransition {
+                from: "idle".into(),
+                remaining_secs: 0.0,
+            }),
+        };
+        assert!(highlight_of(&playback).fading_from.is_none());
+    }
+}

--- a/src/animation/mod.rs
+++ b/src/animation/mod.rs
@@ -1,5 +1,8 @@
 //! The Animation panel and the clip library behind it.
 
+pub mod graph_doc;
+pub mod graph_ops;
+pub mod graph_window;
 pub mod library;
 pub mod markers;
 pub mod panel;
@@ -7,6 +10,8 @@ pub mod preview;
 pub mod timeline_glue;
 pub mod timeline_ops;
 
+pub use graph_doc::AnimationGraphDoc;
+pub use graph_window::{GRAPH_WINDOW_ID, animation_graph_window_content};
 pub use library::{AnimationLibrary, LibraryClip, LibraryDemand, LibraryFile};
 pub use panel::{AnimationPanelState, AnimationPanelTab, animation_panel_content};
 pub use preview::{AnimationPreview, PreviewMannequin};
@@ -16,6 +21,7 @@ use jackdaw_api::prelude::*;
 
 pub(crate) fn plugin(app: &mut App) {
     app.add_plugins((
+        graph_window::plugin,
         library::plugin,
         markers::plugin,
         panel::plugin,
@@ -31,5 +37,6 @@ pub(crate) fn add_to_extension(ctx: &mut ExtensionContext) {
         .register_operator::<preview::AnimationPreviewOp>()
         .register_operator::<preview::AnimationPreviewPauseOp>()
         .register_operator::<preview::AnimationPreviewStopOp>();
+    graph_ops::add_to_extension(ctx);
     timeline_ops::add_to_extension(ctx);
 }

--- a/src/animation/panel.rs
+++ b/src/animation/panel.rs
@@ -35,6 +35,7 @@ pub enum AnimationPanelTab {
     #[default]
     Library,
     Timeline,
+    Graph,
 }
 
 /// What the Library tab is looking at.
@@ -46,6 +47,9 @@ pub struct AnimationPanelState {
     pub clip: Option<String>,
     /// What the filter field holds.
     pub filter: String,
+    /// What the Graph tab's name field holds, which is what a new graph is
+    /// called when the operator is dispatched without a name.
+    pub graph_name: String,
 }
 
 /// Marker for the panel's tab-strip container.
@@ -87,6 +91,14 @@ fn demand_project_walk(
 #[derive(Component)]
 struct LibraryClipList;
 
+/// Marker on the Graph tab's new-graph name field.
+#[derive(Component)]
+struct AnimationGraphNameField;
+
+/// Marker on the scrolling column of graph files.
+#[derive(Component)]
+struct AnimationGraphList;
+
 /// Marker on everything this panel's systems spawn into the window.
 ///
 /// The dock rebuilds a window's content wholesale, which can take away a
@@ -111,22 +123,32 @@ const NOTHING_PREVIEWING: &str = "nothing is previewing";
     params(tab(
         String,
         default = "library",
-        doc = "Which tab to show: \"library\" or \"timeline\"."
+        doc = "Which tab to show: \"library\", \"timeline\" or \"graph\"."
     ),),
     allows_undo = false
 )]
 pub(crate) fn animation_panel_tab(
     params: In<OperatorParameters>,
     mut tab: ResMut<AnimationPanelTab>,
+    mut commands: Commands,
 ) -> OperatorResult {
     *tab = match params.as_str("tab").unwrap_or("library") {
         "timeline" => AnimationPanelTab::Timeline,
         "library" => AnimationPanelTab::Library,
+        "graph" => AnimationPanelTab::Graph,
         other => {
             warn!("animation.panel.tab: no tab is called \"{other}\", showing the library");
             AnimationPanelTab::Library
         }
     };
+    if *tab == AnimationPanelTab::Graph {
+        commands.queue(|world: &mut World| {
+            crate::open_window_in_default_area_if_absent(
+                world,
+                super::graph_window::GRAPH_WINDOW_ID,
+            );
+        });
+    }
     OperatorResult::Finished
 }
 
@@ -294,6 +316,7 @@ fn update_animation_panel_tabs(
             [
                 TabStripItem::new("Library", *tab == AnimationPanelTab::Library, "library"),
                 TabStripItem::new("Timeline", *tab == AnimationPanelTab::Timeline, "timeline"),
+                TabStripItem::new("Graph", *tab == AnimationPanelTab::Graph, "graph"),
             ],
         );
         commands.entity(row).insert(AnimationPanelPart);
@@ -333,6 +356,9 @@ fn update_animation_panel_body(
             }
             AnimationPanelTab::Library => {
                 spawn_library_tab(&mut commands, body, &state, &icon_font);
+            }
+            AnimationPanelTab::Graph => {
+                spawn_graph_tab(&mut commands, body, &state);
             }
         }
     }
@@ -714,6 +740,128 @@ fn spawn_file_row(
     ));
 }
 
+/// The Graph tab: the graphs the project holds, and a field to name a new one.
+///
+/// The canvas itself lives in its own dock window, which the tab opens; this
+/// list is what says which graph that window shows.
+fn spawn_graph_tab(commands: &mut Commands, body: Entity, state: &AnimationPanelState) {
+    let toolbar = commands
+        .spawn((
+            AnimationPanelPart,
+            Node {
+                flex_direction: FlexDirection::Row,
+                align_items: AlignItems::Center,
+                column_gap: px(tokens::SPACING_SM),
+                padding: UiRect::all(px(tokens::SPACING_SM)),
+                flex_shrink: 0.0,
+                ..default()
+            },
+            ChildOf(body),
+        ))
+        .id();
+    commands.spawn((
+        AnimationGraphNameField,
+        text_edit(
+            TextEditProps::default()
+                .with_placeholder("New graph name...")
+                .with_default_value(state.graph_name.clone())
+                .allow_empty(),
+        ),
+        ChildOf(toolbar),
+    ));
+    commands.spawn((
+        button(
+            ButtonProps::new("New graph")
+                .with_variant(ButtonVariant::Default)
+                .with_left_icon(Icon::Plus),
+        ),
+        ButtonOperatorCall::new(crate::animation::graph_ops::AnimationGraphNewOp::ID),
+        ChildOf(toolbar),
+    ));
+    commands.spawn((
+        AnimationGraphList,
+        Node {
+            flex_grow: 1.0,
+            min_height: px(0),
+            flex_direction: FlexDirection::Column,
+            overflow: Overflow::scroll_y(),
+            padding: UiRect::horizontal(px(tokens::SPACING_SM)),
+            row_gap: px(tokens::SPACING_XS),
+            ..default()
+        },
+        ScrollPosition::default(),
+        ChildOf(body),
+    ));
+}
+
+/// Refill the list of graph files the project holds.
+///
+/// The directory is read when the tab is built and when the open graph
+/// changes, rather than every frame: nothing else in the editor writes these
+/// files behind the panel's back.
+fn update_graph_list(
+    mut commands: Commands,
+    doc: Res<crate::animation::graph_doc::AnimationGraphDoc>,
+    project: Option<Res<crate::project::ProjectRoot>>,
+    lists: Query<(Entity, Option<&Children>), With<AnimationGraphList>>,
+    mut last: Local<Option<String>>,
+) {
+    if lists.is_empty() {
+        *last = None;
+        return;
+    }
+    let open = doc.path.clone().unwrap_or_default();
+    if last.as_ref() == Some(&open) && all_filled(&lists) {
+        return;
+    }
+    *last = Some(open.clone());
+
+    let files = project
+        .map(|project| crate::animation::graph_doc::graph_files_in(&project))
+        .unwrap_or_default();
+    for (list, children) in &lists {
+        despawn_children(&mut commands, children);
+        if files.is_empty() {
+            spawn_hint(
+                &mut commands,
+                list,
+                "No graph in this project yet. Name one and press New graph.",
+            );
+            continue;
+        }
+        for path in &files {
+            commands.spawn((
+                AnimationPanelPart,
+                button(
+                    ButtonProps::new(path.clone())
+                        .with_variant(if *path == open {
+                            ButtonVariant::Active
+                        } else {
+                            ButtonVariant::Ghost
+                        })
+                        .with_size(ButtonSize::MD)
+                        .align_left(),
+                ),
+                ButtonOperatorCall::new(crate::animation::graph_ops::AnimationGraphOpenOp::ID)
+                    .with_param("path", path.clone()),
+                ChildOf(list),
+            ));
+        }
+    }
+}
+
+/// Read the new-graph name field into the state the operator falls back on.
+fn update_graph_name_field(
+    mut state: ResMut<AnimationPanelState>,
+    fields: Query<&TextEditValue, (With<AnimationGraphNameField>, Changed<TextEditValue>)>,
+) {
+    for field in &fields {
+        if state.graph_name != field.0 {
+            state.graph_name = field.0.clone();
+        }
+    }
+}
+
 /// Keep the transport's bar in step with the clip without redrawing the tab.
 fn update_preview_progress(
     preview: Res<AnimationPreview>,
@@ -778,11 +926,13 @@ pub(super) fn plugin(app: &mut App) {
             Update,
             (
                 update_library_filter,
+                update_graph_name_field,
                 update_animation_panel_tabs,
                 update_animation_panel_body,
                 demand_project_walk,
                 update_library_files,
                 update_library_clips,
+                update_graph_list,
                 update_preview_progress,
                 update_preview_target_label,
                 drop_orphaned_panel_parts,

--- a/src/builtin_extensions.rs
+++ b/src/builtin_extensions.rs
@@ -359,6 +359,37 @@ impl JackdawExtension for TimelineExtension {
     }
 }
 
+/// The animation graph canvas in the bottom dock.
+#[derive(Default)]
+pub struct AnimationGraphExtension;
+
+impl JackdawExtension for AnimationGraphExtension {
+    fn id(&self) -> String {
+        crate::animation::GRAPH_WINDOW_ID.to_string()
+    }
+
+    fn label(&self) -> String {
+        "Animation Graph".to_string()
+    }
+
+    fn kind(&self) -> ExtensionKind {
+        ExtensionKind::Builtin
+    }
+
+    fn register(&self, ctx: &mut ExtensionContext) {
+        ctx.register_window(
+            WindowDescriptor::new(crate::animation::GRAPH_WINDOW_ID)
+                .with_name("Graph")
+                .with_icon(Icon::Workflow.unicode())
+                .with_default_area(DefaultArea::BottomDock)
+                .with_priority(2)
+                .with_build(|window| {
+                    window.spawn(crate::animation::animation_graph_window_content());
+                }),
+        );
+    }
+}
+
 /// Terminal placeholder in the bottom dock.
 #[derive(Default)]
 pub struct TerminalExtension;

--- a/src/inspector/animation_graph_card.rs
+++ b/src/inspector/animation_graph_card.rs
@@ -1,0 +1,85 @@
+//! The rows an animation card carries beyond its reflected fields: the graphs
+//! a rig can be pointed at, and the way from a set of clips to a graph.
+
+use bevy::prelude::*;
+use jackdaw_animation_runtime::{AnimationGraphRef, AnimationSet};
+use jackdaw_api::op::Operator as _;
+use jackdaw_feathers::{
+    button::{ButtonOperatorCall, ButtonProps, ButtonSize, ButtonVariant, button},
+    tokens,
+};
+
+use crate::animation::graph_doc::graph_files;
+use crate::animation::graph_ops::{AnimationGraphAssignOp, AnimationGraphConvertSetOp};
+
+/// List the project's graph files under an [`AnimationGraphRef`] card, so the
+/// path is picked rather than typed.
+pub(super) fn fill_graph_reference_picker(world: &mut World, entity: Entity, body: Entity) {
+    let held = world
+        .get::<AnimationGraphRef>(entity)
+        .map(|reference| reference.path.clone())
+        .unwrap_or_default();
+    let files = graph_files(world);
+    let column = world
+        .spawn((
+            Node {
+                flex_direction: FlexDirection::Column,
+                row_gap: Val::Px(tokens::SPACING_XS),
+                margin: UiRect::bottom(Val::Px(tokens::SPACING_XS)),
+                ..default()
+            },
+            ChildOf(body),
+        ))
+        .id();
+    if files.is_empty() {
+        world.spawn((
+            Text::new("No graph file in assets/animation yet."),
+            TextFont {
+                font_size: tokens::TEXT_SIZE_SM,
+                ..default()
+            },
+            TextColor(tokens::TEXT_SECONDARY),
+            ChildOf(column),
+        ));
+        return;
+    }
+    for path in files {
+        let variant = if path == held {
+            ButtonVariant::Active
+        } else {
+            ButtonVariant::Ghost
+        };
+        let row = world
+            .spawn((
+                button(
+                    ButtonProps::new(path.clone())
+                        .with_variant(variant)
+                        .with_size(ButtonSize::MD)
+                        .align_left(),
+                ),
+                ButtonOperatorCall::new(AnimationGraphAssignOp::ID).with_param("path", path),
+            ))
+            .id();
+        world.entity_mut(row).insert(ChildOf(column));
+    }
+}
+
+/// Offer the way to a graph on an [`AnimationSet`] card that has none.
+pub(super) fn fill_animation_set_actions(world: &mut World, entity: Entity, body: Entity) {
+    if world.get::<AnimationSet>(entity).is_none()
+        || world.get::<AnimationGraphRef>(entity).is_some()
+    {
+        return;
+    }
+    let action = world
+        .spawn((
+            button(
+                ButtonProps::new("Convert to graph")
+                    .with_variant(ButtonVariant::Default)
+                    .with_size(ButtonSize::MD),
+            ),
+            ButtonOperatorCall::new(AnimationGraphConvertSetOp::ID),
+        ))
+        .id();
+    world.entity_mut(action).insert(ChildOf(body));
+}

--- a/src/inspector/component_display.rs
+++ b/src/inspector/component_display.rs
@@ -38,7 +38,7 @@ use jackdaw_geometry::is_convex_topology;
 use super::{
     ComponentDisplay, ComponentDisplayBody, ComponentDisplayTypePath, ComponentName,
     ComponentPicker, Inspector, InspectorDirty, InspectorGroupSection, InspectorSearch,
-    InspectorTarget, ReflectDisplayable, bindings_card, brush_display,
+    InspectorTarget, ReflectDisplayable, animation_graph_card, bindings_card, brush_display,
     category_strip::ActiveInspectorCategory, component_tooltip::ReflectedTypeTooltip,
     custom_props_display, material_display, modifier_display, node_card, reflect_fields,
 };
@@ -532,6 +532,22 @@ pub(crate) fn build_inspector_displays(
         // (`camera_preview`), above the reflected fields.
         if type_id == Some(TypeId::of::<Camera3d>()) {
             crate::camera_preview::spawn_camera_preview_strip(commands, body_entity);
+        }
+
+        // A graph reference leads with the graphs the project holds, and a set
+        // of clips with the way to a graph. Both are filled world-exclusive
+        // after the flush, then fall through to the reflected fields.
+        if type_id == Some(TypeId::of::<jackdaw_animation_runtime::AnimationGraphRef>()) {
+            let body = body_entity;
+            commands.queue(move |world: &mut World| {
+                animation_graph_card::fill_graph_reference_picker(world, source_entity, body);
+            });
+        }
+        if type_id == Some(TypeId::of::<jackdaw_animation_runtime::AnimationSet>()) {
+            let body = body_entity;
+            commands.queue(move |world: &mut World| {
+                animation_graph_card::fill_animation_set_actions(world, source_entity, body);
+            });
         }
 
         if let Some(type_id) = type_id

--- a/src/inspector/mod.rs
+++ b/src/inspector/mod.rs
@@ -1,5 +1,6 @@
 pub(crate) mod add_header;
 pub(crate) mod anim_diamond;
+mod animation_graph_card;
 pub mod bindings_card;
 mod brush_display;
 pub(crate) mod category_strip;

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -647,6 +647,7 @@ impl Plugin for ExtensionPlugin {
                 .register_extension::<builtin_extensions::AssetBrowserExtension>()
                 .register_extension::<builtin_extensions::GamePanelExtension>()
                 .register_extension::<builtin_extensions::TimelineExtension>()
+                .register_extension::<builtin_extensions::AnimationGraphExtension>()
                 .register_extension::<builtin_extensions::TerminalExtension>()
                 .register_extension::<build_panel::BuildPanelExtension>()
                 .register_extension::<builtin_extensions::InspectorExtension>()

--- a/src/pie_projection.rs
+++ b/src/pie_projection.rs
@@ -53,8 +53,13 @@ const PROJECTION_SKIP_PREFIXES: &[&str] = &["bevy_camera::camera::", "bevy_camer
 /// Streamed but never saved: these must reach the preview even though the
 /// save filter rejects them. The rig activation marker is how the Live
 /// camera lock finds the game's active rig; dropping it here would silently
-/// misalign picking and overlays against the streamed frame.
-const PROJECTION_ALLOW_PATHS: &[&str] = &["jackdaw_camera_rig::ActiveCameraRig"];
+/// misalign picking and overlays against the streamed frame. The graph
+/// playback is what the Graph window lights its running state from while the
+/// game is the one playing.
+const PROJECTION_ALLOW_PATHS: &[&str] = &[
+    "jackdaw_camera_rig::ActiveCameraRig",
+    "jackdaw_animation_runtime::graph::AnimationGraphPlayback",
+];
 
 /// True when a streamed component must not be applied to a preview entity.
 fn projection_skips(type_path: &str) -> bool {

--- a/tests/stage/animation_graph.rs
+++ b/tests/stage/animation_graph.rs
@@ -1,0 +1,269 @@
+//! Authoring an animation graph: the operators write a file the runtime loader
+//! reads back, the canvas and the definition follow each other, and a
+//! parameter written in the window reaches the rig previewing it.
+
+use crate::util;
+
+use bevy::prelude::*;
+use jackdaw::animation::graph_doc::AnimationGraphDoc;
+use jackdaw_animation_runtime::{
+    AnimationConditionOp, AnimationGraphDef, AnimationGraphRef, AnimationMotion, AnimationParams,
+    parse_animation_graph,
+};
+use jackdaw_api::prelude::*;
+use jackdaw_api_internal::operator::{CallOperatorSettings, ExecutionContext};
+use jackdaw_node_graph::GraphNode;
+use jackdaw_scene_types::PropertyValue;
+
+/// An editor holding a project of its own, so the graphs these tests write go
+/// to a directory nothing else reads.
+fn editor_in_a_fresh_project() -> (App, tempfile::TempDir) {
+    let project = tempfile::tempdir().expect("a project directory");
+    std::fs::create_dir_all(project.path().join("assets")).expect("an assets directory");
+    let mut app = util::editor_test_app();
+    app.world_mut()
+        .insert_resource(jackdaw::project::ProjectRoot {
+            root: project.path().to_path_buf(),
+            config: default(),
+        });
+    app.world_mut()
+        .resource_mut::<NextState<jackdaw::AppState>>()
+        .set(jackdaw::AppState::Editor);
+    app.update();
+    (app, project)
+}
+
+#[track_caller]
+fn call(app: &mut App, id: &'static str, params: &[(&'static str, PropertyValue)]) {
+    let mut call = app.world_mut().operator(id).settings(CallOperatorSettings {
+        execution_context: ExecutionContext::Invoke,
+        creates_history_entry: true,
+    });
+    for (key, value) in params {
+        call = call.param(*key, value.clone());
+    }
+    let result = call.call().expect("the operator dispatched");
+    assert_eq!(result, OperatorResult::Finished, "{id} did not finish");
+    app.update();
+}
+
+/// Author the same small locomotion graph every test here starts from.
+fn author_a_locomotion_graph(app: &mut App) {
+    call(
+        app,
+        "animation.graph.new",
+        &[("name", PropertyValue::String("locomotion".into()))],
+    );
+    call(
+        app,
+        "animation.graph.add_param",
+        &[
+            ("name", PropertyValue::String("speed".into())),
+            ("kind", PropertyValue::String("float".into())),
+        ],
+    );
+    call(
+        app,
+        "animation.graph.add_state",
+        &[
+            ("name", PropertyValue::String("idle".into())),
+            ("clip", PropertyValue::String("rig.glb#Idle".into())),
+        ],
+    );
+    call(
+        app,
+        "animation.graph.add_state",
+        &[
+            ("name", PropertyValue::String("run".into())),
+            ("clip", PropertyValue::String("rig.glb#Run".into())),
+            ("speed", PropertyValue::Float(1.5)),
+        ],
+    );
+    call(
+        app,
+        "animation.graph.add_transition",
+        &[
+            ("from", PropertyValue::String("idle".into())),
+            ("to", PropertyValue::String("run".into())),
+            ("when", PropertyValue::String("speed > 0.1".into())),
+            ("fade", PropertyValue::Float(0.2)),
+        ],
+    );
+    call(
+        app,
+        "animation.graph.set_entry",
+        &[("name", PropertyValue::String("idle".into()))],
+    );
+}
+
+/// The graph on disk, read the way the runtime loader reads it.
+fn saved_graph(app: &App, project: &tempfile::TempDir) -> AnimationGraphDef {
+    let file = project
+        .path()
+        .join("assets/animation/locomotion.animgraph.bsn");
+    let text = std::fs::read_to_string(&file).expect("the graph file was written");
+    let registry = app.world().resource::<AppTypeRegistry>().read();
+    parse_animation_graph(&text, &registry).expect("the graph file reads back")
+}
+
+#[test]
+fn a_graph_authored_through_the_operators_reads_back_off_the_disk() {
+    let (mut app, project) = editor_in_a_fresh_project();
+    author_a_locomotion_graph(&mut app);
+    call(&mut app, "animation.graph.save", &[]);
+
+    let def = saved_graph(&app, &project);
+    assert_eq!(def.entry, "idle");
+    assert_eq!(
+        def.states
+            .iter()
+            .map(|state| &state.name)
+            .collect::<Vec<_>>(),
+        vec!["idle", "run"]
+    );
+    assert_eq!(def.states[1].speed, 1.5);
+    assert!(matches!(
+        &def.states[0].motion,
+        AnimationMotion::Clip(clip) if clip.source == "rig.glb" && clip.clip == "Idle"
+    ));
+    assert_eq!(def.parameters.len(), 1);
+    assert_eq!(def.parameters[0].name, "speed");
+
+    let transition = def.transitions.first().expect("the transition was written");
+    assert_eq!(transition.from, "idle");
+    assert_eq!(transition.to, "run");
+    assert_eq!(transition.crossfade_secs, 0.2);
+    assert_eq!(transition.conditions[0].parameter, "speed");
+    assert_eq!(transition.conditions[0].op, AnimationConditionOp::Greater);
+    assert_eq!(transition.conditions[0].value, 0.1);
+}
+
+#[test]
+fn a_saved_graph_opens_again_with_a_node_for_every_state() {
+    let (mut app, _project) = editor_in_a_fresh_project();
+    author_a_locomotion_graph(&mut app);
+    call(&mut app, "animation.graph.save", &[]);
+    call(
+        &mut app,
+        "animation.graph.open",
+        &[(
+            "path",
+            PropertyValue::String("animation/locomotion.animgraph.bsn".into()),
+        )],
+    );
+
+    let states = app.world().resource::<AnimationGraphDoc>().def.states.len();
+    assert_eq!(states, 2);
+    let nodes = app
+        .world_mut()
+        .query::<&GraphNode>()
+        .iter(app.world())
+        .filter(|node| node.node_type == "anim.state")
+        .count();
+    assert_eq!(nodes, 2, "each state is drawn as a node");
+}
+
+#[test]
+fn a_state_renamed_in_the_window_carries_its_transitions_with_it() {
+    let (mut app, project) = editor_in_a_fresh_project();
+    author_a_locomotion_graph(&mut app);
+    call(
+        &mut app,
+        "animation.graph.set_state",
+        &[
+            ("name", PropertyValue::String("run".into())),
+            ("rename", PropertyValue::String("sprint".into())),
+        ],
+    );
+    call(&mut app, "animation.graph.save", &[]);
+
+    let def = saved_graph(&app, &project);
+    assert!(def.states.iter().any(|state| state.name == "sprint"));
+    assert_eq!(def.transitions[0].to, "sprint");
+}
+
+#[test]
+fn a_node_taken_off_the_canvas_takes_its_state_and_wires_with_it() {
+    let (mut app, _project) = editor_in_a_fresh_project();
+    author_a_locomotion_graph(&mut app);
+
+    let node = app
+        .world_mut()
+        .query::<(Entity, &GraphNode)>()
+        .iter(app.world())
+        .find(|(_, node)| node.node_type == "anim.state")
+        .map(|(entity, _)| entity)
+        .expect("a state is drawn on the canvas");
+    app.world_mut().entity_mut(node).despawn();
+    app.update();
+
+    let doc = app.world().resource::<AnimationGraphDoc>();
+    assert_eq!(doc.def.states.len(), 1, "the state left with its node");
+    assert!(
+        doc.def.transitions.is_empty(),
+        "a transition to a state that is gone leaves with it"
+    );
+}
+
+#[test]
+fn undoing_an_added_state_takes_its_node_off_the_canvas() {
+    let (mut app, _project) = editor_in_a_fresh_project();
+    author_a_locomotion_graph(&mut app);
+    call(&mut app, "history.undo", &[]);
+    call(&mut app, "history.undo", &[]);
+
+    let doc = app.world().resource::<AnimationGraphDoc>();
+    assert!(
+        doc.def.transitions.is_empty(),
+        "the first undo took the transition back"
+    );
+    assert_eq!(
+        doc.def
+            .states
+            .iter()
+            .map(|state| &state.name)
+            .collect::<Vec<_>>(),
+        vec!["idle"],
+        "the second undo took the state back"
+    );
+    let nodes = app
+        .world_mut()
+        .query::<&GraphNode>()
+        .iter(app.world())
+        .filter(|node| node.node_type == "anim.state")
+        .count();
+    assert_eq!(nodes, 1, "the canvas follows the definition undo restored");
+}
+
+#[test]
+fn a_parameter_written_in_the_window_reaches_the_rig_being_previewed() {
+    let (mut app, _project) = editor_in_a_fresh_project();
+    author_a_locomotion_graph(&mut app);
+
+    let rig = app
+        .world_mut()
+        .spawn((
+            Name::new("Rig"),
+            AnimationGraphRef {
+                path: "animation/locomotion.animgraph.bsn".to_string(),
+                ..default()
+            },
+        ))
+        .id();
+    app.update();
+
+    call(
+        &mut app,
+        "animation.graph.set_param",
+        &[
+            ("name", PropertyValue::String("speed".into())),
+            ("value", PropertyValue::Float(4.0)),
+        ],
+    );
+
+    let written = app
+        .world()
+        .get::<AnimationParams>(rig)
+        .expect("the preview target was written");
+    assert_eq!(written.float("speed"), 4.0);
+}

--- a/tests/stage/main.rs
+++ b/tests/stage/main.rs
@@ -7,6 +7,7 @@
 #[path = "../util/mod.rs"]
 mod util;
 
+mod animation_graph;
 mod animation_library;
 mod animation_markers;
 mod animation_timeline;


### PR DESCRIPTION
Animation graphs were a runtime asset with no editor surface: the states, transitions and parameters in an `.animgraph.bsn` file could only be written by hand. The Graph tab in the Animation window now opens a dock window that draws the open graph on the node canvas, with states as nodes and transitions as wires annotated with their conditions and crossfade time.

Editing on the canvas writes the graph definition the way scene edits write the document. Adding, connecting, moving and deleting go through one undo step each, and the file is written by `animation.graph.save`. The parameters strip lists what the graph declares as toggles, sliders and trigger buttons, and writing one lands on the rig previewing the graph, so the viewport answers at once. The state the rig is in and the crossfade still running are lit on the canvas, both while the editor previews and while the game is the one playing.

Every control dispatches an operator, so a graph can be authored from a script or the remote as well as by hand, and an `AnimationGraphRef` card now picks a graph file from the project rather than taking a typed path, with a way from an animation set to a graph of its own.

LLM disclaimer: Claude Code was used to help plan and implement this change, but all code was human reviewed by myself!
