### PR TITLE
Edit definition assets as files in the editor

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4992,6 +4992,7 @@ dependencies = [
  "path-slash",
  "pathdiff",
  "smol_str",
+ "tempfile",
  "thiserror 2.0.20",
 ]
 

--- a/crates/jackdaw_api/src/lib.rs
+++ b/crates/jackdaw_api/src/lib.rs
@@ -38,10 +38,10 @@ use jackdaw_dylib;
 // --- Extension authoring surface ---
 
 pub use jackdaw_api_internal::{
-    DefaultArea, ExtensionContext, ExtensionInputContext, ExtensionPoint, ExtensionRegistrar,
-    HierarchyWindow, InspectorWindow, JackdawExtension, MenuEntryDescriptor, PanelContext,
-    ToAnchorId as _, TopLevelMenu, WidgetDefinition, WidgetInstantiateContext, WidgetRegistry,
-    WindowDescriptor,
+    DefaultArea, DefinitionAssetType, DefinitionAssetTypes, ExtensionContext,
+    ExtensionInputContext, ExtensionPoint, ExtensionRegistrar, HierarchyWindow, InspectorWindow,
+    JackdawExtension, MenuEntryDescriptor, PanelContext, ToAnchorId as _, TopLevelMenu,
+    WidgetDefinition, WidgetInstantiateContext, WidgetRegistry, WindowDescriptor,
 };
 
 pub use jackdaw_api_internal::lifecycle::ExtensionKind;
@@ -177,10 +177,10 @@ pub mod prelude {
     pub use crate::pie::PlayState;
     pub use crate::runtime::{GameApp, GamePlugin, GameRegistered, GameRegistry, GameSystems};
     pub use crate::{
-        DefaultArea, ExtensionContext, ExtensionInputContext, ExtensionKind, ExtensionPoint,
-        ExtensionRegistrar, HierarchyWindow, InspectorWindow, JackdawExtension,
-        MenuEntryDescriptor, PanelContext, TopLevelMenu, WidgetDefinition,
-        WidgetInstantiateContext, WidgetRegistry, WindowDescriptor, operator,
+        DefaultArea, DefinitionAssetType, DefinitionAssetTypes, ExtensionContext,
+        ExtensionInputContext, ExtensionKind, ExtensionPoint, ExtensionRegistrar, HierarchyWindow,
+        InspectorWindow, JackdawExtension, MenuEntryDescriptor, PanelContext, TopLevelMenu,
+        WidgetDefinition, WidgetInstantiateContext, WidgetRegistry, WindowDescriptor, operator,
     };
 
     /// Helper [`SystemParam`](bevy::ecs::system::SystemParam) for

--- a/crates/jackdaw_api_internal/src/definition_assets.rs
+++ b/crates/jackdaw_api_internal/src/definition_assets.rs
@@ -1,0 +1,193 @@
+//! Definition asset types: reflected assets saved one value per file.
+//!
+//! A definition type claims a directory under the project's assets and a file
+//! suffix, for example an item definition at `content/items` with
+//! `.item.bsn`. The editor scans each registered directory, keeps the loaded
+//! values by name, and shows a file of that suffix in the inspector.
+
+use bevy::prelude::*;
+
+/// A reflected asset type the project stores one value per file.
+#[derive(Clone, Debug, PartialEq, Eq)]
+pub struct DefinitionAssetType {
+    /// Short identifier used by the operators and reported by the remote,
+    /// for example `item`.
+    pub kind: String,
+    /// Name shown on menus and tiles, for example `Item`.
+    pub label: String,
+    /// Reflect type path of the asset type.
+    pub type_path: String,
+    /// Directory holding the files, relative to the project's assets
+    /// directory.
+    pub directory: String,
+    /// File suffix, including the leading dot. The name is the stem before it.
+    pub suffix: String,
+    /// Whether the definition scanner loads this directory. A kind whose
+    /// files are loaded elsewhere registers with [`Self::loaded_elsewhere`]
+    /// and publishes its own entries into the registry.
+    pub scanned: bool,
+}
+
+impl DefinitionAssetType {
+    pub fn new(
+        kind: impl Into<String>,
+        label: impl Into<String>,
+        type_path: impl Into<String>,
+        directory: impl Into<String>,
+        suffix: impl Into<String>,
+    ) -> Self {
+        Self {
+            kind: kind.into(),
+            label: label.into(),
+            type_path: type_path.into(),
+            directory: directory.into(),
+            suffix: suffix.into(),
+            scanned: true,
+        }
+    }
+
+    /// Leave loading to whoever already owns this directory.
+    pub fn loaded_elsewhere(mut self) -> Self {
+        self.scanned = false;
+        self
+    }
+
+    /// The name a file path denotes, or `None` when the path is not a file of
+    /// this kind.
+    pub fn name_of_file(&self, path: &std::path::Path) -> Option<String> {
+        path.file_name()
+            .and_then(|name| name.to_str())
+            .and_then(|name| name.strip_suffix(&self.suffix))
+            .filter(|stem| !stem.is_empty())
+            .map(str::to_owned)
+    }
+
+    /// The file name a definition of this name saves to.
+    pub fn file_name(&self, name: &str) -> String {
+        format!("{name}{}", self.suffix)
+    }
+}
+
+/// Every definition asset type registered with the editor.
+#[derive(Resource, Default)]
+pub struct DefinitionAssetTypes {
+    types: Vec<DefinitionAssetType>,
+}
+
+impl DefinitionAssetTypes {
+    /// Register a type, replacing an earlier registration of the same kind.
+    pub fn register(&mut self, definition: DefinitionAssetType) {
+        self.types.retain(|known| known.kind != definition.kind);
+        self.types.push(definition);
+    }
+
+    pub fn unregister(&mut self, kind: &str) {
+        self.types.retain(|known| known.kind != kind);
+    }
+
+    pub fn by_kind(&self, kind: &str) -> Option<&DefinitionAssetType> {
+        self.types.iter().find(|known| known.kind == kind)
+    }
+
+    pub fn by_type_path(&self, type_path: &str) -> Option<&DefinitionAssetType> {
+        self.types.iter().find(|known| known.type_path == type_path)
+    }
+
+    /// The type whose suffix this file name ends with, longest suffix first so
+    /// `.item.bsn` wins over a plain `.bsn`.
+    pub fn for_file(&self, path: &std::path::Path) -> Option<&DefinitionAssetType> {
+        let name = path.file_name()?.to_str()?;
+        self.types
+            .iter()
+            .filter(|known| name.ends_with(&known.suffix) && name.len() > known.suffix.len())
+            .max_by_key(|known| known.suffix.len())
+    }
+
+    pub fn iter(&self) -> impl Iterator<Item = &DefinitionAssetType> {
+        self.types.iter()
+    }
+}
+
+/// Marks an entity as tracking a definition asset type registered by an
+/// extension. An observer unregisters the kind when the marker despawns.
+#[derive(Component, Clone, Debug)]
+pub struct RegisteredDefinitionAsset {
+    pub(crate) kind: String,
+}
+
+pub(crate) fn cleanup_definition_asset_on_remove(
+    trigger: On<Remove, RegisteredDefinitionAsset>,
+    registrations: Query<&RegisteredDefinitionAsset>,
+    mut types: ResMut<DefinitionAssetTypes>,
+) {
+    if let Ok(registration) = registrations.get(trigger.event_target()) {
+        types.unregister(&registration.kind);
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use std::path::Path;
+
+    #[test]
+    fn a_file_belongs_to_the_type_with_the_longest_matching_suffix() {
+        let mut types = DefinitionAssetTypes::default();
+        types.register(DefinitionAssetType::new(
+            "scene", "Scene", "Scene", "scenes", ".bsn",
+        ));
+        types.register(DefinitionAssetType::new(
+            "item",
+            "Item",
+            "content::ItemDef",
+            "content/items",
+            ".item.bsn",
+        ));
+
+        let matched = types
+            .for_file(Path::new("/p/assets/content/items/torch.item.bsn"))
+            .expect("a registered type claims the file");
+        assert_eq!(matched.kind, "item");
+        assert_eq!(
+            matched
+                .name_of_file(Path::new("/p/assets/content/items/torch.item.bsn"))
+                .as_deref(),
+            Some("torch")
+        );
+    }
+
+    #[test]
+    fn a_bare_suffix_is_not_a_definition_file() {
+        let mut types = DefinitionAssetTypes::default();
+        types.register(DefinitionAssetType::new(
+            "item",
+            "Item",
+            "content::ItemDef",
+            "content/items",
+            ".item.bsn",
+        ));
+        assert!(types.for_file(Path::new("/p/assets/.item.bsn")).is_none());
+        assert!(types.for_file(Path::new("/p/assets/level.bsn")).is_none());
+    }
+
+    #[test]
+    fn registering_a_kind_again_replaces_the_earlier_registration() {
+        let mut types = DefinitionAssetTypes::default();
+        types.register(DefinitionAssetType::new(
+            "item",
+            "Item",
+            "content::ItemDef",
+            "items",
+            ".item.bsn",
+        ));
+        types.register(DefinitionAssetType::new(
+            "item",
+            "Item",
+            "content::ItemDef",
+            "content/items",
+            ".item.bsn",
+        ));
+        assert_eq!(types.iter().count(), 1);
+        assert_eq!(types.by_kind("item").unwrap().directory, "content/items");
+    }
+}

--- a/crates/jackdaw_api_internal/src/lib.rs
+++ b/crates/jackdaw_api_internal/src/lib.rs
@@ -32,6 +32,7 @@
 //! }
 //! ```
 
+pub mod definition_assets;
 pub mod entity_icons;
 pub mod extensions_config;
 pub mod inspector;
@@ -61,6 +62,7 @@ use operator::{CallOperatorSettings, Operator};
 use registries::WindowExtensionRegistry;
 use snapshot::{ActiveSnapshotter, SceneSnapshot};
 
+pub use definition_assets::{DefinitionAssetType, DefinitionAssetTypes};
 pub use entity_icons::EntityIconRegistry;
 pub use jackdaw_api_macros as macros;
 pub use jackdaw_api_macros::operator;
@@ -95,6 +97,7 @@ pub mod prelude {
     pub use crate::{
         ExtensionContext, ExtensionPoint, ExtensionRegistrar, JackdawExtension,
         MenuEntryDescriptor, PanelContext, WindowDescriptor,
+        definition_assets::{DefinitionAssetType, DefinitionAssetTypes},
         lifecycle::{
             ActiveModalQuery, Extension, ExtensionAppExt as _, ExtensionCatalog, ExtensionKind,
             RegisteredMenuEntry, RegisteredWindow,
@@ -263,6 +266,21 @@ impl<'a> ExtensionContext<'a> {
         self.world.spawn((
             lifecycle::RegisteredWidgetDefinition { id, registration },
             ChildOf(self.extension_entity),
+        ));
+        self
+    }
+
+    /// Register a definition asset type, a reflected asset the project keeps
+    /// one value per file. The registration goes when the extension unloads.
+    pub fn register_definition_asset(&mut self, definition: DefinitionAssetType) -> &mut Self {
+        let ext = self.extension_entity;
+        let kind = definition.kind.clone();
+        self.world
+            .resource_mut::<DefinitionAssetTypes>()
+            .register(definition);
+        self.world.spawn((
+            crate::definition_assets::RegisteredDefinitionAsset { kind },
+            ChildOf(ext),
         ));
         self
     }

--- a/crates/jackdaw_api_internal/src/registries.rs
+++ b/crates/jackdaw_api_internal/src/registries.rs
@@ -1,7 +1,7 @@
 //! Panel-extension registry. Operators now live as entities (see
 //! [`crate::lifecycle::OperatorEntity`]) and keybinds go through BEI, so
 //! this file is much smaller than in v1; only the panel-extension mapping
-//! remains.
+//! remains, alongside the host registries an extension writes into.
 
 use std::{borrow::Cow, collections::HashMap};
 
@@ -11,7 +11,9 @@ use jackdaw_panels::WindowRegistry;
 pub(super) fn plugin(app: &mut App) {
     app.init_resource::<WindowExtensionRegistry>()
         .init_resource::<WindowRegistry>()
-        .init_resource::<crate::widgets::WidgetRegistry>();
+        .init_resource::<crate::widgets::WidgetRegistry>()
+        .init_resource::<crate::definition_assets::DefinitionAssetTypes>()
+        .add_observer(crate::definition_assets::cleanup_definition_asset_on_remove);
 }
 
 #[derive(Resource, Default)]

--- a/crates/jackdaw_bsn/Cargo.toml
+++ b/crates/jackdaw_bsn/Cargo.toml
@@ -27,6 +27,8 @@ smol_str = "0.2"
 # The round-trip test needs a real vocabulary of its own, not a synthetic
 # stand-in: `Bindings` is the list-of-enums shape the read path is weakest on.
 jackdaw_bind.workspace = true
+# A definition type's files are round-tripped through a real directory.
+tempfile = "3"
 
 [build-dependencies]
 lalrpop = "0.23"

--- a/crates/jackdaw_bsn/src/catalog.rs
+++ b/crates/jackdaw_bsn/src/catalog.rs
@@ -552,6 +552,60 @@ mod tests {
         );
     }
 
+    /// One asset per file, named by its file stem, into a fresh world.
+    #[test]
+    fn a_directory_of_named_assets_round_trips_one_file_at_a_time() {
+        let dir = tempfile::tempdir().expect("tempdir");
+        let mut world = scalar_world();
+
+        let written = [("Shiny", 1.0, 0.05), ("Rough", 0.0, 0.9)];
+        for (name, metallic, roughness) in written {
+            let handle = world
+                .resource_mut::<Assets<TestMaterial>>()
+                .add(TestMaterial {
+                    metallic,
+                    roughness,
+                });
+            let text = serialize_assets_to_bsn(
+                &world,
+                &[CatalogAssetRef {
+                    name: name.to_string(),
+                    type_id: TypeId::of::<TestMaterial>(),
+                    asset_id: handle.id().untyped(),
+                }],
+            );
+            std::fs::write(dir.path().join(format!("{name}.material.bsn")), text)
+                .expect("the file is written");
+        }
+
+        let mut fresh = scalar_world();
+        let mut loaded: Vec<(String, f32)> = Vec::new();
+        let mut files: Vec<std::path::PathBuf> = std::fs::read_dir(dir.path())
+            .expect("the directory is there")
+            .flatten()
+            .map(|entry| entry.path())
+            .collect();
+        files.sort();
+        for path in files {
+            let stem = path
+                .file_name()
+                .and_then(|name| name.to_str())
+                .and_then(|name| name.strip_suffix(".material.bsn"))
+                .expect("a file of this suffix")
+                .to_string();
+            let text = std::fs::read_to_string(&path).expect("the file reads");
+            let entries = load_bsn_assets(&mut fresh, &text).expect("load should succeed");
+            assert_eq!(entries.len(), 1, "a definition file holds one asset");
+            assert_eq!(entries[0].name, stem, "the entry is named after its file");
+            loaded.push((stem, get_material(&fresh, &entries[0].handle).roughness));
+        }
+
+        assert_eq!(
+            loaded,
+            vec![("Rough".to_string(), 0.9), ("Shiny".to_string(), 0.05)]
+        );
+    }
+
     #[test]
     fn round_trips_scalar_catalog_by_name_and_value() {
         let mut world = scalar_world();

--- a/crates/jackdaw_extension/src/lib.rs
+++ b/crates/jackdaw_extension/src/lib.rs
@@ -3,9 +3,10 @@
 //! Game runtime and editor-host plumbing are intentionally excluded.
 
 pub use jackdaw_api::{
-    ExtensionInputContext, ExtensionKind, ExtensionPoint, ExtensionRegistrar, JackdawExtension,
-    MenuEntryDescriptor, PanelContext, TopLevelMenu, WidgetDefinition, WidgetInstantiateContext,
-    WidgetRegistry, WindowDescriptor, keymap, op, scene, ui,
+    DefinitionAssetType, DefinitionAssetTypes, ExtensionInputContext, ExtensionKind,
+    ExtensionPoint, ExtensionRegistrar, JackdawExtension, MenuEntryDescriptor, PanelContext,
+    TopLevelMenu, WidgetDefinition, WidgetInstantiateContext, WidgetRegistry, WindowDescriptor,
+    keymap, op, scene, ui,
 };
 pub use jackdaw_api_macros::extension_operator as operator;
 
@@ -18,12 +19,12 @@ pub mod prelude {
     pub use jackdaw_api::keymap::{PresetInput, PresetPhase};
     pub use jackdaw_api::op::{OperatorCommandsExt as _, OperatorWorldExt as _};
     pub use jackdaw_api::prelude::{
-        ButtonProps, CallOperatorError, CallOperatorSettings, ExecutionContext,
-        ExtensionInputContext, ExtensionKind, ExtensionPoint, ExtensionRegistrar, Icon,
-        JackdawExtension, MenuEntryDescriptor, Operator, OperatorParameters, OperatorResult,
-        OperatorSignature, OperatorSystemId, PanelContext, ParamSpec, RefreshOperatorButtons,
-        TopLevelMenu, WidgetDefinition, WidgetInstantiateContext, WidgetRegistry, WindowDescriptor,
-        button,
+        ButtonProps, CallOperatorError, CallOperatorSettings, DefinitionAssetType,
+        DefinitionAssetTypes, ExecutionContext, ExtensionInputContext, ExtensionKind,
+        ExtensionPoint, ExtensionRegistrar, Icon, JackdawExtension, MenuEntryDescriptor, Operator,
+        OperatorParameters, OperatorResult, OperatorSignature, OperatorSystemId, PanelContext,
+        ParamSpec, RefreshOperatorButtons, TopLevelMenu, WidgetDefinition,
+        WidgetInstantiateContext, WidgetRegistry, WindowDescriptor, button,
     };
     pub use jackdaw_api::ui::ButtonPropsOpExt as _;
     pub use jackdaw_api_macros::extension_operator as operator;

--- a/src/asset_browser.rs
+++ b/src/asset_browser.rs
@@ -263,12 +263,28 @@ fn spawn_asset_drag_ghost(
         .id()
 }
 
+/// Context-menu action prefix for creating a definition of a registered kind;
+/// the kind follows it.
+const NEW_DEFINITION_ACTION: &str = "asset_browser.new.";
+
 fn on_asset_browser_context_action(
     event: On<jackdaw_widgets::context_menu::ContextMenuAction>,
     mut commands: Commands,
     state: Res<AssetBrowserState>,
     mut menu_state: ResMut<jackdaw_widgets::context_menu::ContextMenuState>,
 ) {
+    if let Some(kind) = event.action.strip_prefix(NEW_DEFINITION_ACTION) {
+        commands
+            .operator(crate::definition_assets::AssetNewOp::ID)
+            .param("type", kind.to_string())
+            .call();
+        if let Some(menu) = menu_state.menu_entity.take()
+            && let Ok(mut ec) = commands.get_entity(menu)
+        {
+            ec.despawn();
+        }
+        return;
+    }
     if event.action != "asset_browser.delete" {
         return;
     }
@@ -528,6 +544,7 @@ fn setup_initial_directory(
 fn refresh_browser_on_change(
     mut state: ResMut<AssetBrowserState>,
     mut commands: Commands,
+    definition_types: Res<jackdaw_api::prelude::DefinitionAssetTypes>,
     icon_font: Res<IconFont>,
     asset_server: Res<AssetServer>,
     content_query: Query<(Entity, Option<&Children>), With<AssetBrowserContent>>,
@@ -805,7 +822,10 @@ fn refresh_browser_on_change(
                 file_name: entry.file_name.clone(),
             };
 
-            let icon_override = if entry.is_prefab {
+            let definition = definition_types.for_file(&entry.path);
+            let icon_override = if definition.is_some() {
+                Some(icons::Icon::FileBox)
+            } else if entry.is_prefab {
                 Some(icons::Icon::Package)
             } else {
                 None
@@ -843,6 +863,12 @@ fn refresh_browser_on_change(
             // that container before these flush, which would orphan every
             // row under a dead parent.
             jackdaw_feathers::utils::attach_or_despawn(&mut commands, content_entity, item_entity);
+
+            if let Some(definition) = definition {
+                commands
+                    .entity(item_entity)
+                    .insert((Hovered::default(), Tooltip::title(definition.label.clone())));
+            }
 
             // Apply selected highlight if this item is the selected file
             let is_selected =
@@ -894,6 +920,8 @@ fn refresh_browser_on_change(
                       mut commands: Commands,
                       mut state: ResMut<AssetBrowserState>,
                       windows: Query<&Window>,
+                      definition_types: Res<jackdaw_api::prelude::DefinitionAssetTypes>,
+                      project: Option<Res<crate::project::ProjectRoot>>,
                       mut menu_state: ResMut<jackdaw_widgets::context_menu::ContextMenuState>| {
                     if click.event().button != PointerButton::Secondary {
                         return;
@@ -911,11 +939,30 @@ fn refresh_browser_on_change(
                     {
                         ec.despawn();
                     }
+                    let mut items: Vec<(String, String)> = Vec::new();
+                    if let Some(project) = project.as_deref() {
+                        for definition in definition_types.iter() {
+                            if definition.scanned
+                                && crate::definition_assets::definition_dir(project, definition)
+                                    == rmb_path
+                            {
+                                items.push((
+                                    format!("{NEW_DEFINITION_ACTION}{}", definition.kind),
+                                    format!("New {}", definition.label),
+                                ));
+                            }
+                        }
+                    }
+                    items.push(("asset_browser.delete".to_string(), "Delete".to_string()));
+                    let entries: Vec<(&str, &str)> = items
+                        .iter()
+                        .map(|(action, label)| (action.as_str(), label.as_str()))
+                        .collect();
                     let menu = jackdaw_feathers::context_menu::spawn_context_menu(
                         &mut commands,
                         cursor_pos,
                         None,
-                        &[("asset_browser.delete", "Delete")],
+                        &entries,
                     );
                     menu_state.menu_entity = Some(menu);
                 },
@@ -1160,12 +1207,21 @@ fn remove_incompatible_image_nodes(
 fn handle_file_double_click(
     event: On<FileItemDoubleClicked>,
     mut state: ResMut<AssetBrowserState>,
+    definition_types: Res<jackdaw_api::prelude::DefinitionAssetTypes>,
     mut commands: Commands,
 ) {
     if event.is_directory {
         state.current_directory = PathBuf::from(&event.path);
         state.selected_file = None; // Clear selection when navigating
         state.needs_refresh = true;
+        return;
+    }
+
+    if definition_types.for_file(Path::new(&event.path)).is_some() {
+        commands
+            .operator(crate::definition_assets::AssetOpenOp::ID)
+            .param("path", event.path.clone())
+            .call();
         return;
     }
 

--- a/src/commands.rs
+++ b/src/commands.rs
@@ -157,6 +157,9 @@ pub(crate) fn field_edit_preview(
     field_path: &str,
     value: &serde_json::Value,
 ) {
+    if crate::definition_assets::preview_definition_field(world, type_path, field_path, value) {
+        return;
+    }
     field_edit_begin(world, type_path, field_path);
     let targets = field_edit_session_targets(world);
     for target in targets {
@@ -176,6 +179,9 @@ pub(crate) fn field_edit_commit(
     new_json: &serde_json::Value,
     group_label: &str,
 ) {
+    if crate::definition_assets::commit_definition_field(world, type_path, field_path, new_json) {
+        return;
+    }
     // Immediate commits (no prior preview) still need a derived baseline.
     field_edit_begin(world, type_path, field_path);
     let mut targets = field_edit_session_targets(world);

--- a/src/core_extension.rs
+++ b/src/core_extension.rs
@@ -257,6 +257,7 @@ impl JackdawExtension for JackdawCoreExtension {
         crate::hierarchy::add_to_extension(ctx);
         crate::file_ops::add_to_extension(ctx);
         crate::material_assets::add_to_extension(ctx);
+        crate::definition_assets::add_to_extension(ctx);
         crate::viewport_select::add_to_extension(ctx);
         crate::clip_ops::add_to_extension(ctx);
         crate::brush_element_ops::add_to_extension(ctx);

--- a/src/definition_assets.rs
+++ b/src/definition_assets.rs
@@ -1,0 +1,1441 @@
+//! Definition assets: one reflected asset value per file, under the directory
+//! and suffix its type registered.
+//!
+//! A registered type (`assets/content/items` with `.item.bsn`, say) is scanned
+//! at project open and watched while the editor runs. Loading goes through
+//! [`jackdaw_bsn::load_bsn_assets`] and saving through
+//! [`jackdaw_bsn::serialize_assets_to_bsn`], so a file holds only what the
+//! asset changes from its default.
+//!
+//! Opening a definition puts it in the inspector: the open definition rides on
+//! an editor entity carrying [`DefinitionAssetEdit`], the reflected field rows
+//! read the asset behind its handle instead of a component, and their edits
+//! come back here as [`SetDefinitionField`] undo entries.
+
+use std::path::{Path, PathBuf};
+use std::sync::{Mutex, mpsc};
+
+use bevy::asset::{ReflectAsset, UntypedHandle};
+use bevy::prelude::*;
+use bevy::reflect::{GetPath, ReflectRef, prelude::ReflectDefault};
+use jackdaw_api::prelude::{DefinitionAssetType, DefinitionAssetTypes};
+use jackdaw_api_internal::operator::report_to_caller;
+use jackdaw_bsn::CatalogAssetRef;
+use jackdaw_commands::CommandHistory;
+
+use crate::EditorEntity;
+use crate::commands::EditorCommand;
+use crate::prelude::*;
+use crate::project::ProjectRoot;
+
+/// A definition loaded from a file, by the name its file stem gives it.
+pub struct DefinitionEntry {
+    pub kind: String,
+    pub name: String,
+    pub handle: UntypedHandle,
+    pub path: PathBuf,
+}
+
+/// Every loaded definition, across all registered types.
+#[derive(Resource, Default)]
+pub struct DefinitionRegistry {
+    pub entries: Vec<DefinitionEntry>,
+}
+
+impl DefinitionRegistry {
+    pub fn get(&self, kind: &str, name: &str) -> Option<&DefinitionEntry> {
+        self.entries
+            .iter()
+            .find(|entry| entry.kind == kind && entry.name == name)
+    }
+
+    pub fn names_of(&self, kind: &str) -> Vec<String> {
+        let mut names: Vec<String> = self
+            .entries
+            .iter()
+            .filter(|entry| entry.kind == kind)
+            .map(|entry| entry.name.clone())
+            .collect();
+        names.sort();
+        names
+    }
+
+    /// Record a loaded definition, replacing any entry of the same kind and
+    /// name.
+    pub fn insert(&mut self, entry: DefinitionEntry) {
+        self.entries
+            .retain(|known| known.kind != entry.kind || known.name != entry.name);
+        self.entries.push(entry);
+    }
+
+    pub fn remove(&mut self, kind: &str, name: &str) {
+        self.entries
+            .retain(|known| known.kind != kind || known.name != name);
+    }
+}
+
+/// The first `<Label>_N` name of this kind with neither an entry nor a file.
+fn next_free_name(world: &World, definition: &DefinitionAssetType) -> String {
+    let registry = world.resource::<DefinitionRegistry>();
+    let project = world.get_resource::<ProjectRoot>();
+    let mut index = 1u32;
+    loop {
+        let candidate = sanitize_definition_name(&format!("{}_{index}", definition.label));
+        let taken = registry.get(&definition.kind, &candidate).is_some()
+            || project
+                .is_some_and(|project| definition_path(project, definition, &candidate).exists());
+        if !taken {
+            return candidate;
+        }
+        index += 1;
+    }
+}
+
+/// The definition open in the inspector, on its own editor entity.
+#[derive(Component)]
+#[require(EditorEntity)]
+pub struct DefinitionAssetEdit {
+    pub kind: String,
+    pub name: String,
+    pub type_path: String,
+    pub handle: UntypedHandle,
+    pub path: PathBuf,
+    /// Whether the definition has been edited since it was loaded or saved.
+    pub dirty: bool,
+}
+
+/// The entity carrying the open definition, if one is open.
+#[derive(Resource, Default)]
+pub struct OpenDefinition(pub Option<Entity>);
+
+/// Strip what cannot appear in a file stem, so a definition name always maps
+/// to exactly one file.
+pub fn sanitize_definition_name(name: &str) -> String {
+    let cleaned: String = name
+        .trim()
+        .chars()
+        .map(|c| {
+            if c.is_ascii_alphanumeric() || matches!(c, '_' | '-' | '.') {
+                c
+            } else {
+                '_'
+            }
+        })
+        .collect();
+    if cleaned.is_empty() {
+        "definition".to_string()
+    } else {
+        cleaned
+    }
+}
+
+pub fn definition_dir(project: &ProjectRoot, definition: &DefinitionAssetType) -> PathBuf {
+    project.assets_dir().join(&definition.directory)
+}
+
+pub fn definition_path(
+    project: &ProjectRoot,
+    definition: &DefinitionAssetType,
+    name: &str,
+) -> PathBuf {
+    definition_dir(project, definition).join(definition.file_name(&sanitize_definition_name(name)))
+}
+
+/// Every file of this kind as `(name, path)`, sorted by path so scan order is
+/// stable.
+pub fn definition_files(world: &World, definition: &DefinitionAssetType) -> Vec<(String, PathBuf)> {
+    let Some(project) = world.get_resource::<ProjectRoot>() else {
+        return Vec::new();
+    };
+    let Ok(read_dir) = std::fs::read_dir(definition_dir(project, definition)) else {
+        return Vec::new();
+    };
+    let mut files: Vec<(String, PathBuf)> = read_dir
+        .flatten()
+        .map(|entry| entry.path())
+        .filter_map(|path| Some((definition.name_of_file(&path)?, path)))
+        .collect();
+    files.sort_by(|a, b| a.1.cmp(&b.1));
+    files
+}
+
+/// Load one file into its `Assets<T>` store. A file that cannot be read or
+/// parsed, or that holds a value of another type, is reported and skipped.
+pub fn load_definition_file(
+    world: &mut World,
+    definition: &DefinitionAssetType,
+    path: &Path,
+) -> Option<UntypedHandle> {
+    let text = match std::fs::read_to_string(path) {
+        Ok(text) => text,
+        Err(err) => {
+            warn!("Failed to read {}: {err}", path.display());
+            return None;
+        }
+    };
+    let type_id = registered_type_id(world, &definition.type_path)?;
+    let entries = match jackdaw_bsn::load_bsn_assets(world, &text) {
+        Ok(entries) => entries,
+        Err(err) => {
+            warn!("Failed to parse {}: {err}", path.display());
+            return None;
+        }
+    };
+    let entry = entries.into_iter().next()?;
+    if entry.handle.type_id() != type_id {
+        warn!(
+            "{} does not hold a {}",
+            path.display(),
+            definition.type_path
+        );
+        return None;
+    }
+    Some(entry.handle)
+}
+
+/// Write one definition to the file its name gives it.
+pub fn write_definition_file(
+    world: &World,
+    definition: &DefinitionAssetType,
+    name: &str,
+    handle: &UntypedHandle,
+) -> std::io::Result<PathBuf> {
+    let project = world
+        .get_resource::<ProjectRoot>()
+        .ok_or_else(|| std::io::Error::other("no project root"))?;
+    let path = definition_path(project, definition, name);
+    write_definition_at(world, name, handle, &path)
+}
+
+/// Write one definition to a named file, which is where it was opened from
+/// rather than where its name would put it. An identical rewrite is skipped so
+/// the asset watcher does not reload behind an unchanged save.
+fn write_definition_at(
+    world: &World,
+    name: &str,
+    handle: &UntypedHandle,
+    path: &Path,
+) -> std::io::Result<PathBuf> {
+    let text = jackdaw_bsn::serialize_assets_to_bsn(
+        world,
+        &[CatalogAssetRef {
+            name: sanitize_definition_name(name),
+            type_id: handle.type_id(),
+            asset_id: handle.id(),
+        }],
+    );
+    if text.trim().is_empty() {
+        return Err(std::io::Error::other(format!(
+            "nothing to write for '{name}'"
+        )));
+    }
+    if std::fs::read_to_string(path).is_ok_and(|existing| existing == text) {
+        return Ok(path.to_path_buf());
+    }
+    if let Some(parent) = path.parent() {
+        std::fs::create_dir_all(parent)?;
+    }
+    crate::scene_io::save::write_atomic(path, text.as_bytes())?;
+    Ok(path.to_path_buf())
+}
+
+/// Add a default value of the type to its `Assets<T>` store.
+pub fn default_definition_value(
+    world: &mut World,
+    definition: &DefinitionAssetType,
+) -> Option<UntypedHandle> {
+    let registry = world.resource::<AppTypeRegistry>().clone();
+    let registry = registry.read();
+    let registration = registry.get_with_type_path(&definition.type_path)?;
+    let reflect_asset = registration.data::<ReflectAsset>()?;
+    let value = registration.data::<ReflectDefault>()?.default();
+    Some(reflect_asset.add(world, value.as_partial_reflect()))
+}
+
+fn registered_type_id(world: &World, type_path: &str) -> Option<std::any::TypeId> {
+    let registry = world.resource::<AppTypeRegistry>().read();
+    Some(registry.get_with_type_path(type_path)?.type_id())
+}
+
+fn registered_types(world: &World) -> Vec<DefinitionAssetType> {
+    world
+        .get_resource::<DefinitionAssetTypes>()
+        .map(|types| types.iter().cloned().collect())
+        .unwrap_or_default()
+}
+
+/// What a rescan of the registered directories found.
+#[derive(Default, Debug, PartialEq, Eq)]
+pub struct DefinitionRescan {
+    /// `(kind, name)` of files that appeared since the last scan.
+    pub added: Vec<(String, String)>,
+    /// `(kind, name)` of entries whose file has gone.
+    pub removed: Vec<(String, String)>,
+}
+
+/// Scan every registered directory: files that appeared are loaded, entries
+/// whose file has gone are dropped.
+///
+/// A file changed in place is not reloaded, and a definition open in the
+/// inspector keeps its value when its file disappears: the loaded value is
+/// what the editor is editing, and its Save writes the file again.
+pub fn rescan_definitions(world: &mut World) -> DefinitionRescan {
+    let mut scan = DefinitionRescan::default();
+    for definition in registered_types(world) {
+        if !definition.scanned {
+            continue;
+        }
+        let files = definition_files(world, &definition);
+        let known = world
+            .resource::<DefinitionRegistry>()
+            .names_of(&definition.kind);
+
+        for gone in known
+            .iter()
+            .filter(|name| !files.iter().any(|(found, _)| found == *name))
+        {
+            world
+                .resource_mut::<DefinitionRegistry>()
+                .remove(&definition.kind, gone);
+            scan.removed.push((definition.kind.clone(), gone.clone()));
+        }
+
+        for (name, path) in files {
+            if known.contains(&name) {
+                continue;
+            }
+            let Some(handle) = load_definition_file(world, &definition, &path) else {
+                continue;
+            };
+            world
+                .resource_mut::<DefinitionRegistry>()
+                .insert(DefinitionEntry {
+                    kind: definition.kind.clone(),
+                    name: name.clone(),
+                    handle,
+                    path,
+                });
+            scan.added.push((definition.kind.clone(), name));
+        }
+    }
+    scan
+}
+
+// -- Reading and writing a definition's fields ------------------------------
+
+/// The asset a definition-editing entity stands for, reflected out of its
+/// store. `None` when the entity is not editing a definition of `type_path`.
+pub fn definition_value<'w>(
+    world: &'w World,
+    entity: Entity,
+    type_path: &str,
+    registry: &bevy::reflect::TypeRegistry,
+) -> Option<&'w dyn Reflect> {
+    let edit = world.get::<DefinitionAssetEdit>(entity)?;
+    if edit.type_path != type_path {
+        return None;
+    }
+    let reflect_asset = registry
+        .get_with_type_path(type_path)?
+        .data::<ReflectAsset>()?;
+    reflect_asset.get(world, edit.handle.id())
+}
+
+/// Whether this entity is editing a definition of `type_path`.
+fn edits_definition(world: &World, entity: Entity, type_path: &str) -> bool {
+    world
+        .get::<DefinitionAssetEdit>(entity)
+        .is_some_and(|edit| edit.type_path == type_path)
+}
+
+/// The open definition's entity, while the inspector is showing it and it is
+/// editing `type_path`. Selecting a scene entity again hands the same type's
+/// edits back to the scene.
+fn open_edit_of(world: &World, type_path: &str) -> Option<Entity> {
+    let entity = world.get_resource::<OpenDefinition>()?.0?;
+    let shown = world
+        .get_resource::<crate::selection::Selection>()
+        .is_some_and(|selection| selection.primary() == Some(entity));
+    (shown && edits_definition(world, entity, type_path)).then_some(entity)
+}
+
+/// The baseline a drag started from, so the undo entry a drag commits restores
+/// what the field held before the first tick rather than after the last one.
+#[derive(Resource, Default)]
+struct DefinitionEditSession {
+    field: Option<(String, String)>,
+    baseline: Option<serde_json::Value>,
+}
+
+fn field_as_json(
+    world: &World,
+    entity: Entity,
+    type_path: &str,
+    field_path: &str,
+) -> Option<serde_json::Value> {
+    let registry = world.resource::<AppTypeRegistry>().read();
+    let value = definition_value(world, entity, type_path, &registry)?;
+    let field = if field_path.is_empty() {
+        value.as_partial_reflect()
+    } else {
+        value.reflect_path(field_path).ok()?
+    };
+    crate::inspector::reflect_fields::reflect_to_json(field, &registry)
+}
+
+/// Write one field of the asset behind `handle`, and mark whatever definition
+/// is editing it as having unsaved changes.
+fn write_field(
+    world: &mut World,
+    handle: &UntypedHandle,
+    type_path: &str,
+    field_path: &str,
+    json: &serde_json::Value,
+) -> bool {
+    let registry = world.resource::<AppTypeRegistry>().clone();
+    let registry = registry.read();
+    let Some(reflect_asset) = registry
+        .get_with_type_path(type_path)
+        .and_then(|registration| registration.data::<ReflectAsset>())
+    else {
+        return false;
+    };
+    let Some(value) = reflect_asset.get_mut(world, handle.id()) else {
+        return false;
+    };
+    let written = if field_path.is_empty() {
+        crate::commands::apply_json_to_reflect(value.as_partial_reflect_mut(), json, &registry);
+        true
+    } else if let Ok(field) = value.reflect_path_mut(field_path) {
+        crate::commands::apply_json_to_reflect(field, json, &registry);
+        true
+    } else {
+        false
+    };
+    drop(registry);
+    if written {
+        mark_dirty(world, handle);
+    }
+    written
+}
+
+/// The entity editing the asset behind `handle`, if one is open.
+fn edit_of_handle(world: &mut World, handle: &UntypedHandle) -> Option<Entity> {
+    let mut edits = world.query::<(Entity, &DefinitionAssetEdit)>();
+    edits
+        .iter(world)
+        .find(|(_, edit)| edit.handle == *handle)
+        .map(|(entity, _)| entity)
+}
+
+fn mark_dirty(world: &mut World, handle: &UntypedHandle) {
+    let Some(entity) = edit_of_handle(world, handle) else {
+        return;
+    };
+    if let Some(mut edit) = world.get_mut::<DefinitionAssetEdit>(entity) {
+        edit.dirty = true;
+    }
+}
+
+/// Set one field of a definition, as one undo entry.
+///
+/// Keyed by handle rather than by the entity the definition was open on, so
+/// undo still reaches the asset after the card has been closed and reopened.
+pub struct SetDefinitionField {
+    pub handle: UntypedHandle,
+    pub type_path: String,
+    pub field_path: String,
+    pub old_json: serde_json::Value,
+    pub new_json: serde_json::Value,
+    /// Whether applying this edit changes which rows the inspector shows, as
+    /// an enum variant or a list length does.
+    pub rebuilds_rows: bool,
+}
+
+impl SetDefinitionField {
+    fn apply(&self, world: &mut World, json: &serde_json::Value) {
+        if !write_field(world, &self.handle, &self.type_path, &self.field_path, json) {
+            return;
+        }
+        let open = edit_of_handle(world, &self.handle);
+        if self.rebuilds_rows
+            && let Some(open) = open
+            && let Some(mut pending) =
+                world.get_resource_mut::<crate::inspector::PendingInspectorRebuild>()
+        {
+            pending.0 = Some(open);
+        }
+    }
+}
+
+impl EditorCommand for SetDefinitionField {
+    fn execute(&mut self, world: &mut World) {
+        let json = self.new_json.clone();
+        self.apply(world, &json);
+    }
+
+    fn undo(&mut self, world: &mut World) {
+        let json = self.old_json.clone();
+        self.apply(world, &json);
+    }
+
+    fn description(&self) -> &str {
+        "Set definition field"
+    }
+}
+
+/// Commit a field edit to the open definition, pushing one undo entry.
+///
+/// Returns whether the edit belonged to a definition; a caller whose edit is
+/// refused here writes to the selection as usual.
+pub(crate) fn commit_definition_field(
+    world: &mut World,
+    type_path: &str,
+    field_path: &str,
+    new_json: &serde_json::Value,
+) -> bool {
+    let Some(entity) = open_edit_of(world, type_path) else {
+        return false;
+    };
+    let Some(handle) = world
+        .get::<DefinitionAssetEdit>(entity)
+        .map(|edit| edit.handle.clone())
+    else {
+        return false;
+    };
+    let Some(current) = field_as_json(world, entity, type_path, field_path) else {
+        return false;
+    };
+    let old_json = take_baseline(world, type_path, field_path).unwrap_or(current);
+    let rebuilds_rows = field_rebuilds_rows(world, entity, type_path, field_path);
+    let mut command: Box<dyn EditorCommand> = Box::new(SetDefinitionField {
+        handle,
+        type_path: type_path.to_string(),
+        field_path: field_path.to_string(),
+        old_json,
+        new_json: new_json.clone(),
+        rebuilds_rows,
+    });
+    command.execute(world);
+    world
+        .resource_mut::<CommandHistory>()
+        .push_executed(command);
+    true
+}
+
+/// Write a field of the open definition without an undo entry, for the ticks
+/// of a drag.
+pub(crate) fn preview_definition_field(
+    world: &mut World,
+    type_path: &str,
+    field_path: &str,
+    new_json: &serde_json::Value,
+) -> bool {
+    let Some(entity) = open_edit_of(world, type_path) else {
+        return false;
+    };
+    let Some(handle) = world
+        .get::<DefinitionAssetEdit>(entity)
+        .map(|edit| edit.handle.clone())
+    else {
+        return false;
+    };
+    remember_baseline(world, entity, type_path, field_path);
+    write_field(world, &handle, type_path, field_path, new_json)
+}
+
+/// Record what the field held before a drag's first tick.
+fn remember_baseline(world: &mut World, entity: Entity, type_path: &str, field_path: &str) {
+    let field = (type_path.to_string(), field_path.to_string());
+    if world
+        .get_resource::<DefinitionEditSession>()
+        .is_some_and(|session| session.field.as_ref() == Some(&field))
+    {
+        return;
+    }
+    let baseline = field_as_json(world, entity, type_path, field_path);
+    let mut session = world.get_resource_or_init::<DefinitionEditSession>();
+    session.field = Some(field);
+    session.baseline = baseline;
+}
+
+/// Take the baseline a drag on this field left, if there is one.
+fn take_baseline(
+    world: &mut World,
+    type_path: &str,
+    field_path: &str,
+) -> Option<serde_json::Value> {
+    let mut session = world.get_resource_or_init::<DefinitionEditSession>();
+    let matches = session
+        .field
+        .as_ref()
+        .is_some_and(|(known_type, known_field)| {
+            known_type == type_path && known_field == field_path
+        });
+    session.field = None;
+    let baseline = session.baseline.take();
+    matches.then_some(baseline).flatten()
+}
+
+/// Whether the field holds a value whose shape decides the rows shown for it.
+fn field_rebuilds_rows(world: &World, entity: Entity, type_path: &str, field_path: &str) -> bool {
+    let registry = world.resource::<AppTypeRegistry>().read();
+    let Some(value) = definition_value(world, entity, type_path, &registry) else {
+        return false;
+    };
+    let field = if field_path.is_empty() {
+        Some(value.as_partial_reflect())
+    } else {
+        value.reflect_path(field_path).ok()
+    };
+    field.is_some_and(|field| {
+        matches!(
+            field.reflect_ref(),
+            ReflectRef::Enum(_) | ReflectRef::List(_) | ReflectRef::Array(_)
+        )
+    })
+}
+
+// -- Opening, saving and creating -------------------------------------------
+
+/// Load a definition file, or reuse the loaded one, and put it in the
+/// inspector. A kind loaded elsewhere is only ever shown through the handle
+/// its owner published.
+pub fn open_definition_file(world: &mut World, path: &Path) -> bool {
+    let Some(definition) = world
+        .get_resource::<DefinitionAssetTypes>()
+        .and_then(|types| types.for_file(path))
+        .cloned()
+    else {
+        return false;
+    };
+    let Some(name) = definition.name_of_file(path) else {
+        return false;
+    };
+
+    let known = world
+        .resource::<DefinitionRegistry>()
+        .get(&definition.kind, &name)
+        .map(|entry| entry.handle.clone());
+    let handle = match known {
+        Some(handle) => handle,
+        None => {
+            if !definition.scanned {
+                warn!("No {} named '{name}' is loaded", definition.kind);
+                return false;
+            }
+            let Some(handle) = load_definition_file(world, &definition, path) else {
+                return false;
+            };
+            world
+                .resource_mut::<DefinitionRegistry>()
+                .insert(DefinitionEntry {
+                    kind: definition.kind.clone(),
+                    name: name.clone(),
+                    handle: handle.clone(),
+                    path: path.to_path_buf(),
+                });
+            handle
+        }
+    };
+
+    show_definition(world, &definition, &name, handle, path.to_path_buf());
+    true
+}
+
+fn show_definition(
+    world: &mut World,
+    definition: &DefinitionAssetType,
+    name: &str,
+    handle: UntypedHandle,
+    path: PathBuf,
+) {
+    close_open_definition(world);
+    let entity = world
+        .spawn((
+            Name::new(format!("{} ({})", name, definition.label)),
+            DefinitionAssetEdit {
+                kind: definition.kind.clone(),
+                name: name.to_string(),
+                type_path: definition.type_path.clone(),
+                handle,
+                path,
+                dirty: false,
+            },
+        ))
+        .id();
+    world.resource_mut::<OpenDefinition>().0 = Some(entity);
+    crate::selection::select_only(world, entity);
+}
+
+/// Drop the editing entity for whatever definition was open. The definition
+/// itself stays loaded and registered.
+pub fn close_open_definition(world: &mut World) {
+    let Some(entity) = world.resource_mut::<OpenDefinition>().0.take() else {
+        return;
+    };
+    if let Ok(entity_mut) = world.get_entity_mut(entity) {
+        entity_mut.despawn();
+    }
+    if world
+        .get_resource::<crate::selection::Selection>()
+        .is_some_and(|selection| selection.entities.contains(&entity))
+    {
+        crate::selection::clear_selection_in_world(world);
+    }
+}
+
+/// Write the open definition back to its file, reporting the name it saved
+/// under.
+fn save_open_definition(world: &mut World, entity: Entity) -> Option<String> {
+    let (kind, name, handle, path) = world.get::<DefinitionAssetEdit>(entity).map(|edit| {
+        (
+            edit.kind.clone(),
+            edit.name.clone(),
+            edit.handle.clone(),
+            edit.path.clone(),
+        )
+    })?;
+    save_definition(world, &kind, &name, &handle, &path)
+}
+
+/// Write the definition a file path names back to that file, without taking
+/// the inspector off whatever it is showing.
+fn save_definition_at(world: &mut World, path: &Path) -> Option<String> {
+    let definition = world
+        .get_resource::<DefinitionAssetTypes>()
+        .and_then(|types| types.for_file(path))
+        .cloned();
+    let Some(definition) = definition else {
+        warn!("asset.save: {} is not a definition file", path.display());
+        return None;
+    };
+    let name = definition.name_of_file(path)?;
+    let Some(handle) = world
+        .resource::<DefinitionRegistry>()
+        .get(&definition.kind, &name)
+        .map(|entry| entry.handle.clone())
+    else {
+        warn!(
+            "asset.save: no {} named '{name}' is loaded",
+            definition.kind
+        );
+        return None;
+    };
+    save_definition(world, &definition.kind, &name, &handle, path)
+}
+
+/// Write one definition back to the file it came from and record where it
+/// landed.
+fn save_definition(
+    world: &mut World,
+    kind: &str,
+    name: &str,
+    handle: &UntypedHandle,
+    path: &Path,
+) -> Option<String> {
+    let path = match write_definition_at(world, name, handle, path) {
+        Ok(path) => path,
+        Err(err) => {
+            warn!("asset.save: failed to write '{name}': {err}");
+            return None;
+        }
+    };
+    if let Some(open) = edit_of_handle(world, handle)
+        && let Some(mut edit) = world.get_mut::<DefinitionAssetEdit>(open)
+    {
+        edit.dirty = false;
+        edit.path = path.clone();
+    }
+    world
+        .resource_mut::<DefinitionRegistry>()
+        .insert(DefinitionEntry {
+            kind: kind.to_string(),
+            name: name.to_string(),
+            handle: handle.clone(),
+            path,
+        });
+    Some(name.to_string())
+}
+
+// -- Operators --------------------------------------------------------------
+
+pub(crate) fn add_to_extension(ctx: &mut ExtensionContext) {
+    ctx.register_operator::<AssetNewOp>()
+        .register_operator::<AssetOpenOp>()
+        .register_operator::<AssetSaveOp>()
+        .register_operator::<AssetDeleteOp>()
+        .register_operator::<AssetSetOp>()
+        .register_operator::<AssetListOp>();
+}
+
+/// The kind saved materials list under, so the material directory is browsed,
+/// opened and edited through the same registry as any other definition.
+pub const MATERIAL_KIND: &str = "material";
+
+pub(crate) fn plugin(app: &mut App) {
+    app.world_mut()
+        .get_resource_or_init::<DefinitionAssetTypes>()
+        .register(
+            DefinitionAssetType::new(
+                MATERIAL_KIND,
+                "Material",
+                "bevy_pbr::pbr_material::StandardMaterial",
+                crate::material_assets::MATERIALS_DIR,
+                crate::material_assets::MATERIAL_FILE_SUFFIX,
+            )
+            .loaded_elsewhere(),
+        );
+    app.init_resource::<DefinitionRegistry>()
+        .init_resource::<DefinitionEditSession>()
+        .init_resource::<OpenDefinition>()
+        .init_resource::<DefinitionScanPending>()
+        .add_systems(OnEnter(crate::AppState::Editor), watch_definition_files)
+        .add_systems(
+            Update,
+            (
+                follow_registered_types.run_if(resource_changed::<DefinitionAssetTypes>),
+                poll_definition_watcher,
+                apply_definition_scan,
+            )
+                .chain()
+                .run_if(in_state(crate::AppState::Editor)),
+        )
+        .add_systems(
+            Update,
+            mirror_material_definitions
+                .run_if(resource_exists_and_changed::<crate::material_assets::MaterialRegistry>),
+        );
+}
+
+/// Publish the saved materials into the definition registry, so the material
+/// directory browses and opens like any other kind.
+fn mirror_material_definitions(world: &mut World) {
+    let Some(definition) = definition_of_kind(world, MATERIAL_KIND) else {
+        return;
+    };
+    let saved: Vec<(String, UntypedHandle)> = world
+        .resource::<crate::material_assets::MaterialRegistry>()
+        .saved_entries()
+        .map(|entry| {
+            (
+                sanitize_definition_name(&entry.name),
+                entry.handle.clone().untyped(),
+            )
+        })
+        .collect();
+    let paths: Vec<PathBuf> = {
+        let Some(project) = world.get_resource::<ProjectRoot>() else {
+            return;
+        };
+        saved
+            .iter()
+            .map(|(name, _)| definition_path(project, &definition, name))
+            .collect()
+    };
+
+    let mut registry = world.resource_mut::<DefinitionRegistry>();
+    registry.entries.retain(|entry| entry.kind != MATERIAL_KIND);
+    for ((name, handle), path) in saved.into_iter().zip(paths) {
+        registry.insert(DefinitionEntry {
+            kind: MATERIAL_KIND.to_string(),
+            name,
+            handle,
+            path,
+        });
+    }
+}
+
+/// Watches the project's assets directory so a definition file written by
+/// another tool registers without reopening the project.
+#[derive(Resource)]
+struct DefinitionFileWatcher {
+    _watcher: notify::RecommendedWatcher,
+    receiver: Mutex<mpsc::Receiver<()>>,
+}
+
+#[derive(Resource, Default)]
+struct DefinitionScanPending(bool);
+
+fn watch_definition_files(
+    project: Option<Res<ProjectRoot>>,
+    mut pending: ResMut<DefinitionScanPending>,
+    mut commands: Commands,
+) {
+    pending.0 = true;
+    let Some(assets) = project.map(|project| project.assets_dir()) else {
+        return;
+    };
+    let (sender, receiver) = mpsc::channel();
+    let watcher =
+        notify::recommended_watcher(move |event: Result<notify::Event, notify::Error>| {
+            use notify::EventKind;
+            if let Ok(event) = event
+                && matches!(
+                    event.kind,
+                    EventKind::Create(_)
+                        | EventKind::Remove(_)
+                        | EventKind::Modify(notify::event::ModifyKind::Name(_))
+                )
+            {
+                let _ = sender.send(());
+            }
+        });
+    if let Ok(mut watcher) = watcher {
+        use notify::Watcher as _;
+        if watcher
+            .watch(&assets, notify::RecursiveMode::Recursive)
+            .is_ok()
+        {
+            commands.insert_resource(DefinitionFileWatcher {
+                _watcher: watcher,
+                receiver: Mutex::new(receiver),
+            });
+        }
+    }
+}
+
+fn poll_definition_watcher(
+    watcher: Option<Res<DefinitionFileWatcher>>,
+    mut pending: ResMut<DefinitionScanPending>,
+) {
+    let Some(watcher) = watcher else { return };
+    let Ok(receiver) = watcher.receiver.lock() else {
+        return;
+    };
+    if receiver.try_recv().is_ok() {
+        while receiver.try_recv().is_ok() {}
+        pending.0 = true;
+    }
+}
+
+/// Follow the registered types: a kind that has gone takes its loaded entries
+/// and its open card with it, and a kind that has arrived gets its directory
+/// scanned.
+fn follow_registered_types(world: &mut World) {
+    let kinds: Vec<String> = registered_types(world)
+        .into_iter()
+        .map(|definition| definition.kind)
+        .collect();
+    world
+        .resource_mut::<DefinitionRegistry>()
+        .entries
+        .retain(|entry| kinds.contains(&entry.kind));
+    let open_kind = world
+        .resource::<OpenDefinition>()
+        .0
+        .and_then(|entity| world.get::<DefinitionAssetEdit>(entity))
+        .map(|edit| edit.kind.clone());
+    if let Some(kind) = open_kind
+        && !kinds.contains(&kind)
+    {
+        close_open_definition(world);
+    }
+    world.resource_mut::<DefinitionScanPending>().0 = true;
+}
+
+fn apply_definition_scan(world: &mut World) {
+    if !std::mem::take(&mut world.resource_mut::<DefinitionScanPending>().0) {
+        return;
+    }
+    let scan = rescan_definitions(world);
+    if !scan.added.is_empty() {
+        info!("Loaded {} definition files", scan.added.len());
+    }
+}
+
+fn definition_of_kind(world: &World, kind: &str) -> Option<DefinitionAssetType> {
+    world
+        .get_resource::<DefinitionAssetTypes>()
+        .and_then(|types| types.by_kind(kind))
+        .cloned()
+}
+
+/// Create a definition file of a registered type and open it.
+#[operator(
+    id = "asset.new",
+    label = "New Definition",
+    description = "Create a definition file of a registered type and open it in the inspector.",
+    allows_undo = false,
+    params(
+        r#type(
+            String,
+            doc = "Kind of definition to create, as its type registered it."
+        ),
+        name(
+            String,
+            doc = "Name to create it under. Defaults to the next free name."
+        )
+    )
+)]
+pub fn asset_new(params: In<OperatorParameters>, mut commands: Commands) -> OperatorResult {
+    let Some(kind) = params.as_str("type").map(str::to_owned) else {
+        warn!("asset.new: no type given");
+        return OperatorResult::Cancelled;
+    };
+    let name = params.as_str("name").map(str::to_owned);
+    commands.queue(move |world: &mut World| {
+        new_definition(world, &kind, name.as_deref());
+    });
+    OperatorResult::Finished
+}
+
+fn new_definition(world: &mut World, kind: &str, name: Option<&str>) {
+    let Some((definition, name, handle, path)) = create_definition(world, kind, name) else {
+        return;
+    };
+    show_definition(world, &definition, &name, handle, path);
+    report_to_caller(world, format!("Created {kind} '{name}'"));
+}
+
+/// Write a fresh default value of a registered kind to its file and register
+/// it.
+fn create_definition(
+    world: &mut World,
+    kind: &str,
+    name: Option<&str>,
+) -> Option<(DefinitionAssetType, String, UntypedHandle, PathBuf)> {
+    let Some(definition) = definition_of_kind(world, kind) else {
+        warn!("asset.new: '{kind}' is not a registered definition type");
+        return None;
+    };
+    if !definition.scanned {
+        warn!("asset.new: {kind} definitions are created by whoever loads them");
+        return None;
+    }
+    let name = match name {
+        Some(name) => sanitize_definition_name(name),
+        None => next_free_name(world, &definition),
+    };
+    if world
+        .resource::<DefinitionRegistry>()
+        .get(kind, &name)
+        .is_some()
+    {
+        warn!("asset.new: a {kind} named '{name}' already exists");
+        return None;
+    }
+    if world
+        .get_resource::<ProjectRoot>()
+        .is_some_and(|project| definition_path(project, &definition, &name).exists())
+    {
+        warn!("asset.new: a file for the {kind} '{name}' is already there");
+        return None;
+    }
+    let Some(handle) = default_definition_value(world, &definition) else {
+        warn!(
+            "asset.new: {} has no registered default",
+            definition.type_path
+        );
+        return None;
+    };
+    let path = match write_definition_file(world, &definition, &name, &handle) {
+        Ok(path) => path,
+        Err(err) => {
+            warn!("asset.new: failed to write '{name}': {err}");
+            return None;
+        }
+    };
+    world
+        .resource_mut::<DefinitionRegistry>()
+        .insert(DefinitionEntry {
+            kind: definition.kind.clone(),
+            name: name.clone(),
+            handle: handle.clone(),
+            path: path.clone(),
+        });
+    Some((definition, name, handle, path))
+}
+
+/// Open a definition file in the inspector.
+#[operator(
+    id = "asset.open",
+    label = "Open Definition",
+    description = "Open a definition file in the inspector.",
+    allows_undo = false,
+    params(path(String, doc = "File to open, as a path under the project."))
+)]
+pub fn asset_open(params: In<OperatorParameters>, mut commands: Commands) -> OperatorResult {
+    let Some(path) = params.as_str("path").map(PathBuf::from) else {
+        warn!("asset.open: no path given");
+        return OperatorResult::Cancelled;
+    };
+    commands.queue(move |world: &mut World| {
+        let path = resolve_project_path(world, &path);
+        if !open_definition_file(world, &path) {
+            warn!("asset.open: {} is not a definition file", path.display());
+        }
+    });
+    OperatorResult::Finished
+}
+
+/// Write a definition back to its file.
+#[operator(
+    id = "asset.save",
+    label = "Save Definition",
+    description = "Write the open definition back to its file.",
+    allows_undo = false,
+    params(path(
+        String,
+        doc = "Definition file to save. Defaults to the open definition."
+    ))
+)]
+pub fn asset_save(params: In<OperatorParameters>, mut commands: Commands) -> OperatorResult {
+    let path = params.as_str("path").map(PathBuf::from);
+    commands.queue(move |world: &mut World| {
+        let saved = match &path {
+            Some(path) => {
+                let path = resolve_project_path(world, path);
+                save_definition_at(world, &path)
+            }
+            None => {
+                let Some(entity) = world.resource::<OpenDefinition>().0 else {
+                    warn!("asset.save: no definition is open");
+                    return;
+                };
+                save_open_definition(world, entity)
+            }
+        };
+        if let Some(name) = saved {
+            report_to_caller(world, format!("Saved '{name}'"));
+        }
+    });
+    OperatorResult::Finished
+}
+
+/// Delete a definition file and forget what it held.
+#[operator(
+    id = "asset.delete",
+    label = "Delete Definition",
+    description = "Delete a definition file and drop it from this project.",
+    allows_undo = false,
+    params(path(String, doc = "Definition file to delete."))
+)]
+pub fn asset_delete(params: In<OperatorParameters>, mut commands: Commands) -> OperatorResult {
+    let Some(path) = params.as_str("path").map(PathBuf::from) else {
+        warn!("asset.delete: no path given");
+        return OperatorResult::Cancelled;
+    };
+    commands.queue(move |world: &mut World| {
+        let path = resolve_project_path(world, &path);
+        delete_definition(world, &path);
+    });
+    OperatorResult::Finished
+}
+
+fn delete_definition(world: &mut World, path: &Path) {
+    let Some(definition) = world
+        .get_resource::<DefinitionAssetTypes>()
+        .and_then(|types| types.for_file(path))
+        .cloned()
+    else {
+        warn!("asset.delete: {} is not a definition file", path.display());
+        return;
+    };
+    if !definition.scanned {
+        warn!(
+            "asset.delete: {} definitions are removed by whoever loads them",
+            definition.kind
+        );
+        return;
+    }
+    let Some(name) = definition.name_of_file(path) else {
+        return;
+    };
+    match std::fs::remove_file(path) {
+        Ok(()) => info!("Removed {}", path.display()),
+        Err(err) if err.kind() == std::io::ErrorKind::NotFound => {}
+        Err(err) => {
+            warn!("asset.delete: failed to remove {}: {err}", path.display());
+            return;
+        }
+    }
+    world
+        .resource_mut::<DefinitionRegistry>()
+        .remove(&definition.kind, &name);
+    let open_is_gone = world
+        .resource::<OpenDefinition>()
+        .0
+        .and_then(|entity| world.get::<DefinitionAssetEdit>(entity))
+        .is_some_and(|edit| edit.kind == definition.kind && edit.name == name);
+    if open_is_gone {
+        close_open_definition(world);
+    }
+}
+
+/// Set a field of the open definition, for edits driven from outside the
+/// inspector.
+#[operator(
+    id = "asset.set",
+    label = "Set Definition Field",
+    description = "Set a field of the open definition.",
+    allows_undo = false,
+    params(
+        field(
+            String,
+            doc = "Field path on the definition, for example 'stack_size'."
+        ),
+        value(String, doc = "Value to set, as JSON or as a plain scalar.")
+    )
+)]
+pub fn asset_set(params: In<OperatorParameters>, mut commands: Commands) -> OperatorResult {
+    let (Some(field), Some(value)) = (
+        params.as_str("field").map(str::to_owned),
+        params.as_str("value").map(str::to_owned),
+    ) else {
+        warn!("asset.set: both field and value are required");
+        return OperatorResult::Cancelled;
+    };
+    commands.queue(move |world: &mut World| {
+        set_definition_field(world, &field, &value);
+    });
+    OperatorResult::Finished
+}
+
+fn set_definition_field(world: &mut World, field: &str, value: &str) {
+    let Some(entity) = world.resource::<OpenDefinition>().0 else {
+        warn!("asset.set: no definition is open");
+        return;
+    };
+    let Some(type_path) = world
+        .get::<DefinitionAssetEdit>(entity)
+        .map(|edit| edit.type_path.clone())
+    else {
+        return;
+    };
+    if world
+        .get_resource::<crate::selection::Selection>()
+        .and_then(crate::selection::Selection::primary)
+        != Some(entity)
+    {
+        crate::selection::select_only(world, entity);
+    }
+    let json = serde_json::from_str::<serde_json::Value>(value)
+        .unwrap_or_else(|_| serde_json::Value::String(value.to_string()));
+    if commit_definition_field(world, &type_path, field, &json) {
+        report_to_caller(world, format!("Set {field}"));
+    } else {
+        warn!("asset.set: '{field}' is not a field of {type_path}");
+    }
+}
+
+/// Report the definitions of a kind this project holds.
+#[operator(
+    id = "asset.list",
+    label = "List Definitions",
+    description = "Report the definitions of a registered type this project holds.",
+    allows_undo = false,
+    params(r#type(String, doc = "Kind of definition to list."))
+)]
+pub fn asset_list(params: In<OperatorParameters>, mut commands: Commands) -> OperatorResult {
+    let Some(kind) = params.as_str("type").map(str::to_owned) else {
+        warn!("asset.list: no type given");
+        return OperatorResult::Cancelled;
+    };
+    commands.queue(move |world: &mut World| {
+        if definition_of_kind(world, &kind).is_none() {
+            warn!("asset.list: '{kind}' is not a registered definition type");
+            return;
+        }
+        let names = world.resource::<DefinitionRegistry>().names_of(&kind);
+        report_to_caller(world, format!("{kind}: {}", names.join(", ")));
+    });
+    OperatorResult::Finished
+}
+
+/// Accept both a path under the project and one relative to its assets
+/// directory, so a caller can pass what the asset browser lists.
+fn resolve_project_path(world: &World, path: &Path) -> PathBuf {
+    if path.is_absolute() {
+        return path.to_path_buf();
+    }
+    let Some(project) = world.get_resource::<ProjectRoot>() else {
+        return path.to_path_buf();
+    };
+    let under_root = project.root.join(path);
+    if under_root.exists() {
+        return under_root;
+    }
+    project.assets_dir().join(path)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use bevy::asset::{Asset, AssetPlugin};
+    use bevy::reflect::Reflect;
+
+    #[derive(Reflect, Clone, Default, PartialEq, Debug)]
+    #[reflect(Default)]
+    struct LootRoll {
+        item: String,
+        weight: u32,
+    }
+
+    #[derive(Reflect, Clone, Default, PartialEq, Debug)]
+    #[reflect(Default)]
+    enum Rarity {
+        #[default]
+        Common,
+        Rare,
+    }
+
+    #[derive(Asset, Reflect, Clone, Default)]
+    #[reflect(Default)]
+    struct ItemDef {
+        stack_size: u32,
+        rarity: Rarity,
+        loot: Vec<LootRoll>,
+    }
+
+    fn item_type() -> DefinitionAssetType {
+        DefinitionAssetType::new(
+            "item",
+            "Item",
+            "jackdaw::definition_assets::tests::ItemDef",
+            "content/items",
+            ".item.bsn",
+        )
+    }
+
+    fn definition_app() -> (App, tempfile::TempDir) {
+        let tmp = tempfile::tempdir().expect("tempdir");
+        let mut app = App::new();
+        app.add_plugins((bevy::app::TaskPoolPlugin::default(), AssetPlugin::default()));
+        app.init_asset::<ItemDef>();
+        app.register_asset_reflect::<ItemDef>();
+        app.register_type::<ItemDef>();
+        app.register_type::<LootRoll>();
+        app.register_type::<Rarity>();
+        app.init_resource::<DefinitionAssetTypes>();
+        app.init_resource::<DefinitionRegistry>();
+        app.insert_resource(ProjectRoot {
+            root: tmp.path().to_path_buf(),
+            config: crate::project::ProjectConfig::default(),
+        });
+        app.world_mut()
+            .resource_mut::<DefinitionAssetTypes>()
+            .register(item_type());
+        (app, tmp)
+    }
+
+    fn item_of(app: &App, handle: &UntypedHandle) -> ItemDef {
+        app.world()
+            .resource::<Assets<ItemDef>>()
+            .get(&handle.clone().typed::<ItemDef>())
+            .expect("the definition is in its store")
+            .clone()
+    }
+
+    #[test]
+    fn a_written_definition_reloads_from_its_directory() {
+        let (mut app, tmp) = definition_app();
+        let handle = app
+            .world_mut()
+            .resource_mut::<Assets<ItemDef>>()
+            .add(ItemDef {
+                stack_size: 20,
+                rarity: Rarity::Rare,
+                loot: vec![LootRoll {
+                    item: "coin".into(),
+                    weight: 3,
+                }],
+            });
+
+        write_definition_file(app.world(), &item_type(), "torch", &handle.untyped())
+            .expect("the file is written");
+        assert!(
+            tmp.path()
+                .join("assets/content/items/torch.item.bsn")
+                .is_file()
+        );
+
+        let scan = rescan_definitions(app.world_mut());
+        assert_eq!(scan.added, vec![("item".to_string(), "torch".to_string())]);
+
+        let loaded = app
+            .world()
+            .resource::<DefinitionRegistry>()
+            .get("item", "torch")
+            .expect("the scan registered it")
+            .handle
+            .clone();
+        let item = item_of(&app, &loaded);
+        assert_eq!(item.stack_size, 20);
+        assert_eq!(item.rarity, Rarity::Rare);
+        assert_eq!(
+            item.loot,
+            vec![LootRoll {
+                item: "coin".into(),
+                weight: 3
+            }]
+        );
+    }
+
+    #[test]
+    fn a_file_deleted_on_disk_drops_its_entry_on_the_next_scan() {
+        let (mut app, tmp) = definition_app();
+        let handle = app
+            .world_mut()
+            .resource_mut::<Assets<ItemDef>>()
+            .add(ItemDef::default());
+        write_definition_file(app.world(), &item_type(), "torch", &handle.untyped())
+            .expect("the file is written");
+        rescan_definitions(app.world_mut());
+
+        std::fs::remove_file(tmp.path().join("assets/content/items/torch.item.bsn"))
+            .expect("the file is removed");
+        let scan = rescan_definitions(app.world_mut());
+
+        assert_eq!(
+            scan.removed,
+            vec![("item".to_string(), "torch".to_string())]
+        );
+        assert!(
+            app.world()
+                .resource::<DefinitionRegistry>()
+                .get("item", "torch")
+                .is_none()
+        );
+    }
+
+    #[test]
+    fn two_kinds_sharing_a_name_keep_their_own_files() {
+        let (mut app, tmp) = definition_app();
+        app.world_mut()
+            .resource_mut::<DefinitionAssetTypes>()
+            .register(DefinitionAssetType::new(
+                "mob",
+                "Mob",
+                "jackdaw::definition_assets::tests::ItemDef",
+                "content/mobs",
+                ".mob.bsn",
+            ));
+        let handle = app
+            .world_mut()
+            .resource_mut::<Assets<ItemDef>>()
+            .add(ItemDef::default());
+
+        create_definition(app.world_mut(), "item", Some("rat")).expect("the item is created");
+        create_definition(app.world_mut(), "mob", Some("rat")).expect("the mob is created");
+        let _ = handle;
+
+        assert!(
+            tmp.path()
+                .join("assets/content/items/rat.item.bsn")
+                .is_file()
+        );
+        assert!(tmp.path().join("assets/content/mobs/rat.mob.bsn").is_file());
+        let registry = app.world().resource::<DefinitionRegistry>();
+        assert!(registry.get("item", "rat").is_some());
+        assert!(registry.get("mob", "rat").is_some());
+    }
+
+    #[test]
+    fn names_sanitize_to_one_file_each() {
+        assert_eq!(sanitize_definition_name("torch"), "torch");
+        assert_eq!(sanitize_definition_name("a/b"), "a_b");
+        assert_eq!(sanitize_definition_name("../escape"), ".._escape");
+        assert_eq!(sanitize_definition_name("  "), "definition");
+    }
+}

--- a/src/inspector/component_display.rs
+++ b/src/inspector/component_display.rs
@@ -47,6 +47,17 @@ use crate::prefab::PrefabAstCache;
 use crate::type_metadata::{TypeChrome, TypeMetadata};
 use bevy::picking::hover::Hovered;
 
+/// What the inspector reads to place its target: the entity's parents, the
+/// prefab it instances, and whether it edits a definition asset rather than a
+/// scene entity. Bundled into one param so the systems that read it stay under
+/// the system param-count limit.
+#[derive(bevy::ecs::system::SystemParam)]
+pub(crate) struct InspectorLineage<'w, 's> {
+    pub(crate) child_of: Query<'w, 's, &'static bevy::ecs::hierarchy::ChildOf>,
+    pub(crate) is_a: Query<'w, 's, &'static crate::prefab::IsA>,
+    pub(crate) definitions: Query<'w, 's, (), With<crate::definition_assets::DefinitionAssetEdit>>,
+}
+
 /// The live scene-document resource bundled into one param so the systems
 /// that read it stay under the system param-count limit.
 #[derive(bevy::ecs::system::SystemParam)]
@@ -73,8 +84,7 @@ pub(crate) fn sync_inspector_to_selection(
     materials: Res<Assets<StandardMaterial>>,
     asts: SceneAsts,
     prefab_cache: Res<PrefabAstCache>,
-    child_of_query: Query<&bevy::ecs::hierarchy::ChildOf>,
-    isa_query: Query<&crate::prefab::IsA>,
+    lineage: InspectorLineage,
     collapse_state: Res<super::InspectorCollapseState>,
     displays: Query<Entity, Or<(With<ComponentDisplay>, With<ComponentPicker>)>>,
 ) {
@@ -99,6 +109,7 @@ pub(crate) fn sync_inspector_to_selection(
         if let Some(primary) = desired
             && current.is_none()
             && entity_query.get(primary).is_err()
+            && !lineage.definitions.contains(primary)
         {
             continue;
         }
@@ -111,6 +122,17 @@ pub(crate) fn sync_inspector_to_selection(
         let Some(primary) = desired else {
             continue;
         };
+        if lineage.definitions.contains(primary) {
+            commands.queue(move |world: &mut World| {
+                super::definition_card::fill_definition_card(world, inspector, primary);
+            });
+            commands.entity(inspector).insert((
+                InspectorTarget(primary),
+                Monitor(primary),
+                NotifyAdded::<InspectorDirty>::default(),
+            ));
+            continue;
+        }
         let Ok((archetype, entity_ref)) = entity_query.get(primary) else {
             continue;
         };
@@ -121,8 +143,8 @@ pub(crate) fn sync_inspector_to_selection(
             &prefab_cache,
             source_entity,
             entity_ref,
-            &child_of_query,
-            &isa_query,
+            &lineage.child_of,
+            &lineage.is_a,
         );
 
         build_inspector_displays(
@@ -778,8 +800,7 @@ pub(crate) fn on_inspector_dirty(
     materials: Res<Assets<StandardMaterial>>,
     asts: SceneAsts,
     prefab_cache: Res<PrefabAstCache>,
-    child_of_query: Query<&bevy::ecs::hierarchy::ChildOf>,
-    isa_query: Query<&crate::prefab::IsA>,
+    lineage: InspectorLineage,
     collapse_state: Res<super::InspectorCollapseState>,
 ) {
     // Multi-instance: rebuild every Inspector tab in lockstep. Each
@@ -791,6 +812,15 @@ pub(crate) fn on_inspector_dirty(
         let mut source_entity = target.0;
 
         despawn_inspector_display_children(&mut commands, children, &displays);
+
+        if lineage.definitions.contains(source_entity) {
+            let source = source_entity;
+            commands.queue(move |world: &mut World| {
+                super::definition_card::fill_definition_card(world, inspector_entity, source);
+            });
+            clear_dirty_for = clear_dirty_for.or(Some(source_entity));
+            continue;
+        }
 
         // Rebuild this inspector's contents. If the monitored target is gone
         // (despawned/respawned by CSG, undo, or prefab install), fall back to
@@ -824,8 +854,8 @@ pub(crate) fn on_inspector_dirty(
             &prefab_cache,
             source_entity,
             entity_ref,
-            &child_of_query,
-            &isa_query,
+            &lineage.child_of,
+            &lineage.is_a,
         );
 
         build_inspector_displays(

--- a/src/inspector/definition_card.rs
+++ b/src/inspector/definition_card.rs
@@ -1,0 +1,170 @@
+//! The inspector card for the open definition asset.
+//!
+//! The card is the generic component card with the definition's reflected
+//! fields in its body, so scalars, enum menus and list rows behave exactly as
+//! they do on a component. Its header carries the Save action and says when
+//! the definition has unsaved edits.
+
+use bevy::ecs::system::SystemState;
+use bevy::prelude::*;
+use bevy::reflect::ReflectFromReflect;
+use jackdaw_api::op::Operator as _;
+use jackdaw_api::prelude::DefinitionAssetTypes;
+use jackdaw_feathers::{
+    button::{ButtonOperatorCall, ButtonProps, ButtonSize, ButtonVariant, button},
+    icons::{EditorFont, IconFont},
+    tokens,
+};
+use jackdaw_widgets::collapsible::CollapsibleHeader;
+
+use crate::definition_assets::{AssetSaveOp, DefinitionAssetEdit};
+
+use super::component_display::{ComponentDisplaySpec, spawn_component_display};
+
+/// Build the card for the definition `source` is editing under `inspector`.
+pub(crate) fn fill_definition_card(world: &mut World, inspector: Entity, source: Entity) {
+    let Some((kind, name, type_path, dirty)) =
+        world.get::<DefinitionAssetEdit>(source).map(|edit| {
+            (
+                edit.kind.clone(),
+                edit.name.clone(),
+                edit.type_path.clone(),
+                edit.dirty,
+            )
+        })
+    else {
+        return;
+    };
+    let label = world
+        .get_resource::<DefinitionAssetTypes>()
+        .and_then(|types| types.by_kind(&kind))
+        .map_or_else(|| kind.clone(), |definition| definition.label.clone());
+
+    let Some(value) = definition_snapshot(world, source, &type_path) else {
+        return;
+    };
+
+    let registry = world.resource::<AppTypeRegistry>().clone();
+    let icon_font = world.resource::<IconFont>().0.clone();
+    let editor_font = world.resource::<EditorFont>().0.clone();
+    let collapse_state =
+        super::InspectorCollapseState(world.resource::<super::InspectorCollapseState>().0.clone());
+
+    let card_name = format!("{name} ({label})");
+    let mut state: SystemState<(Commands, Query<&Name>)> = SystemState::new(world);
+    let Ok((mut commands, names)) = state.get_mut(world) else {
+        return;
+    };
+    let card = spawn_component_display(
+        &mut commands,
+        ComponentDisplaySpec {
+            name: &card_name,
+            type_path: &type_path,
+            entity: source,
+            component: None,
+            is_overridden: false,
+            is_derived: false,
+            prefab_ctx: None,
+            revert_through_prefab: false,
+            icon_font: &icon_font,
+            editor_font: &editor_font,
+            collapse_state: &collapse_state,
+        },
+    );
+    jackdaw_feathers::utils::attach_or_despawn(&mut commands, inspector, card.section);
+    super::reflect_fields::spawn_reflected_fields(
+        &mut commands,
+        card.body,
+        value.as_ref(),
+        0,
+        String::new(),
+        source,
+        &type_path,
+        &names,
+        &registry,
+        &editor_font,
+        &icon_font,
+    );
+    state.apply(world);
+
+    spawn_save_action(world, card.section, source, dirty);
+}
+
+/// The definition's value, owned, so the field rows can be spawned while the
+/// world is borrowed for commands.
+fn definition_snapshot(world: &World, source: Entity, type_path: &str) -> Option<Box<dyn Reflect>> {
+    let registry = world.resource::<AppTypeRegistry>().read();
+    let value = crate::definition_assets::definition_value(world, source, type_path, &registry)?;
+    registry
+        .get_with_type_path(type_path)?
+        .data::<ReflectFromReflect>()?
+        .from_reflect(value.as_partial_reflect())
+}
+
+/// The header's unsaved-edits marker, following the definition it names.
+#[derive(Component)]
+pub(crate) struct UnsavedMarker(Entity);
+
+/// Show the marker exactly while the definition it names has unsaved edits.
+pub(crate) fn keep_unsaved_marker_in_step(
+    mut markers: Query<(&UnsavedMarker, &mut Node)>,
+    edits: Query<&DefinitionAssetEdit>,
+) {
+    for (marker, mut node) in &mut markers {
+        let display = if edits.get(marker.0).is_ok_and(|edit| edit.dirty) {
+            Display::Flex
+        } else {
+            Display::None
+        };
+        if node.display != display {
+            node.display = display;
+        }
+    }
+}
+
+/// Put Save, and the unsaved-edits marker, in the card's header.
+fn spawn_save_action(world: &mut World, section: Entity, source: Entity, dirty: bool) {
+    let Some(header) = world.get::<Children>(section).and_then(|children| {
+        children
+            .iter()
+            .find(|&child| world.get::<CollapsibleHeader>(child).is_some())
+    }) else {
+        return;
+    };
+    let row = world
+        .spawn((
+            Node {
+                flex_direction: FlexDirection::Row,
+                align_items: AlignItems::Center,
+                column_gap: Val::Px(tokens::SPACING_XS),
+                ..default()
+            },
+            ChildOf(header),
+        ))
+        .id();
+    world.spawn((
+        Text::new("Unsaved"),
+        TextFont {
+            font_size: tokens::TEXT_SIZE_XS,
+            ..default()
+        },
+        TextColor(tokens::TEXT_SECONDARY),
+        Node {
+            display: if dirty { Display::Flex } else { Display::None },
+            ..default()
+        },
+        UnsavedMarker(source),
+        ChildOf(row),
+    ));
+    let save = world
+        .spawn((
+            button(
+                ButtonProps::new("Save")
+                    .with_variant(ButtonVariant::Default)
+                    .with_size(ButtonSize::MD),
+            ),
+            ButtonOperatorCall::new(AssetSaveOp::ID),
+        ))
+        .id();
+    world.entity_mut(save).insert(ChildOf(row));
+}

--- a/src/inspector/mod.rs
+++ b/src/inspector/mod.rs
@@ -8,6 +8,7 @@ pub(crate) mod component_display;
 pub mod component_picker;
 pub(crate) mod component_tooltip;
 mod custom_props_display;
+mod definition_card;
 mod live_edit_dots;
 pub(crate) mod material_card_routing;
 mod material_display;
@@ -145,6 +146,7 @@ impl Plugin for InspectorPlugin {
                         node_card::refresh_node_enum_combos,
                         node_card::refresh_node_optional_numbers,
                         bindings_card::refresh_bindings_card_on_change,
+                        definition_card::keep_unsaved_marker_in_step,
                     ),
                     brush_display::update_brush_face_properties,
                     category_strip::resolve_active_on_rebuild,

--- a/src/inspector/reflect_fields.rs
+++ b/src/inspector/reflect_fields.rs
@@ -2692,6 +2692,23 @@ pub(crate) fn on_checkbox_commit(
     });
 }
 
+/// The value a field row reads: the definition asset the entity is editing, or
+/// the component of that type on the entity.
+pub(crate) fn inspected_value<'w>(
+    world: &'w World,
+    entity_ref: bevy::ecs::world::EntityRef<'w>,
+    registration: &bevy::reflect::TypeRegistration,
+    registry: &bevy::reflect::TypeRegistry,
+) -> Option<&'w dyn Reflect> {
+    let type_path = registration.type_info().type_path();
+    if let Some(value) =
+        crate::definition_assets::definition_value(world, entity_ref.id(), type_path, registry)
+    {
+        return Some(value);
+    }
+    registration.data::<ReflectComponent>()?.reflect(entity_ref)
+}
+
 /// True when any component on `entity_ref` changed within the tick window
 /// `(last_run, this_run]`. Gates the reflection-based field/enum refresh on real
 /// data changes (undo, gizmos, operators, AST live-edit all mark the component
@@ -2790,10 +2807,7 @@ pub(crate) fn refresh_inspector_fields(
         let Some(registration) = registry.get_with_type_path(comp_type_path) else {
             continue;
         };
-        let Some(reflect_component) = registration.data::<ReflectComponent>() else {
-            continue;
-        };
-        let Some(reflected) = reflect_component.reflect(entity_ref) else {
+        let Some(reflected) = inspected_value(world, entity_ref, registration, &registry) else {
             continue;
         };
         let Ok(field) = reflected.reflect_path(field_path.as_str()) else {
@@ -2826,10 +2840,7 @@ pub(crate) fn refresh_inspector_fields(
         let Some(registration) = registry.get_with_type_path(comp_type_path) else {
             continue;
         };
-        let Some(reflect_component) = registration.data::<ReflectComponent>() else {
-            continue;
-        };
-        let Some(reflected) = reflect_component.reflect(entity_ref) else {
+        let Some(reflected) = inspected_value(world, entity_ref, registration, &registry) else {
             continue;
         };
         let Ok(field) = reflected.reflect_path(field_path.as_str()) else {
@@ -3633,9 +3644,9 @@ fn list_items_as_json(
     let registry = world.resource::<AppTypeRegistry>().clone();
     let registry = registry.read();
     let registration = registry.get_with_type_path(type_path)?;
-    let reflect_component = registration.data::<ReflectComponent>()?;
-    let component = reflect_component.reflect(world.get_entity(source).ok()?)?;
-    let field = component.reflect_path(field_path).ok()?;
+    let entity_ref = world.get_entity(source).ok()?;
+    let value = inspected_value(world, entity_ref, registration, &registry)?;
+    let field = value.reflect_path(field_path).ok()?;
     let ReflectRef::List(list) = field.reflect_ref() else {
         return None;
     };
@@ -3659,9 +3670,9 @@ fn default_list_item(
     let registry = world.resource::<AppTypeRegistry>().clone();
     let registry = registry.read();
     let registration = registry.get_with_type_path(type_path)?;
-    let reflect_component = registration.data::<ReflectComponent>()?;
-    let component = reflect_component.reflect(world.get_entity(source).ok()?)?;
-    let field = component.reflect_path(field_path).ok()?;
+    let entity_ref = world.get_entity(source).ok()?;
+    let value = inspected_value(world, entity_ref, registration, &registry)?;
+    let field = value.reflect_path(field_path).ok()?;
     let TypeInfo::List(info) = field.get_represented_type_info()? else {
         return None;
     };

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -29,6 +29,7 @@ pub mod component_json;
 pub mod creation_taxonomy;
 pub mod custom_properties;
 pub mod default_style;
+pub mod definition_assets;
 pub mod draw_brush;
 pub mod edit_mode_ops;
 pub mod entity_ops;
@@ -461,6 +462,7 @@ impl Plugin for EditorCorePlugin {
             remote::debug::RemoteDebugPlugin,
             camera_settings::plugin,
         ))
+        .add_plugins(definition_assets::plugin)
         .add_plugins(model_thumbnail::plugin)
         .add_plugins(boot_ops::plugin)
         .add_plugins(fps_overlay::plugin)

--- a/src/remote/server.rs
+++ b/src/remote/server.rs
@@ -1042,6 +1042,7 @@ pub fn assets_handler(
     if let Some(mut demand) = world.get_resource_mut::<crate::animation::LibraryDemand>() {
         demand.requested = true;
     }
+    let definition_types = world.get_resource::<jackdaw_api::prelude::DefinitionAssetTypes>();
     let library = world.get_resource::<crate::animation::AnimationLibrary>();
     let detailed: Vec<Value> = found
         .into_iter()
@@ -1050,7 +1051,10 @@ pub fn assets_handler(
                 .and_then(|library| library.file(&path))
                 .map(|file| file.clips.iter().map(|clip| clip.name.as_str()).collect())
                 .unwrap_or_default();
-            json!({ "path": path, "kind": asset_kind(&path), "clips": clips })
+            let kind = definition_types
+                .and_then(|types| types.for_file(Path::new(&path)))
+                .map_or_else(|| asset_kind(&path).to_string(), |known| known.kind.clone());
+            json!({ "path": path, "kind": kind, "clips": clips })
         })
         .collect();
     Ok(Some(json!({ "assets": detailed })))
@@ -1059,7 +1063,8 @@ pub fn assets_handler(
 /// What kind of thing an asset path names, from its extension.
 ///
 /// Coarse on purpose: a caller uses it to tell a model from a document, and
-/// asks the editor about anything finer.
+/// asks the editor about anything finer. A file belonging to a registered
+/// definition type reports that type's kind instead.
 fn asset_kind(path: &str) -> &'static str {
     let extension = path
         .rsplit_once('.')

--- a/tests/inspector/definition_card.rs
+++ b/tests/inspector/definition_card.rs
@@ -1,0 +1,275 @@
+//! A definition asset in the inspector. The card is the generic reflected
+//! card, so what it is showing is an asset behind a handle rather than a
+//! component on the selected entity: the rows have to read and write that
+//! asset without a panel of their own.
+
+use crate::util;
+
+use bevy::asset::{Asset, Assets};
+use bevy::prelude::*;
+use bevy::ui_widgets::ValueChange;
+use jackdaw::definition_assets::{DefinitionAssetEdit, OpenDefinition};
+use jackdaw_api::prelude::*;
+use jackdaw_api_internal::operator::{CallOperatorSettings, ExecutionContext};
+use jackdaw_commands::CommandHistory;
+use jackdaw_feathers::button::ButtonClickEvent;
+use jackdaw_feathers::tooltip::Tooltip;
+
+#[derive(Reflect, Clone, Default, PartialEq, Debug)]
+#[reflect(Default)]
+struct LootRoll {
+    item: String,
+    weight: u32,
+}
+
+#[derive(Asset, Reflect, Clone, Default)]
+#[reflect(Default)]
+struct MobDef {
+    health: u32,
+    loot: Vec<LootRoll>,
+}
+
+/// An editor showing the inspector, with a mob definition open in it.
+fn app_with_open_definition() -> (App, tempfile::TempDir) {
+    let tmp = tempfile::tempdir().expect("tempdir");
+    let mut app = util::editor_test_app();
+    app.init_asset::<MobDef>();
+    app.register_asset_reflect::<MobDef>();
+    app.register_type::<MobDef>();
+    app.register_type::<LootRoll>();
+    app.world_mut()
+        .insert_resource(jackdaw::project::ProjectRoot {
+            root: tmp.path().to_path_buf(),
+            config: default(),
+        });
+    app.world_mut()
+        .resource_mut::<DefinitionAssetTypes>()
+        .register(DefinitionAssetType::new(
+            "mob",
+            "Mob",
+            MobDef::type_path(),
+            "content/mobs",
+            ".mob.bsn",
+        ));
+    app.world_mut()
+        .spawn(jackdaw::layout::inspector_components_content(default()));
+    app.world_mut()
+        .resource_mut::<NextState<jackdaw::AppState>>()
+        .set(jackdaw::AppState::Editor);
+    app.update();
+
+    let result = app
+        .world_mut()
+        .operator("asset.new")
+        .settings(CallOperatorSettings {
+            execution_context: ExecutionContext::Invoke,
+            creates_history_entry: true,
+        })
+        .param("type", "mob")
+        .param("name", "rat")
+        .call()
+        .expect("the operator dispatched");
+    assert_eq!(result, OperatorResult::Finished);
+    for _ in 0..6 {
+        app.update();
+    }
+    (app, tmp)
+}
+
+fn open_mob(app: &App) -> MobDef {
+    let entity = app
+        .world()
+        .resource::<OpenDefinition>()
+        .0
+        .expect("a definition is open");
+    let handle = app
+        .world()
+        .get::<DefinitionAssetEdit>(entity)
+        .expect("the entity is editing a definition")
+        .handle
+        .clone();
+    app.world()
+        .resource::<Assets<MobDef>>()
+        .get(&handle.typed::<MobDef>())
+        .expect("the definition is in its store")
+        .clone()
+}
+
+fn all_entities(app: &mut App) -> Vec<Entity> {
+    app.world_mut()
+        .query::<Entity>()
+        .iter(app.world())
+        .collect()
+}
+
+fn field_widget(app: &mut App, field_path: &str) -> Entity {
+    let type_path = MobDef::type_path();
+    let found = all_entities(app).into_iter().find(|entity| {
+        jackdaw::inspector::field_edited_by(app.world(), *entity) == Some((type_path, field_path))
+    });
+    found.unwrap_or_else(|| {
+        let paths: Vec<String> = all_entities(app)
+            .into_iter()
+            .filter_map(|entity| {
+                jackdaw::inspector::field_edited_by(app.world(), entity)
+                    .map(|(known, field)| format!("{known}.{field}"))
+            })
+            .collect();
+        panic!("no control on the inspector writes `{field_path}`; it writes {paths:?}")
+    })
+}
+
+fn add_button(app: &mut App) -> Entity {
+    all_entities(app)
+        .into_iter()
+        .find(|entity| {
+            app.world()
+                .get::<Tooltip>(*entity)
+                .is_some_and(|tip| tip.title == "Add an item to the list")
+        })
+        .expect("the list field offers an Add")
+}
+
+#[test]
+fn a_scalar_row_on_the_card_writes_the_definition_behind_its_handle() {
+    let (mut app, _tmp) = app_with_open_definition();
+
+    let widget = field_widget(&mut app, "health");
+    app.world_mut().trigger(ValueChange {
+        source: widget,
+        value: 40.0_f64,
+        is_final: true,
+    });
+    for _ in 0..4 {
+        app.update();
+    }
+
+    assert_eq!(open_mob(&app).health, 40, "the row wrote the asset");
+    let open = app.world().resource::<OpenDefinition>().0.expect("open");
+    assert!(
+        app.world()
+            .get::<DefinitionAssetEdit>(open)
+            .is_some_and(|edit| edit.dirty),
+        "and the card knows it has something to save",
+    );
+}
+
+fn unsaved_marker_display(app: &mut App) -> Display {
+    let marker = all_entities(app)
+        .into_iter()
+        .find(|entity| {
+            app.world()
+                .get::<Text>(*entity)
+                .is_some_and(|text| text.0 == "Unsaved")
+        })
+        .expect("the card header carries an unsaved marker");
+    app.world()
+        .get::<Node>(marker)
+        .expect("the marker lays out as a node")
+        .display
+}
+
+#[test]
+fn the_header_marks_unsaved_edits_and_clears_the_mark_once_the_file_is_written() {
+    let (mut app, _tmp) = app_with_open_definition();
+    assert_eq!(unsaved_marker_display(&mut app), Display::None);
+
+    let widget = field_widget(&mut app, "health");
+    app.world_mut().trigger(ValueChange {
+        source: widget,
+        value: 12.0_f64,
+        is_final: true,
+    });
+    for _ in 0..4 {
+        app.update();
+    }
+    assert_eq!(
+        unsaved_marker_display(&mut app),
+        Display::Flex,
+        "an edit that has not reached the file says so"
+    );
+
+    let result = app
+        .world_mut()
+        .operator("asset.save")
+        .settings(CallOperatorSettings {
+            execution_context: ExecutionContext::Invoke,
+            creates_history_entry: true,
+        })
+        .call()
+        .expect("the operator dispatched");
+    assert_eq!(result, OperatorResult::Finished);
+    for _ in 0..4 {
+        app.update();
+    }
+
+    assert_eq!(
+        unsaved_marker_display(&mut app),
+        Display::None,
+        "and stops saying so once it has"
+    );
+}
+
+#[test]
+fn a_drag_across_the_card_undoes_to_the_value_it_started_from() {
+    let (mut app, _tmp) = app_with_open_definition();
+    let widget = field_widget(&mut app, "health");
+    let before = app.world().resource::<CommandHistory>().undo_stack.len();
+
+    for value in [10.0_f64, 20.0] {
+        app.world_mut().trigger(ValueChange {
+            source: widget,
+            value,
+            is_final: false,
+        });
+        app.update();
+    }
+    app.world_mut().trigger(ValueChange {
+        source: widget,
+        value: 30.0_f64,
+        is_final: true,
+    });
+    for _ in 0..4 {
+        app.update();
+    }
+    assert_eq!(open_mob(&app).health, 30);
+    assert_eq!(
+        app.world().resource::<CommandHistory>().undo_stack.len(),
+        before + 1,
+        "the ticks of a drag mint no history of their own"
+    );
+
+    app.world_mut()
+        .resource_scope(|world, mut history: Mut<CommandHistory>| {
+            history.undo(world);
+        });
+
+    assert_eq!(
+        open_mob(&app).health,
+        0,
+        "undo goes back to before the drag, not to its last tick"
+    );
+}
+
+#[test]
+fn the_list_controls_add_a_row_to_the_definitions_list() {
+    let (mut app, _tmp) = app_with_open_definition();
+    assert!(open_mob(&app).loot.is_empty());
+
+    let add = add_button(&mut app);
+    app.world_mut().trigger(ButtonClickEvent { entity: add });
+    for _ in 0..10 {
+        app.update();
+    }
+
+    assert_eq!(
+        open_mob(&app).loot.len(),
+        1,
+        "Add put one entry on the definition's list"
+    );
+    let row = field_widget(&mut app, "loot[0].weight");
+    assert!(
+        jackdaw::inspector::field_edited_by(app.world(), row).is_some(),
+        "and the card rebuilt with a row for it",
+    );
+}

--- a/tests/inspector/main.rs
+++ b/tests/inspector/main.rs
@@ -9,6 +9,7 @@ mod util;
 
 mod bindings_card;
 mod bindings_link;
+mod definition_card;
 mod inspector_panel_width;
 mod inspector_preview_guard;
 mod inspector_val;

--- a/tests/stage/definition_assets.rs
+++ b/tests/stage/definition_assets.rs
@@ -1,0 +1,561 @@
+//! Definition assets: a registered asset type edited as files in the project.
+//!
+//! A definition type claims a directory and a suffix, and its files are
+//! created, edited, saved and listed through the same operators whether the
+//! edit comes from the inspector or from a caller with no viewport.
+
+use crate::util;
+
+use bevy::asset::{Asset, Assets, UntypedHandle};
+use bevy::prelude::*;
+use jackdaw::definition_assets::{
+    DefinitionAssetEdit, DefinitionRegistry, MATERIAL_KIND, OpenDefinition,
+};
+use jackdaw_api::prelude::*;
+use jackdaw_api_internal::operator::{CallOperatorSettings, ExecutionContext};
+use jackdaw_commands::CommandHistory;
+use jackdaw_scene_types::PropertyValue;
+
+#[derive(Reflect, Clone, Default, PartialEq, Debug)]
+#[reflect(Default)]
+struct LootRoll {
+    item: String,
+    weight: u32,
+}
+
+#[derive(Reflect, Clone, Default, PartialEq, Debug)]
+#[reflect(Default)]
+enum Rarity {
+    #[default]
+    Common,
+    Rare,
+}
+
+#[derive(Asset, Reflect, Clone, Default)]
+#[reflect(Default)]
+struct ItemDef {
+    stack_size: u32,
+    rarity: Rarity,
+    loot: Vec<LootRoll>,
+}
+
+fn item_type() -> DefinitionAssetType {
+    DefinitionAssetType::new(
+        "item",
+        "Item",
+        ItemDef::type_path(),
+        "content/items",
+        ".item.bsn",
+    )
+}
+
+/// An editor with a project of its own and one definition type registered.
+fn editor_with_items() -> (App, tempfile::TempDir) {
+    let tmp = tempfile::tempdir().expect("tempdir");
+    let mut app = util::editor_test_app();
+    app.init_asset::<ItemDef>();
+    app.register_asset_reflect::<ItemDef>();
+    app.register_type::<ItemDef>();
+    app.register_type::<LootRoll>();
+    app.register_type::<Rarity>();
+    app.world_mut()
+        .insert_resource(jackdaw::project::ProjectRoot {
+            root: tmp.path().to_path_buf(),
+            config: default(),
+        });
+    app.world_mut()
+        .resource_mut::<DefinitionAssetTypes>()
+        .register(item_type());
+    app.world_mut()
+        .resource_mut::<NextState<jackdaw::AppState>>()
+        .set(jackdaw::AppState::Editor);
+    app.update();
+    (app, tmp)
+}
+
+#[track_caller]
+fn call(app: &mut App, id: &'static str, params: &[(&'static str, PropertyValue)]) {
+    let mut call = app.world_mut().operator(id).settings(CallOperatorSettings {
+        execution_context: ExecutionContext::Invoke,
+        creates_history_entry: true,
+    });
+    for (key, value) in params {
+        call = call.param(*key, value.clone());
+    }
+    let result = call.call().expect("the operator dispatched");
+    assert_eq!(result, OperatorResult::Finished, "{id} did not finish");
+    app.update();
+}
+
+fn open_item(app: &App) -> ItemDef {
+    let entity = app
+        .world()
+        .resource::<OpenDefinition>()
+        .0
+        .expect("a definition is open");
+    let handle = app
+        .world()
+        .get::<DefinitionAssetEdit>(entity)
+        .expect("the entity is editing a definition")
+        .handle
+        .clone();
+    item_of(app, &handle)
+}
+
+fn item_of(app: &App, handle: &UntypedHandle) -> ItemDef {
+    app.world()
+        .resource::<Assets<ItemDef>>()
+        .get(&handle.clone().typed::<ItemDef>())
+        .expect("the definition is in its store")
+        .clone()
+}
+
+#[test]
+fn a_definition_is_created_edited_and_saved_through_its_operators() {
+    let (mut app, tmp) = editor_with_items();
+
+    call(
+        &mut app,
+        "asset.new",
+        &[("type", "item".into()), ("name", "torch".into())],
+    );
+    let path = tmp.path().join("assets/content/items/torch.item.bsn");
+    assert!(path.is_file(), "asset.new writes the file at {path:?}");
+
+    call(
+        &mut app,
+        "asset.set",
+        &[("field", "stack_size".into()), ("value", "12".into())],
+    );
+    call(
+        &mut app,
+        "asset.set",
+        &[("field", "rarity".into()), ("value", "Rare".into())],
+    );
+    call(
+        &mut app,
+        "asset.set",
+        &[
+            ("field", "loot".into()),
+            ("value", r#"[{"item":"coin","weight":3}]"#.into()),
+        ],
+    );
+
+    let edited = open_item(&app);
+    assert_eq!(edited.stack_size, 12);
+    assert_eq!(edited.rarity, Rarity::Rare);
+    assert_eq!(
+        edited.loot,
+        vec![LootRoll {
+            item: "coin".into(),
+            weight: 3
+        }]
+    );
+
+    call(&mut app, "asset.save", &[]);
+    let written = std::fs::read_to_string(&path).expect("the file reads");
+    assert!(written.contains("stack_size: 12"), "got:\n{written}");
+    assert!(written.contains("Rare"), "got:\n{written}");
+    assert!(written.contains("coin"), "got:\n{written}");
+
+    app.world_mut()
+        .resource_mut::<DefinitionRegistry>()
+        .remove("item", "torch");
+    let scan = jackdaw::definition_assets::rescan_definitions(app.world_mut());
+    assert_eq!(scan.added, vec![("item".to_string(), "torch".to_string())]);
+    let reloaded = {
+        let handle = app
+            .world()
+            .resource::<DefinitionRegistry>()
+            .get("item", "torch")
+            .expect("the scan found it")
+            .handle
+            .clone();
+        item_of(&app, &handle)
+    };
+    assert_eq!(reloaded.stack_size, 12);
+    assert_eq!(reloaded.rarity, Rarity::Rare);
+    assert_eq!(reloaded.loot.len(), 1);
+}
+
+#[test]
+fn undo_takes_back_one_definition_field_edit() {
+    let (mut app, _tmp) = editor_with_items();
+    call(
+        &mut app,
+        "asset.new",
+        &[("type", "item".into()), ("name", "torch".into())],
+    );
+    call(
+        &mut app,
+        "asset.set",
+        &[("field", "stack_size".into()), ("value", "12".into())],
+    );
+    assert_eq!(open_item(&app).stack_size, 12);
+
+    app.world_mut()
+        .resource_scope(|world, mut history: Mut<CommandHistory>| {
+            history.undo(world);
+        });
+
+    assert_eq!(
+        open_item(&app).stack_size,
+        0,
+        "undo restores what the field held before the edit"
+    );
+}
+
+#[test]
+fn undo_reaches_the_definition_after_its_card_is_closed() {
+    let (mut app, _tmp) = editor_with_items();
+    call(
+        &mut app,
+        "asset.new",
+        &[("type", "item".into()), ("name", "torch".into())],
+    );
+    call(
+        &mut app,
+        "asset.set",
+        &[("field", "stack_size".into()), ("value", "12".into())],
+    );
+    let handle = app
+        .world()
+        .resource::<DefinitionRegistry>()
+        .get("item", "torch")
+        .expect("the definition is registered")
+        .handle
+        .clone();
+
+    jackdaw::definition_assets::close_open_definition(app.world_mut());
+    app.update();
+    assert!(app.world().resource::<OpenDefinition>().0.is_none());
+
+    app.world_mut()
+        .resource_scope(|world, mut history: Mut<CommandHistory>| {
+            history.undo(world);
+        });
+
+    assert_eq!(
+        item_of(&app, &handle).stack_size,
+        0,
+        "the entry is keyed by handle, so it outlives the card"
+    );
+}
+
+#[test]
+fn a_scene_entity_edit_still_lands_while_a_definition_is_open() {
+    let (mut app, _tmp) = editor_with_items();
+    let node = app
+        .world_mut()
+        .spawn((Name::new("Target"), Node::default()))
+        .id();
+    jackdaw::scene_io::register_entity_in_ast(app.world_mut(), node);
+    app.update();
+
+    call(
+        &mut app,
+        "asset.new",
+        &[("type", "item".into()), ("name", "torch".into())],
+    );
+
+    let result = app
+        .world_mut()
+        .operator("field.set")
+        .param("entity", node)
+        .param("type_path", Node::type_path().to_string())
+        .param("field", "width".to_string())
+        .param("value", "{\"Px\":120.0}".to_string())
+        .call()
+        .expect("field.set dispatches");
+    assert_eq!(result, OperatorResult::Finished);
+    app.update();
+
+    assert_eq!(
+        app.world().get::<Node>(node).map(|node| node.width),
+        Some(Val::Px(120.0)),
+        "the edit reached the entity it named"
+    );
+    assert_eq!(
+        open_item(&app).stack_size,
+        0,
+        "and left the open definition alone"
+    );
+}
+
+#[test]
+fn a_definition_saves_back_to_the_file_it_was_opened_from() {
+    let (mut app, tmp) = editor_with_items();
+    let handle = app
+        .world_mut()
+        .resource_mut::<Assets<ItemDef>>()
+        .add(ItemDef::default());
+    let flat = jackdaw::definition_assets::write_definition_file(
+        app.world(),
+        &item_type(),
+        "sword",
+        &handle.untyped(),
+    )
+    .expect("the file is written");
+    let nested = tmp
+        .path()
+        .join("assets/content/items/weapons/sword.item.bsn");
+    std::fs::create_dir_all(nested.parent().expect("a parent")).expect("the directory is made");
+    std::fs::rename(&flat, &nested).expect("the file moves into its subdirectory");
+
+    call(
+        &mut app,
+        "asset.open",
+        &[("path", nested.to_string_lossy().into_owned().into())],
+    );
+    call(
+        &mut app,
+        "asset.set",
+        &[("field", "stack_size".into()), ("value", "5".into())],
+    );
+    call(&mut app, "asset.save", &[]);
+
+    let written = std::fs::read_to_string(&nested).expect("the file reads");
+    assert!(written.contains("stack_size: 5"), "got:\n{written}");
+    assert!(
+        !flat.exists(),
+        "the save does not leave a second file where the name alone would put it"
+    );
+}
+
+#[test]
+fn deleting_a_definition_closes_its_card_and_drops_the_entry() {
+    let (mut app, tmp) = editor_with_items();
+    call(
+        &mut app,
+        "asset.new",
+        &[("type", "item".into()), ("name", "torch".into())],
+    );
+    let path = tmp.path().join("assets/content/items/torch.item.bsn");
+
+    call(
+        &mut app,
+        "asset.delete",
+        &[("path", path.to_string_lossy().into_owned().into())],
+    );
+
+    assert!(!path.exists(), "the file is gone");
+    assert!(app.world().resource::<OpenDefinition>().0.is_none());
+    assert!(
+        app.world()
+            .resource::<DefinitionRegistry>()
+            .get("item", "torch")
+            .is_none()
+    );
+}
+
+#[test]
+fn creating_a_definition_refuses_a_name_whose_file_is_already_there() {
+    let (mut app, tmp) = editor_with_items();
+    let path = tmp.path().join("assets/content/items/torch.item.bsn");
+    std::fs::create_dir_all(path.parent().expect("a parent")).expect("the directory is made");
+    std::fs::write(&path, "#torch ItemDef(stack_size: 7)\n").expect("the file is written");
+
+    call(
+        &mut app,
+        "asset.new",
+        &[("type", "item".into()), ("name", "torch".into())],
+    );
+
+    assert_eq!(
+        std::fs::read_to_string(&path).expect("the file reads"),
+        "#torch ItemDef(stack_size: 7)\n",
+        "the file that was already there is left alone"
+    );
+}
+
+#[test]
+fn unregistering_a_definition_type_drops_its_entries_and_closes_the_card() {
+    let (mut app, _tmp) = editor_with_items();
+    call(
+        &mut app,
+        "asset.new",
+        &[("type", "item".into()), ("name", "torch".into())],
+    );
+    assert!(app.world().resource::<OpenDefinition>().0.is_some());
+
+    app.world_mut()
+        .resource_mut::<DefinitionAssetTypes>()
+        .unregister("item");
+    app.update();
+
+    assert!(
+        app.world().resource::<OpenDefinition>().0.is_none(),
+        "the card goes with the type that registered it"
+    );
+    assert!(
+        app.world()
+            .resource::<DefinitionRegistry>()
+            .names_of("item")
+            .is_empty()
+    );
+}
+
+#[test]
+fn a_material_file_is_not_deleted_through_the_definition_operator() {
+    let (mut app, tmp) = editor_with_items();
+    let handle = app
+        .world_mut()
+        .resource_mut::<Assets<StandardMaterial>>()
+        .add(StandardMaterial::default());
+    jackdaw::material_assets::write_material_file(app.world(), "slate", &handle)
+        .expect("the material file is written");
+    let path = tmp.path().join("assets/materials/slate.material.bsn");
+
+    call(
+        &mut app,
+        "asset.delete",
+        &[("path", path.to_string_lossy().into_owned().into())],
+    );
+
+    assert!(
+        path.is_file(),
+        "materials are removed by the tool that keeps their registry in step"
+    );
+}
+
+#[test]
+fn a_definition_file_reports_its_registered_kind() {
+    let (app, _tmp) = editor_with_items();
+    let types = app.world().resource::<DefinitionAssetTypes>();
+    let matched = types
+        .for_file(std::path::Path::new("assets/content/items/torch.item.bsn"))
+        .expect("a registered type claims the file");
+    assert_eq!(matched.kind, "item");
+    assert!(
+        types
+            .for_file(std::path::Path::new("assets/scenes/level.bsn"))
+            .is_none(),
+        "a plain scene is still a scene"
+    );
+}
+
+/// Materials are loaded with their textures by the material browser, and the
+/// definition registry lists them alongside every other kind.
+#[test]
+fn the_material_directory_still_loads_and_lists_as_a_definition() {
+    let (mut app, tmp) = editor_with_items();
+    let handle = app
+        .world_mut()
+        .resource_mut::<Assets<StandardMaterial>>()
+        .add(StandardMaterial {
+            perceptual_roughness: 0.31,
+            ..default()
+        });
+    jackdaw::material_assets::write_material_file(app.world(), "slate", &handle)
+        .expect("the material file is written");
+    assert!(
+        tmp.path()
+            .join("assets/materials/slate.material.bsn")
+            .is_file()
+    );
+
+    let scan = jackdaw::material_assets::rescan_material_files(app.world_mut());
+    assert_eq!(scan.added, vec!["slate".to_string()]);
+    app.world_mut()
+        .resource_mut::<jackdaw::material_assets::MaterialRegistry>()
+        .add_saved("slate".to_string(), handle);
+    app.update();
+
+    let entry_path = app
+        .world()
+        .resource::<DefinitionRegistry>()
+        .get(MATERIAL_KIND, "slate")
+        .expect("the material lists as a definition")
+        .path
+        .clone();
+    assert_eq!(
+        entry_path,
+        tmp.path().join("assets/materials/slate.material.bsn")
+    );
+}
+
+#[test]
+fn a_material_saved_by_its_own_operator_carries_what_asset_set_wrote() {
+    let (mut app, tmp) = editor_with_items();
+    let handle = app
+        .world_mut()
+        .resource_mut::<Assets<StandardMaterial>>()
+        .add(StandardMaterial::default());
+    jackdaw::material_assets::write_material_file(app.world(), "slate", &handle)
+        .expect("the material file is written");
+    app.world_mut()
+        .resource_mut::<jackdaw::material_assets::MaterialRegistry>()
+        .add_saved("slate".to_string(), handle.clone());
+    app.world_mut()
+        .insert_resource(jackdaw::material_preview::MaterialPreviewState {
+            active_material: Some(handle),
+            ..default()
+        });
+    app.update();
+
+    call(
+        &mut app,
+        "asset.open",
+        &[("path", "assets/materials/slate.material.bsn".into())],
+    );
+    call(
+        &mut app,
+        "asset.set",
+        &[("field", "metallic".into()), ("value", "0.75".into())],
+    );
+    call(&mut app, "material.save", &[("material", "slate".into())]);
+    app.update();
+
+    let written = std::fs::read_to_string(tmp.path().join("assets/materials/slate.material.bsn"))
+        .expect("the file reads");
+    assert!(written.contains("metallic: 0.75"), "got:\n{written}");
+}
+
+/// A material's fields are filled in through the definition operators, with
+/// no panel in the way.
+#[test]
+fn a_material_is_opened_and_its_fields_set_through_the_definition_operators() {
+    let (mut app, tmp) = editor_with_items();
+    let handle = app
+        .world_mut()
+        .resource_mut::<Assets<StandardMaterial>>()
+        .add(StandardMaterial::default());
+    jackdaw::material_assets::write_material_file(app.world(), "slate", &handle)
+        .expect("the material file is written");
+    app.world_mut()
+        .resource_mut::<jackdaw::material_assets::MaterialRegistry>()
+        .add_saved("slate".to_string(), handle.clone());
+    app.update();
+
+    call(
+        &mut app,
+        "asset.open",
+        &[("path", "assets/materials/slate.material.bsn".into())],
+    );
+    call(
+        &mut app,
+        "asset.set",
+        &[
+            ("field", "perceptual_roughness".into()),
+            ("value", "0.25".into()),
+        ],
+    );
+    call(&mut app, "asset.save", &[]);
+
+    let roughness = app
+        .world()
+        .resource::<Assets<StandardMaterial>>()
+        .get(&handle)
+        .expect("the material the scene is using")
+        .perceptual_roughness;
+    assert!(
+        (roughness - 0.25).abs() < f32::EPSILON,
+        "the edit lands on the loaded material, not on a copy"
+    );
+    let written = std::fs::read_to_string(tmp.path().join("assets/materials/slate.material.bsn"))
+        .expect("the file reads");
+    assert!(
+        written.contains("perceptual_roughness: 0.25"),
+        "got:\n{written}"
+    );
+}

--- a/tests/stage/main.rs
+++ b/tests/stage/main.rs
@@ -14,6 +14,7 @@ mod animation_timeline;
 mod brush_ops;
 mod canvas_guides;
 mod canvas_snap;
+mod definition_assets;
 mod gltf_authoring;
 mod mesh_quick_menu;
 mod modeling_essentials;


### PR DESCRIPTION
Jackdaw can now treat a reflected asset type as project content. An extension registers a type with a directory and a file suffix, and the editor scans and watches that directory, keeps the loaded values by name, and writes them back through the same default-diffing BSN save the catalog uses. The material directory registers as one of those kinds, so saved materials browse, open and save through the same registry instead of a second path of their own.

A file whose suffix belongs to a registered type opens in the inspector rather than a scene tab. It gets the ordinary reflected card, because the field rows now read and commit an asset behind a handle exactly as they read and commit a component: scalars, enum menus and list add, move and remove all work with no panel written for them. Edits go through the existing field-edit history, and the card header carries Save and says when there is something to save.

The same work is reachable with no viewport through `asset.new`, `asset.open`, `asset.save`, `asset.delete`, `asset.set` and `asset.list`, and the assets listing over the remote reports a registered type's own kind for its files.

LLM disclaimer: Claude Code was used to help plan and implement this change, but all code was human reviewed by myself!
