### PR TITLE
Start every native dialog in the folder being browsed

### DIFF
--- a/book/src/user-guide/scene-management.md
+++ b/book/src/user-guide/scene-management.md
@@ -11,10 +11,20 @@ normal Bevy crate: a folder with a `Cargo.toml`, a
 - `Ctrl+S` saves the current scene to its on-disk path. The
   first save prompts for a path; pick something under
   `assets/`.
-- `Ctrl+O` opens a scene in a new tab. The picker starts in the
-  current project's `assets/` folder.
+- `Ctrl+O` opens a scene in a new tab.
 - `Ctrl+T` creates a new empty scene tab; it is
   unsaved until you `Ctrl+S` it.
+
+The dialogs that reach for project files -- opening and saving
+scenes, picking a prefab, a reference image, a preview model or
+a texture -- start in the folder you are already looking at: the
+asset browser's folder while it points inside the project,
+otherwise the folder of the scene you have open, otherwise the
+project's `assets/`. Installing an extension bundle instead
+starts where you picked the last bundle from, since bundles
+live outside the project. Either way the folder you pick from
+is recorded in `.jackdaw/project.json` and read back when you
+reopen the project.
 
 Scene files are human-readable, line-diffable, and designed to
 read in `git diff` without making you cry. Legacy `.jsn` scenes

--- a/src/asset_browser.rs
+++ b/src/asset_browser.rs
@@ -10,7 +10,7 @@ use bevy::{
     prelude::*,
     render::render_resource::{Extent3d, TextureDimension, TextureSampleType},
     tasks::{AsyncComputeTaskPool, Task, futures_lite::future},
-    window::{PrimaryWindow, RawHandleWrapper, SystemCursorIcon},
+    window::{PrimaryWindow, SystemCursorIcon},
 };
 use jackdaw_feathers::button::{
     ButtonClickEvent, ButtonOperatorCall, ButtonProps, ButtonVariant, IconButtonProps, button,
@@ -21,7 +21,6 @@ use jackdaw_feathers::tooltip::Tooltip;
 use jackdaw_feathers::{file_browser, icons, icons::EditorFont, icons::IconFont, tokens};
 use jackdaw_widgets::file_browser::{FileBrowserItem, FileItemDoubleClicked};
 use path_slash::PathExt as _;
-use rfd::AsyncFileDialog;
 
 use crate::{
     EditorEntity,
@@ -358,6 +357,18 @@ impl Default for AssetBrowserState {
             last_click_time: 0.0,
             prefabs_only: false,
             kind_cache: crate::asset_files::AssetKindCache::default(),
+        }
+    }
+}
+
+impl AssetBrowserState {
+    /// A browser rooted at `directory` and showing it.
+    pub fn at(directory: impl Into<PathBuf>) -> Self {
+        let directory = directory.into();
+        Self {
+            current_directory: directory.clone(),
+            root_directory: directory,
+            ..Self::default()
         }
     }
 }
@@ -1871,20 +1882,18 @@ pub(crate) fn asset_cycle_array_layer(
     label = "Select Assets Folder",
     description = "Choose a different folder as the assets directory."
 )]
-pub fn asset_select_folder(
-    _: In<OperatorParameters>,
-    mut commands: Commands,
-    raw_handle: Query<&RawHandleWrapper, With<PrimaryWindow>>,
-) -> OperatorResult {
-    let mut dialog = AsyncFileDialog::new().set_title("Select assets directory");
-    if let Ok(rh) = raw_handle.single() {
-        // SAFETY: the primary window is open, so its `RawHandleWrapper`
-        // points to a live OS handle. We use the returned wrapper only
-        // to parent the modal dialog within this scope.
-        let handle = unsafe { rh.get_handle() };
-        dialog = dialog.set_parent(&handle);
-    }
-    let task = AsyncComputeTaskPool::get().spawn(async move { dialog.pick_folder().await });
-    commands.insert_resource(AssetBrowserFolderTask(task));
+pub fn asset_select_folder(_: In<OperatorParameters>, mut commands: Commands) -> OperatorResult {
+    commands.queue(|world: &mut World| {
+        if world.contains_resource::<AssetBrowserFolderTask>() {
+            return;
+        }
+        let current = world
+            .get_resource::<AssetBrowserState>()
+            .map(|state| state.current_directory.clone());
+        let dialog = crate::native_dialog::dialog_starting_at(world, current)
+            .set_title("Select assets directory");
+        let task = AsyncComputeTaskPool::get().spawn(async move { dialog.pick_folder().await });
+        world.insert_resource(AssetBrowserFolderTask(task));
+    });
     OperatorResult::Finished
 }

--- a/src/extensions_dialog.rs
+++ b/src/extensions_dialog.rs
@@ -24,7 +24,7 @@ use jackdaw_feathers::{
     dialog::{CloseDialogEvent, DialogChildrenSlot, OpenDialogEvent},
     tooltip::Tooltip,
 };
-use rfd::{AsyncFileDialog, FileHandle};
+use rfd::FileHandle;
 #[cfg(feature = "dylib")]
 use rfd::{MessageButtons, MessageDialog, MessageDialogResult, MessageLevel};
 
@@ -371,8 +371,12 @@ fn install_button() -> impl Scene {
                 if world.resource::<InstallStatus>().task.is_some() {
                     return;
                 }
-                let dialog =
-                    AsyncFileDialog::new().add_filter("Jackdaw extension bundle", &["jdext"]);
+                let dialog = crate::native_dialog::file_dialog(
+                    world,
+                    crate::native_dialog::DialogPurpose::Bundle,
+                )
+                .set_title("Select extension bundle")
+                .add_filter("Jackdaw extension bundle", &["jdext"]);
                 let task =
                     AsyncComputeTaskPool::get().spawn(async move { dialog.pick_file().await });
                 world.resource_mut::<InstallStatus>().task = Some(task);
@@ -408,6 +412,11 @@ fn poll_install_task(
         Some(picked) => {
             let src = picked.path().to_path_buf();
             commands.queue(move |world: &mut World| {
+                crate::native_dialog::remember_pick(
+                    world,
+                    crate::native_dialog::DialogPurpose::Bundle,
+                    &src,
+                );
                 if let Err(err) = world.run_system_cached_with(handle_install, src) {
                     error!("Failed to install extension: {err}");
                 }

--- a/src/inspector/type_metadata_pane.rs
+++ b/src/inspector/type_metadata_pane.rs
@@ -6,14 +6,13 @@ use bevy::picking::hover::Hovered;
 use bevy::prelude::*;
 use bevy::tasks::{AsyncComputeTaskPool, Task, futures_lite::future};
 use bevy::ui_widgets::{Activate, ToggleChecked};
-use bevy::window::{PrimaryWindow, RawHandleWrapper, SystemCursorIcon};
+use bevy::window::SystemCursorIcon;
 use jackdaw_feathers::icons::{Icon, icon_scene};
 use jackdaw_feathers::text_edit::{self, TextEditCommitEvent, TextEditProps};
 use jackdaw_feathers::tokens;
 use jackdaw_feathers::tooltip::Tooltip;
 use jackdaw_feathers::utils::find_ancestor;
 use jackdaw_widgets::collapsible::CollapsibleSection;
-use rfd::AsyncFileDialog;
 
 use crate::preview_model::import_preview_model;
 use crate::project::ProjectRoot;
@@ -380,25 +379,10 @@ fn open_preview_picker(world: &mut World, type_path: String) {
     if world.contains_resource::<PreviewPickTask>() {
         return;
     }
-    let assets_dir = world
-        .get_resource::<ProjectRoot>()
-        .map(ProjectRoot::assets_dir);
-    let raw_handle = world
-        .query_filtered::<&RawHandleWrapper, With<PrimaryWindow>>()
-        .single(world)
-        .ok()
-        .cloned();
-    let mut dialog = AsyncFileDialog::new()
-        .set_title("Select preview model")
-        .add_filter("glTF", &["glb", "gltf"]);
-    if let Some(dir) = &assets_dir {
-        dialog = dialog.set_directory(dir);
-    }
-    if let Some(ref rh) = raw_handle {
-        // SAFETY: called on the main thread from an exclusive context
-        let handle = unsafe { rh.get_handle() };
-        dialog = dialog.set_parent(&handle);
-    }
+    let dialog =
+        crate::native_dialog::file_dialog(world, crate::native_dialog::DialogPurpose::Model)
+            .set_title("Select preview model")
+            .add_filter("glTF", &["glb", "gltf"]);
     let task = AsyncComputeTaskPool::get().spawn(async move { dialog.pick_file().await });
     world.insert_resource(PreviewPickTask { type_path, task });
 }
@@ -416,6 +400,7 @@ fn poll_preview_pick(world: &mut World) {
         return;
     };
     let picked = file_handle.path().to_path_buf();
+    crate::native_dialog::remember_pick(world, crate::native_dialog::DialogPurpose::Model, &picked);
     let Some(project) = world.get_resource::<ProjectRoot>() else {
         return;
     };

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -89,6 +89,7 @@ pub mod modal_inputs;
 pub mod modal_transform;
 pub mod model_thumbnail;
 pub mod modifier_ops;
+pub mod native_dialog;
 pub mod new_project;
 pub mod numeric_transform;
 pub mod operator_tooltip;
@@ -466,6 +467,7 @@ impl Plugin for EditorCorePlugin {
             remote::debug::RemoteDebugPlugin,
             camera_settings::plugin,
         ))
+        .add_plugins(native_dialog::NativeDialogPlugin)
         .add_plugins(definition_assets::plugin)
         .add_plugins(model_thumbnail::plugin)
         .add_plugins(boot_ops::plugin)

--- a/src/material_browser.rs
+++ b/src/material_browser.rs
@@ -5,7 +5,6 @@ use bevy::{
     image::ImageLoaderSettings,
     prelude::*,
     tasks::{AsyncComputeTaskPool, Task, futures_lite::future},
-    window::{PrimaryWindow, RawHandleWrapper},
 };
 use jackdaw_feathers::{
     button::{ButtonOperatorCall, ButtonVariant, IconButtonProps, icon_button},
@@ -15,7 +14,6 @@ use jackdaw_feathers::{
     tokens,
 };
 use path_slash::PathExt as _;
-use rfd::AsyncFileDialog;
 
 use crate::brush::LastUsedMaterial;
 use crate::material_ui::{
@@ -713,29 +711,54 @@ fn handle_browse_texture_slot(
     event: On<BrowseTextureSlot>,
     mut commands: Commands,
     existing_task: Option<Res<TextureSlotPickTask>>,
-    raw_handle: Query<&RawHandleWrapper, With<PrimaryWindow>>,
 ) {
     if existing_task.is_some() {
         return;
     }
     let slot = event.slot;
     let material_handle = event.material_handle.clone();
-    let mut dialog = AsyncFileDialog::new()
+    commands.queue(move |world: &mut World| {
+        if world.contains_resource::<TextureSlotPickTask>() {
+            return;
+        }
+        let directory = material_file_directory(world, &material_handle);
+        let dialog = match directory {
+            Some(directory) => crate::native_dialog::dialog_starting_at(world, Some(directory)),
+            None => crate::native_dialog::file_dialog(
+                world,
+                crate::native_dialog::DialogPurpose::Texture,
+            ),
+        }
         .set_title(format!("Select image for {}", slot.field()))
         .add_filter(
             "Images",
             &["png", "jpg", "jpeg", "ktx2", "bmp", "tga", "webp"],
         );
-    if let Ok(rh) = raw_handle.single() {
-        let handle = unsafe { rh.get_handle() };
-        dialog = dialog.set_parent(&handle);
-    }
-    let task = AsyncComputeTaskPool::get().spawn(async move { dialog.pick_file().await });
-    commands.insert_resource(TextureSlotPickTask {
-        task,
-        slot,
-        material_handle,
+        let task = AsyncComputeTaskPool::get().spawn(async move { dialog.pick_file().await });
+        world.insert_resource(TextureSlotPickTask {
+            task,
+            slot,
+            material_handle,
+        });
     });
+}
+
+/// The folder holding the material's own asset file, when it came from one.
+fn material_file_directory(
+    world: &World,
+    material_handle: &Handle<StandardMaterial>,
+) -> Option<PathBuf> {
+    let asset_server = world.get_resource::<AssetServer>()?;
+    let asset_path = asset_server.get_path(material_handle.id())?;
+    let assets_root = crate::project::open_project_assets_dir()?;
+    texture_browse_directory(&assets_root, asset_path.path())
+}
+
+/// The folder a texture browse starts in for a material stored at
+/// `material_path`, relative to `assets_root`.
+fn texture_browse_directory(assets_root: &Path, material_path: &Path) -> Option<PathBuf> {
+    let directory = assets_root.join(material_path.parent()?);
+    directory.is_dir().then_some(directory)
 }
 
 fn poll_texture_slot_pick(world: &mut World) {
@@ -753,6 +776,7 @@ fn poll_texture_slot_pick(world: &mut World) {
         return;
     };
     let path = file_handle.path().to_path_buf();
+    crate::native_dialog::remember_pick(world, crate::native_dialog::DialogPurpose::Texture, &path);
     let fs_path = path.to_slash_lossy();
     let asset_path = crate::entity_ops::to_asset_path(&fs_path);
     let asset_server = world.resource::<AssetServer>().clone();
@@ -1157,22 +1181,19 @@ pub(crate) fn material_rescan(
     label = "Select Materials Folder",
     description = "Choose a different folder as the materials directory."
 )]
-pub fn material_select_folder(
-    _: In<OperatorParameters>,
-    mut commands: Commands,
-    raw_handle: Query<&bevy::window::RawHandleWrapper, With<bevy::window::PrimaryWindow>>,
-) -> OperatorResult {
-    let mut dialog = AsyncFileDialog::new().set_title("Select materials directory");
-    if let Ok(rh) = raw_handle.single() {
-        // SAFETY: the primary window is open, so its `RawHandleWrapper`
-        // points to a live OS handle. We use the returned wrapper only
-        // to parent the modal dialog within this scope.
-        let handle = unsafe { rh.get_handle() };
-        dialog = dialog.set_parent(&handle);
-    }
-    let task =
-        bevy::tasks::AsyncComputeTaskPool::get().spawn(async move { dialog.pick_folder().await });
-    commands.insert_resource(MaterialBrowserFolderTask(task));
+pub fn material_select_folder(_: In<OperatorParameters>, mut commands: Commands) -> OperatorResult {
+    commands.queue(|world: &mut World| {
+        if world.contains_resource::<MaterialBrowserFolderTask>() {
+            return;
+        }
+        let current = world
+            .get_resource::<MaterialBrowserState>()
+            .map(|state| state.scan_directory.clone());
+        let dialog = crate::native_dialog::dialog_starting_at(world, current)
+            .set_title("Select materials directory");
+        let task = AsyncComputeTaskPool::get().spawn(async move { dialog.pick_folder().await });
+        world.insert_resource(MaterialBrowserFolderTask(task));
+    });
     OperatorResult::Finished
 }
 
@@ -1237,6 +1258,27 @@ mod tests {
         app.init_asset::<Image>();
         app.init_asset::<StandardMaterial>();
         app
+    }
+
+    #[test]
+    fn a_texture_browse_starts_in_the_folder_holding_the_material() {
+        let dir = tempfile::tempdir().expect("a temporary directory");
+        let assets = dir.path();
+        std::fs::create_dir_all(assets.join("materials/stone")).expect("the material folder");
+
+        let start = texture_browse_directory(assets, Path::new("materials/stone/granite.bsn"))
+            .expect("a start directory");
+        assert_eq!(start, assets.join("materials/stone"));
+    }
+
+    #[test]
+    fn a_texture_browse_ignores_a_material_folder_that_is_not_there() {
+        let dir = tempfile::tempdir().expect("a temporary directory");
+
+        assert_eq!(
+            texture_browse_directory(dir.path(), Path::new("materials/gone/granite.bsn")),
+            None
+        );
     }
 
     fn detected(paths: &[&str]) -> jackdaw_material::MaterialSet {

--- a/src/native_dialog.rs
+++ b/src/native_dialog.rs
@@ -1,0 +1,279 @@
+//! Every native file and folder dialog in the editor is built here, so
+//! they all open parented to the main window and pointed at the folder
+//! the user is already browsing rather than at the home directory.
+
+use std::collections::BTreeMap;
+use std::path::{Path, PathBuf};
+
+use bevy::prelude::*;
+use bevy::window::{PrimaryWindow, RawHandleWrapper};
+use rfd::AsyncFileDialog;
+
+use crate::project::ProjectRoot;
+
+/// What a dialog is being opened for. Each purpose remembers the folder
+/// it was last used in.
+#[derive(Clone, Copy, PartialEq, Eq, Debug)]
+pub enum DialogPurpose {
+    Scene,
+    Prefab,
+    Image,
+    Texture,
+    Model,
+    Bundle,
+}
+
+impl DialogPurpose {
+    fn key(self) -> &'static str {
+        match self {
+            Self::Scene => "scene",
+            Self::Prefab => "prefab",
+            Self::Image => "image",
+            Self::Texture => "texture",
+            Self::Model => "model",
+            Self::Bundle => "bundle",
+        }
+    }
+
+    /// Whether this purpose picks files from outside the project, where the
+    /// folder the editor is browsing is no help and the last one used is.
+    fn looks_outside_the_project(self) -> bool {
+        matches!(self, Self::Bundle)
+    }
+}
+
+/// The folder each dialog purpose was last used in, kept for the session
+/// and written back to `.jackdaw/project.json` while a project is open.
+#[derive(Resource, Default)]
+pub struct DialogMemory {
+    folders: BTreeMap<String, PathBuf>,
+}
+
+impl DialogMemory {
+    pub fn folder(&self, purpose: DialogPurpose) -> Option<&Path> {
+        self.folders.get(purpose.key()).map(PathBuf::as_path)
+    }
+
+    pub fn remember(&mut self, purpose: DialogPurpose, directory: &Path) {
+        self.folders
+            .insert(purpose.key().to_string(), directory.to_path_buf());
+    }
+
+    pub fn folders(&self) -> &BTreeMap<String, PathBuf> {
+        &self.folders
+    }
+
+    pub fn restore(&mut self, folders: BTreeMap<String, PathBuf>) {
+        self.folders = folders;
+    }
+}
+
+pub struct NativeDialogPlugin;
+
+impl Plugin for NativeDialogPlugin {
+    fn build(&self, app: &mut App) {
+        app.init_resource::<DialogMemory>()
+            .add_systems(Update, restore_dialog_memory);
+    }
+}
+
+fn restore_dialog_memory(project: Option<Res<ProjectRoot>>, mut memory: ResMut<DialogMemory>) {
+    let Some(project) = project else {
+        return;
+    };
+    if !project.is_added() {
+        return;
+    }
+    memory.restore(project.config.dialog_directories.clone());
+}
+
+fn resolved(path: &Path) -> PathBuf {
+    dunce::canonicalize(path).unwrap_or_else(|_| path.to_path_buf())
+}
+
+fn existing_directory(path: &Path) -> Option<PathBuf> {
+    path.is_dir().then(|| path.to_path_buf())
+}
+
+fn project_root_path(world: &World) -> Option<PathBuf> {
+    world.get_resource::<ProjectRoot>().map(|p| p.root.clone())
+}
+
+/// Is `candidate` the project root or a folder under it? Both sides are
+/// resolved first so a symlinked `assets/` or a root reached by a
+/// different path still counts as inside.
+fn within_project(root: &Path, candidate: &Path) -> bool {
+    resolved(candidate).starts_with(resolved(root))
+}
+
+fn asset_browser_directory(world: &World) -> Option<PathBuf> {
+    let state = world.get_resource::<crate::asset_browser::AssetBrowserState>()?;
+    let directory = existing_directory(&state.current_directory)?;
+    let root = project_root_path(world)?;
+    within_project(&root, &directory).then_some(directory)
+}
+
+/// The folder of the file the editor currently has open: the active
+/// scene tab first, then whatever the last scene load or save touched.
+fn open_file_directory(world: &World) -> Option<PathBuf> {
+    let active_tab_path = world
+        .get_resource::<crate::scenes::Scenes>()
+        .and_then(|scenes| scenes.tabs.get(scenes.active))
+        .and_then(|tab| tab.path.clone());
+    let scene_file = world.get_resource::<crate::scene_io::SceneFilePath>();
+    let recorded_path = scene_file
+        .and_then(|scene| scene.path.as_ref())
+        .map(PathBuf::from);
+    let last_directory = scene_file.and_then(|scene| scene.last_directory.clone());
+
+    active_tab_path
+        .or(recorded_path)
+        .and_then(|path| path.parent().map(Path::to_path_buf))
+        .or(last_directory)
+        .as_deref()
+        .and_then(existing_directory)
+}
+
+fn project_directory(world: &World) -> Option<PathBuf> {
+    let project = world.get_resource::<ProjectRoot>()?;
+    existing_directory(&project.assets_dir()).or_else(|| existing_directory(&project.root))
+}
+
+/// The folder the user is looking at: the Asset Browser's folder while
+/// it points inside the project, else the open file's folder, else the
+/// project's `assets/`, else the project root.
+pub fn browsing_directory(world: &World) -> Option<PathBuf> {
+    asset_browser_directory(world)
+        .or_else(|| open_file_directory(world))
+        .or_else(|| project_directory(world))
+}
+
+/// Where a dialog opened for `purpose` should start. The Asset Browser
+/// wins for the purposes that read project files; the folder the purpose
+/// was last used in comes first for the ones that read files from outside
+/// the project, and otherwise fills in when the browser has nothing.
+pub fn start_directory(world: &World, purpose: DialogPurpose) -> Option<PathBuf> {
+    let remembered = remembered_directory(world, purpose);
+    if purpose.looks_outside_the_project() {
+        return remembered.or_else(|| browsing_directory(world));
+    }
+    asset_browser_directory(world)
+        .or(remembered)
+        .or_else(|| browsing_directory(world))
+}
+
+fn remembered_directory(world: &World, purpose: DialogPurpose) -> Option<PathBuf> {
+    world
+        .get_resource::<DialogMemory>()
+        .and_then(|memory| memory.folder(purpose))
+        .and_then(existing_directory)
+}
+
+fn primary_window_handle(world: &mut World) -> Option<RawHandleWrapper> {
+    world
+        .query_filtered::<&RawHandleWrapper, With<PrimaryWindow>>()
+        .single(world)
+        .ok()
+        .cloned()
+}
+
+/// Parent `dialog` to the editor window and start it in `directory`.
+pub fn dialog_at(directory: Option<PathBuf>, parent: Option<&RawHandleWrapper>) -> AsyncFileDialog {
+    let mut dialog = AsyncFileDialog::new();
+    if let Some(directory) = directory {
+        dialog = dialog.set_directory(directory);
+    }
+    if let Some(parent) = parent {
+        // SAFETY: called on the main thread, where the primary window's
+        // handle is live; it is only read to parent the dialog.
+        let handle = unsafe { parent.get_handle() };
+        dialog = dialog.set_parent(&handle);
+    }
+    dialog
+}
+
+/// An open dialog for `purpose`, started where the user is browsing.
+pub fn file_dialog(world: &mut World, purpose: DialogPurpose) -> AsyncFileDialog {
+    let directory = start_directory(world, purpose);
+    let parent = primary_window_handle(world);
+    dialog_at(directory, parent.as_ref())
+}
+
+/// A save dialog for `purpose`, started where the user is browsing and
+/// prefilled with `suggested_name`.
+pub fn save_dialog(
+    world: &mut World,
+    purpose: DialogPurpose,
+    suggested_name: &str,
+) -> AsyncFileDialog {
+    file_dialog(world, purpose).set_file_name(suggested_name)
+}
+
+/// A dialog started at `directory`, for the pickers that already hold
+/// the folder they are re-choosing.
+pub fn dialog_starting_at(world: &mut World, directory: Option<PathBuf>) -> AsyncFileDialog {
+    let directory = directory.as_deref().and_then(existing_directory);
+    let parent = primary_window_handle(world);
+    dialog_at(directory, parent.as_ref())
+}
+
+/// The folder to record for a dialog that returned `picked`: the pick
+/// itself when it is a folder, its parent when it is a file.
+fn picked_directory(picked: &Path) -> Option<PathBuf> {
+    if picked.is_dir() {
+        return Some(picked.to_path_buf());
+    }
+    picked.parent().map(Path::to_path_buf)
+}
+
+/// Record where a dialog for `purpose` ended up, so the next one starts
+/// there. Persisted with the project when one is open.
+pub fn remember_pick(world: &mut World, purpose: DialogPurpose, picked: &Path) {
+    let Some(directory) = picked_directory(picked) else {
+        return;
+    };
+    if let Some(mut memory) = world.get_resource_mut::<DialogMemory>() {
+        memory.remember(purpose, &directory);
+    }
+    let Some(folders) = world
+        .get_resource::<DialogMemory>()
+        .map(|memory| memory.folders().clone())
+    else {
+        return;
+    };
+    let Some(mut project) = world.get_resource_mut::<ProjectRoot>() else {
+        return;
+    };
+    if project.config.dialog_directories == folders {
+        return;
+    }
+    let root = project.root.clone();
+    let mut config = project.config.clone();
+    config.dialog_directories = folders;
+    match crate::project::save_project_config(&root, &config) {
+        Ok(()) => project.config = config,
+        Err(err) => warn!(
+            "Failed to persist the dialog folder for {}: {err}",
+            purpose.key()
+        ),
+    }
+}
+
+/// Where the launcher's project browser starts: beside the most recent
+/// project, else the default projects folder, else home.
+pub fn launcher_project_directory() -> Option<PathBuf> {
+    let recent = crate::project::read_recent_projects();
+    let beside_recent = recent
+        .projects
+        .first()
+        .and_then(|entry| entry.path.parent().map(Path::to_path_buf))
+        .and_then(|parent| existing_directory(&parent));
+    beside_recent
+        .or_else(|| {
+            dirs::home_dir()
+                .map(|home| home.join("Projects"))
+                .as_deref()
+                .and_then(existing_directory)
+        })
+        .or_else(|| dirs::home_dir().as_deref().and_then(existing_directory))
+}

--- a/src/prefab/operators.rs
+++ b/src/prefab/operators.rs
@@ -1132,31 +1132,13 @@ pub struct PrefabPickTask(bevy::tasks::Task<Option<rfd::FileHandle>>);
 /// Open the prefab file picker backing `entity.add.prefab`. No-op while a
 /// pick is already pending.
 pub fn open_prefab_picker(world: &mut World) {
-    use bevy::window::{PrimaryWindow, RawHandleWrapper};
-
     if world.contains_resource::<PrefabPickTask>() {
         return;
     }
-    let raw_handle = world
-        .query_filtered::<&RawHandleWrapper, With<PrimaryWindow>>()
-        .single(world)
-        .ok()
-        .cloned();
-    let mut dialog = rfd::AsyncFileDialog::new()
-        .set_title("Select prefab")
-        .add_filter("Prefab", &["bsn"]);
-    // Where `Save As Prefab` writes them, when a project is open.
-    if let Some(root) = world.get_resource::<crate::project::ProjectRoot>() {
-        let prefabs = root.root.join("assets/prefabs");
-        if prefabs.is_dir() {
-            dialog = dialog.set_directory(prefabs);
-        }
-    }
-    if let Some(ref handle) = raw_handle {
-        // SAFETY: called on the main thread from an exclusive context
-        let handle = unsafe { handle.get_handle() };
-        dialog = dialog.set_parent(&handle);
-    }
+    let dialog =
+        crate::native_dialog::file_dialog(world, crate::native_dialog::DialogPurpose::Prefab)
+            .set_title("Select prefab")
+            .add_filter("Prefab", &["bsn"]);
     let task =
         bevy::tasks::AsyncComputeTaskPool::get().spawn(async move { dialog.pick_file().await });
     world.insert_resource(PrefabPickTask(task));
@@ -1176,7 +1158,9 @@ pub fn poll_prefab_pick(world: &mut World) {
     let Some(file_handle) = result else {
         return;
     };
-    spawn_instance(world, file_handle.path(), Vec3::ZERO);
+    let path = file_handle.path().to_path_buf();
+    crate::native_dialog::remember_pick(world, crate::native_dialog::DialogPurpose::Prefab, &path);
+    spawn_instance(world, &path, Vec3::ZERO);
 }
 
 /// Add a new prefab instance to the live scene at `world_pos`. Caches the

--- a/src/project.rs
+++ b/src/project.rs
@@ -1,4 +1,5 @@
 use std::{
+    collections::BTreeMap,
     fs,
     path::{Path, PathBuf},
 };
@@ -72,6 +73,10 @@ pub struct ProjectConfig {
     /// Index into `last_open_tabs` of the tab that was active. Clamped on load.
     #[serde(default, skip_serializing_if = "is_zero")]
     pub last_active_tab: usize,
+    /// The folder each native dialog purpose was last used in, keyed by
+    /// purpose, so a dialog reopens where the user left it.
+    #[serde(default, skip_serializing_if = "BTreeMap::is_empty")]
+    pub dialog_directories: BTreeMap<String, PathBuf>,
 }
 
 fn is_zero(n: &usize) -> bool {

--- a/src/project_select.rs
+++ b/src/project_select.rs
@@ -14,7 +14,7 @@ use jackdaw_feathers::{
 };
 use jackdaw_localization::LocalizedText;
 use jackdaw_project_build::project_manifest;
-use rfd::{AsyncFileDialog, FileHandle};
+use rfd::FileHandle;
 
 use crate::{
     AppState,
@@ -1060,13 +1060,11 @@ fn pick_project_folder(
         FolderPurpose::Open => "Select project folder",
         FolderPurpose::Import => "Select the Bevy project to import",
     };
-    let mut dialog = AsyncFileDialog::new().set_title(title);
-
-    if let Ok(rh) = raw_handle.single() {
-        // SAFETY: called on the main thread during an observer
-        let handle = unsafe { rh.get_handle() };
-        dialog = dialog.set_parent(&handle);
-    }
+    let dialog = crate::native_dialog::dialog_at(
+        crate::native_dialog::launcher_project_directory(),
+        raw_handle.single().ok(),
+    )
+    .set_title(title);
 
     let task = AsyncComputeTaskPool::get().spawn(async move { dialog.pick_folder().await });
     commands.insert_resource(FolderDialogTask { task, purpose });
@@ -2919,17 +2917,27 @@ fn on_browse_new_location(
     _: On<Pointer<Click>>,
     mut commands: Commands,
     raw_handle: Query<&RawHandleWrapper, With<PrimaryWindow>>,
+    state: Res<NewProjectState>,
 ) {
-    let mut dialog = AsyncFileDialog::new().set_title("Choose parent directory");
-    if let Ok(rh) = raw_handle.single() {
-        // SAFETY: called on the main thread during an observer.
-        let handle = unsafe { rh.get_handle() };
-        dialog = dialog.set_parent(&handle);
-    }
+    let dialog = crate::native_dialog::dialog_at(
+        new_project_browse_directory(&state.location),
+        raw_handle.single().ok(),
+    )
+    .set_title("Choose parent directory");
     let task = AsyncComputeTaskPool::get().spawn(async move { dialog.pick_folder().await });
     commands.queue(move |world: &mut World| {
         world.resource_mut::<NewProjectState>().folder_task = Some(task);
     });
+}
+
+/// Where the New Project browse starts: the location the field already
+/// names, climbing to its nearest existing ancestor.
+fn new_project_browse_directory(location: &Path) -> Option<PathBuf> {
+    location
+        .ancestors()
+        .find(|ancestor| ancestor.is_dir())
+        .map(Path::to_path_buf)
+        .or_else(crate::native_dialog::launcher_project_directory)
 }
 
 fn spawn_reset_location_button(
@@ -3198,6 +3206,25 @@ fn poll_new_project_tasks(
 #[cfg(test)]
 mod tests {
     use super::*;
+
+    #[test]
+    fn the_new_project_browse_starts_where_the_location_field_points() {
+        let dir = tempfile::tempdir().expect("a temporary directory");
+        let location = dir.path().join("Games");
+        std::fs::create_dir_all(&location).expect("the location folder");
+
+        let start = new_project_browse_directory(&location).expect("a start directory");
+        assert_eq!(start, location);
+    }
+
+    #[test]
+    fn a_location_that_does_not_exist_yet_browses_its_nearest_parent() {
+        let dir = tempfile::tempdir().expect("a temporary directory");
+        let location = dir.path().join("Games/Unwritten");
+
+        let start = new_project_browse_directory(&location).expect("a start directory");
+        assert_eq!(start, dir.path());
+    }
 
     /// The card builders need the two font resources, the modal state,
     /// and enough of the asset/scene stack for `bsn!` `spawn_scene`

--- a/src/reference_image.rs
+++ b/src/reference_image.rs
@@ -4,9 +4,7 @@ use bevy::asset::LoadState;
 use bevy::ecs::system::SystemState;
 use bevy::prelude::*;
 use bevy::tasks::{AsyncComputeTaskPool, Task, futures_lite::future};
-use bevy::window::{PrimaryWindow, RawHandleWrapper};
 use path_slash::PathExt as _;
-use rfd::AsyncFileDialog;
 
 use crate::selection::Selection;
 
@@ -129,22 +127,13 @@ pub fn open_reference_image_picker(world: &mut World) {
     if world.contains_resource::<ReferenceImagePickTask>() {
         return;
     }
-    let raw_handle = world
-        .query_filtered::<&RawHandleWrapper, With<PrimaryWindow>>()
-        .single(world)
-        .ok()
-        .cloned();
-    let mut dialog = AsyncFileDialog::new()
-        .set_title("Select reference image")
-        .add_filter(
-            "Images",
-            &["png", "jpg", "jpeg", "ktx2", "bmp", "tga", "webp"],
-        );
-    if let Some(ref rh) = raw_handle {
-        // SAFETY: called on the main thread from an exclusive context
-        let handle = unsafe { rh.get_handle() };
-        dialog = dialog.set_parent(&handle);
-    }
+    let dialog =
+        crate::native_dialog::file_dialog(world, crate::native_dialog::DialogPurpose::Image)
+            .set_title("Select reference image")
+            .add_filter(
+                "Images",
+                &["png", "jpg", "jpeg", "ktx2", "bmp", "tga", "webp"],
+            );
     let task = AsyncComputeTaskPool::get().spawn(async move { dialog.pick_file().await });
     world.insert_resource(ReferenceImagePickTask(task));
 }
@@ -160,6 +149,11 @@ fn poll_reference_image_pick(world: &mut World) {
     let Some(file_handle) = result else {
         return;
     };
+    crate::native_dialog::remember_pick(
+        world,
+        crate::native_dialog::DialogPurpose::Image,
+        file_handle.path(),
+    );
     let path = file_handle.path().to_slash_lossy().into_owned();
     spawn_reference_image_in_world(world, &path, Vec3::ZERO);
 }

--- a/src/scene_io/load.rs
+++ b/src/scene_io/load.rs
@@ -44,7 +44,23 @@ fn forget_prefab_cache_bump(world: &mut World, before: Option<u64>) {
 
 #[derive(Resource)]
 pub(super) enum SceneDialogTask {
+    Open(Task<Option<FileHandle>>),
     Save(Task<Option<FileHandle>>),
+}
+
+/// Open the scene file picker behind File > Open. No-op while another
+/// scene dialog is already up.
+pub fn spawn_open_dialog(world: &mut World) {
+    if world.contains_resource::<SceneDialogTask>() {
+        return;
+    }
+    let dialog =
+        crate::native_dialog::file_dialog(world, crate::native_dialog::DialogPurpose::Scene)
+            .set_title("Open scene")
+            .add_filter("Jackdaw scene", &["bsn", "jsn"]);
+    let task =
+        bevy::tasks::AsyncComputeTaskPool::get().spawn(async move { dialog.pick_file().await });
+    world.insert_resource(SceneDialogTask::Open(task));
 }
 
 /// Whether a load put its document in the world. Every refusal is fail-soft:
@@ -857,6 +873,21 @@ pub(super) fn poll_scene_dialog(world: &mut World) {
     };
 
     match &mut task {
+        SceneDialogTask::Open(t) => {
+            let Some(result) = future::block_on(future::poll_once(t)) else {
+                world.insert_resource(task); // Not ready, put it back
+                return;
+            };
+            if let Some(file) = result {
+                let path = file.path().to_path_buf();
+                crate::native_dialog::remember_pick(
+                    world,
+                    crate::native_dialog::DialogPurpose::Scene,
+                    &path,
+                );
+                crate::migrate_dialog::request_open_with_conversion(world, &path);
+            }
+        }
         SceneDialogTask::Save(t) => {
             let Some(result) = future::block_on(future::poll_once(t)) else {
                 world.insert_resource(task); // Not ready, put it back
@@ -888,6 +919,11 @@ pub(super) fn poll_scene_dialog(world: &mut World) {
                 // scene to a new name, so a rename cannot take part of it.
                 crate::scene_io::retarget_active_scene(world, &path.to_string_lossy());
                 world.resource_mut::<SceneFilePath>().last_directory = last_dir;
+                crate::native_dialog::remember_pick(
+                    world,
+                    crate::native_dialog::DialogPurpose::Scene,
+                    &path,
+                );
 
                 match save_scene_inner(world) {
                     Ok(()) => {}

--- a/src/scene_io/mod.rs
+++ b/src/scene_io/mod.rs
@@ -5,10 +5,7 @@ use std::any::TypeId;
 use std::collections::HashSet;
 use std::path::PathBuf;
 
-use bevy::{
-    prelude::*,
-    window::{PrimaryWindow, RawHandleWrapper},
-};
+use bevy::prelude::*;
 
 mod legacy;
 mod load;
@@ -20,7 +17,7 @@ pub use legacy::{load_inline_assets, load_scene_from_jsn};
 pub use load::{
     LoadOutcome, LoadRefusal, RefusalCategory, declared_scene_kind, declares_ui_scene_root,
     is_ui_scene_root_type_path, load_scene_from_file, load_scene_from_file_with_outcome,
-    spawn_default_lighting,
+    spawn_default_lighting, spawn_open_dialog,
 };
 pub(crate) use load::{
     SidecarImport, clear_scene_entities, despawn_scene_entities, import_terrain_sidecars,
@@ -294,14 +291,6 @@ impl From<jackdaw_jsn::format::JsnMetadata> for SceneMetadata {
             modified: metadata.modified,
         }
     }
-}
-
-fn get_window_handle(world: &mut World) -> Option<RawHandleWrapper> {
-    world
-        .query_filtered::<&RawHandleWrapper, With<PrimaryWindow>>()
-        .single(world)
-        .ok()
-        .cloned()
 }
 
 #[cfg(test)]

--- a/src/scene_io/save.rs
+++ b/src/scene_io/save.rs
@@ -4,13 +4,9 @@ use std::path::{Path, PathBuf};
 use bevy::asset::{ReflectAsset, ReflectHandle, UntypedAssetId};
 use bevy::reflect::TypeRegistry;
 use bevy::{ecs::reflect::AppTypeRegistry, prelude::*, tasks::AsyncComputeTaskPool};
-use rfd::AsyncFileDialog;
 
 use super::load::SceneDialogTask;
-use super::{
-    SceneDirtyState, SceneFilePath, get_window_handle, should_skip_component,
-    structural_skip_type_ids,
-};
+use super::{SceneDirtyState, SceneFilePath, should_skip_component, structural_skip_type_ids};
 
 /// Write `contents` to `path` atomically: write to a temp file beside
 /// `path`, then rename over the target. `std::fs::write` truncates the
@@ -45,21 +41,12 @@ pub(crate) fn write_atomic(path: &Path, contents: &[u8]) -> std::io::Result<()> 
 }
 
 fn spawn_save_dialog(world: &mut World) {
-    let raw_handle = get_window_handle(world);
-    let last_dir = world.resource::<SceneFilePath>().last_directory.clone();
-
-    let mut dialog = AsyncFileDialog::new()
-        .add_filter("BSN Scene", &["bsn"])
-        .set_file_name("scene.bsn");
-
-    if let Some(dir) = &last_dir {
-        dialog = dialog.set_directory(dir);
-    }
-    if let Some(ref rh) = raw_handle {
-        // SAFETY: called on the main thread during an exclusive system
-        let handle = unsafe { rh.get_handle() };
-        dialog = dialog.set_parent(&handle);
-    }
+    let dialog = crate::native_dialog::save_dialog(
+        world,
+        crate::native_dialog::DialogPurpose::Scene,
+        "scene.bsn",
+    )
+    .add_filter("BSN Scene", &["bsn"]);
 
     let task = AsyncComputeTaskPool::get().spawn(async move { dialog.save_file().await });
     world.insert_resource(SceneDialogTask::Save(task));

--- a/src/scenes/operators.rs
+++ b/src/scenes/operators.rs
@@ -194,7 +194,8 @@ pub fn scene_open(In(params): In<OperatorParameters>, mut commands: Commands) ->
             }
             None => None,
         };
-        let Some(path) = path.or_else(pick_scene_file) else {
+        let Some(path) = path else {
+            crate::scene_io::spawn_open_dialog(world);
             return;
         };
         // Legacy .jsn picks confirm conversion before opening.
@@ -387,12 +388,6 @@ pub fn scene_open_system(world: &mut World, path: &std::path::Path) {
 
     let target = world.resource_mut::<Scenes>().push_tab(tab);
     activate_pushed_tab(world, target);
-}
-
-fn pick_scene_file() -> Option<std::path::PathBuf> {
-    rfd::FileDialog::new()
-        .add_filter("Jackdaw scene", &["bsn", "jsn"])
-        .pick_file()
 }
 
 #[operator(id = "scene.close", label = "Close Tab", allows_undo = false)]

--- a/tests/scenes/main.rs
+++ b/tests/scenes/main.rs
@@ -14,6 +14,7 @@ mod headless;
 mod integration;
 mod jsn_conversion_commit;
 mod jsn_to_bsn;
+mod native_dialogs;
 mod scene_reopen;
 mod scenes_swap;
 mod widget_defaults;

--- a/tests/scenes/native_dialogs.rs
+++ b/tests/scenes/native_dialogs.rs
@@ -1,0 +1,230 @@
+//! Where the native file and folder dialogs open.
+
+use std::path::{Path, PathBuf};
+
+use bevy::prelude::*;
+use jackdaw::asset_browser::AssetBrowserState;
+use jackdaw::native_dialog::{
+    DialogMemory, DialogPurpose, browsing_directory, remember_pick, start_directory,
+};
+use jackdaw::project::{ProjectConfig, ProjectRoot, load_project_config};
+use jackdaw::scene_io::SceneFilePath;
+use jackdaw::scenes::{SceneTab, Scenes};
+
+struct Project {
+    _dir: tempfile::TempDir,
+    root: PathBuf,
+}
+
+fn project() -> Project {
+    let dir = tempfile::tempdir().expect("a temporary directory");
+    let root = dir.path().to_path_buf();
+    std::fs::create_dir_all(root.join("assets/props")).expect("the assets tree");
+    std::fs::create_dir_all(root.join("scenes")).expect("a scenes folder");
+    Project { _dir: dir, root }
+}
+
+fn world_with(project: &Project) -> World {
+    let mut world = World::new();
+    world.insert_resource(ProjectRoot::new(
+        project.root.clone(),
+        ProjectConfig::default(),
+    ));
+    world.insert_resource(DialogMemory::default());
+    world
+}
+
+fn browse_at(world: &mut World, directory: &Path) {
+    world.insert_resource(AssetBrowserState::at(directory));
+}
+
+fn open_scene_at(world: &mut World, path: &Path) {
+    let mut tab = SceneTab::new_untitled(0);
+    tab.path = Some(path.to_path_buf());
+    world.insert_resource(Scenes {
+        tabs: vec![tab],
+        active: 0,
+    });
+}
+
+fn same_folder(left: &Path, right: &Path) -> bool {
+    let resolve = |path: &Path| std::fs::canonicalize(path).unwrap_or_else(|_| path.to_path_buf());
+    resolve(left) == resolve(right)
+}
+
+#[test]
+fn a_dialog_opens_in_the_folder_the_asset_browser_is_showing() {
+    let project = project();
+    let mut world = world_with(&project);
+    let props = project.root.join("assets/props");
+    browse_at(&mut world, &props);
+
+    let start = browsing_directory(&world).expect("a start directory");
+    assert!(
+        same_folder(&start, &props),
+        "expected {}, got {}",
+        props.display(),
+        start.display()
+    );
+}
+
+#[test]
+fn a_folder_outside_the_project_gives_way_to_the_open_scene() {
+    let project = project();
+    let elsewhere = tempfile::tempdir().expect("a folder outside the project");
+    let mut world = world_with(&project);
+    browse_at(&mut world, elsewhere.path());
+    let scene = project.root.join("scenes/town.bsn");
+    std::fs::write(&scene, "").expect("a scene file");
+    open_scene_at(&mut world, &scene);
+
+    let start = browsing_directory(&world).expect("a start directory");
+    assert!(
+        same_folder(&start, &project.root.join("scenes")),
+        "expected the open scene's folder, got {}",
+        start.display()
+    );
+}
+
+#[test]
+fn with_nothing_open_a_dialog_starts_in_the_assets_directory() {
+    let project = project();
+    let world = world_with(&project);
+
+    let start = browsing_directory(&world).expect("a start directory");
+    assert!(
+        same_folder(&start, &project.root.join("assets")),
+        "expected the assets directory, got {}",
+        start.display()
+    );
+}
+
+#[test]
+fn a_purpose_reopens_in_the_folder_it_was_last_used_in() {
+    let project = project();
+    let mut world = world_with(&project);
+    let props = project.root.join("assets/props");
+    let texture = props.join("bark.png");
+    std::fs::write(&texture, "").expect("a texture file");
+
+    remember_pick(&mut world, DialogPurpose::Texture, &texture);
+
+    let start = start_directory(&world, DialogPurpose::Texture).expect("a start directory");
+    assert!(
+        same_folder(&start, &props),
+        "expected the remembered folder, got {}",
+        start.display()
+    );
+    assert!(
+        same_folder(
+            &start_directory(&world, DialogPurpose::Prefab).expect("a start directory"),
+            &project.root.join("assets")
+        ),
+        "another purpose keeps its own folder"
+    );
+}
+
+#[test]
+fn the_bundle_dialog_reopens_where_the_last_bundle_came_from() {
+    let project = project();
+    let downloads = tempfile::tempdir().expect("a folder outside the project");
+    let mut world = world_with(&project);
+    let props = project.root.join("assets/props");
+    browse_at(&mut world, &props);
+    let bundle = downloads.path().join("terrain-tools.jdext");
+    std::fs::write(&bundle, "").expect("a bundle file");
+
+    remember_pick(&mut world, DialogPurpose::Bundle, &bundle);
+
+    let start = start_directory(&world, DialogPurpose::Bundle).expect("a start directory");
+    assert!(
+        same_folder(&start, downloads.path()),
+        "expected the folder the last bundle came from, got {}",
+        start.display()
+    );
+    assert!(
+        same_folder(
+            &start_directory(&world, DialogPurpose::Prefab).expect("a start directory"),
+            &props
+        ),
+        "a project file still follows the asset browser"
+    );
+}
+
+#[test]
+fn the_bundle_dialog_falls_back_to_the_browsing_folder_before_any_install() {
+    let project = project();
+    let mut world = world_with(&project);
+    let props = project.root.join("assets/props");
+    browse_at(&mut world, &props);
+
+    let start = start_directory(&world, DialogPurpose::Bundle).expect("a start directory");
+    assert!(
+        same_folder(&start, &props),
+        "expected the browsing folder, got {}",
+        start.display()
+    );
+}
+
+#[test]
+fn a_remembered_folder_survives_reopening_the_project() {
+    let project = project();
+    let mut world = world_with(&project);
+    let props = project.root.join("assets/props");
+    remember_pick(&mut world, DialogPurpose::Prefab, &props.join("crate.bsn"));
+
+    let config = load_project_config(&project.root).expect("the project config was written");
+    let mut reopened = World::new();
+    reopened.insert_resource(ProjectRoot::new(project.root.clone(), config));
+    let mut memory = DialogMemory::default();
+    memory.restore(
+        reopened
+            .resource::<ProjectRoot>()
+            .config
+            .dialog_directories
+            .clone(),
+    );
+    reopened.insert_resource(memory);
+
+    let start = start_directory(&reopened, DialogPurpose::Prefab).expect("a start directory");
+    assert!(
+        same_folder(&start, &props),
+        "expected the folder remembered before the reopen, got {}",
+        start.display()
+    );
+}
+
+#[test]
+fn a_remembered_folder_that_is_gone_falls_back_to_the_project() {
+    let project = project();
+    let mut world = world_with(&project);
+    let removed = project.root.join("assets/props");
+    remember_pick(&mut world, DialogPurpose::Image, &removed.join("sky.png"));
+    std::fs::remove_dir_all(&removed).expect("remove the folder");
+
+    let start = start_directory(&world, DialogPurpose::Image).expect("a start directory");
+    assert!(
+        same_folder(&start, &project.root.join("assets")),
+        "expected the assets directory, got {}",
+        start.display()
+    );
+}
+
+#[test]
+fn the_save_dialog_follows_the_scene_that_is_open() {
+    let project = project();
+    let mut world = world_with(&project);
+    let scene = project.root.join("scenes/town.bsn");
+    std::fs::write(&scene, "").expect("a scene file");
+    world.insert_resource(SceneFilePath {
+        path: Some(scene.to_string_lossy().into_owned()),
+        ..Default::default()
+    });
+
+    let start = start_directory(&world, DialogPurpose::Scene).expect("a start directory");
+    assert!(
+        same_folder(&start, &project.root.join("scenes")),
+        "expected the open scene's folder, got {}",
+        start.display()
+    );
+}


### PR DESCRIPTION
Native open and save dialogs opened at the home directory instead of the folder being worked in, because each call site built its own dialog and most set no start directory.

They now all go through one module that parents the dialog to the editor window and starts it where the user is looking: the asset browser's folder while it points inside the project, otherwise the folder of the open scene, otherwise the project's `assets/`. Each kind of dialog remembers the folder it was last used in, persisted with the project, and the texture-slot browse prefers the folder of the material being edited. Installing an extension bundle starts where the last bundle came from, since bundles live outside the project. The launcher's project browse starts beside the most recent project, and the New Project browse starts where its location field points.

File > Open was still a blocking, unparented dialog; it is now async like the others.

LLM disclaimer: Claude Code was used to help plan and implement this change, but all code was human reviewed by myself!
