### PR TITLE
Fill the definition card from the schema and keep a file's root name

### DIFF
--- a/crates/jackdaw_bsn/src/emitter.rs
+++ b/crates/jackdaw_bsn/src/emitter.rs
@@ -309,14 +309,10 @@ fn emit_value_maybe_multiline(value: &BsnValue, indent: usize, out: &mut String)
         }
         BsnValue::List(items) if !items.is_empty() => {
             writeln!(out, "[").unwrap();
-            for (i, item) in items.iter().enumerate() {
+            for item in items {
                 write_indent(indent + 1, out);
                 emit_value_maybe_multiline(item, indent + 1, out);
-                if i + 1 < items.len() {
-                    writeln!(out, ",").unwrap();
-                } else {
-                    writeln!(out).unwrap();
-                }
+                writeln!(out, ",").unwrap();
             }
             write_indent(indent, out);
             write!(out, "]").unwrap();
@@ -451,6 +447,36 @@ mod tests {
 
         let text = emit_scene(&ast);
         assert!(text.contains("SceneRoot(\"models/FlightHelmet/FlightHelmet.gltf#Scene0\")"));
+    }
+
+    #[test]
+    fn every_row_of_a_list_ends_in_a_comma_so_adding_one_touches_one_line() {
+        let mut ast = SceneBsnAst::default();
+
+        let row = |item: &str| {
+            BsnValue::Struct(BsnStructData {
+                type_path: "test::LootRoll".into(),
+                fields: BsnStructFields(vec![BsnField {
+                    name: "item".into(),
+                    value: BsnValue::String(item.into()),
+                }]),
+            })
+        };
+        let patch = ast
+            .world
+            .spawn(BsnPatch::Struct(BsnStructData {
+                type_path: "test::ItemDef".into(),
+                fields: BsnStructFields(vec![BsnField {
+                    name: "loot".into(),
+                    value: BsnValue::List(vec![row("coin"), row("gem")]),
+                }]),
+            }))
+            .id();
+        let entity = ast.world.spawn(BsnPatches(vec![patch])).id();
+        ast.roots.push(entity);
+
+        let expected = "test::ItemDef {\n    loot: [\n        test::LootRoll {\n            item: \"coin\",\n        },\n        test::LootRoll {\n            item: \"gem\",\n        },\n    ],\n}\n";
+        assert_eq!(emit_scene(&ast), expected);
     }
 
     #[test]

--- a/src/definition_assets.rs
+++ b/src/definition_assets.rs
@@ -198,16 +198,15 @@ pub fn definition_file_path(dir: &Path, name: &str) -> PathBuf {
     dir.join(format!("{}.bsn", sanitize_definition_name(name)))
 }
 
-/// The name a file gives the definition it holds: its stem, without a
-/// trailing `.<kind>` segment from the suffixes files used to carry.
-pub fn definition_name_of(path: &Path, kind: &str) -> String {
-    let stem = path
-        .file_stem()
-        .and_then(|stem| stem.to_str())
-        .unwrap_or_default();
-    stem.strip_suffix(&format!(".{kind}"))
-        .unwrap_or(stem)
-        .to_string()
+/// The name a file gives the definition it holds: everything before the first
+/// dot of its file name, so `torch.item.bsn` holds `torch`.
+pub fn definition_name_of(path: &Path) -> String {
+    let file = path
+        .file_name()
+        .and_then(|name| name.to_str())
+        .unwrap_or_default()
+        .trim_start_matches('.');
+    file.split('.').next().unwrap_or(file).to_string()
 }
 
 /// The folder a new definition lands in: the one the browser is showing when
@@ -269,7 +268,7 @@ fn load_schema_definition(
     path: &Path,
     text: &str,
 ) -> Option<DefinitionValue> {
-    let name = definition_name_of(path, &definition.kind);
+    let name = definition_name_of(path);
     let ast = match jackdaw_bsn::parse_bsn_text(text) {
         Ok(ast) => ast,
         Err(err) => {
@@ -321,22 +320,42 @@ fn empty_patch(type_path: &str) -> BsnStructData {
     }
 }
 
-/// Write one definition to the file it was opened from or created in. An
-/// identical rewrite is skipped so the asset watcher does not reload behind an
-/// unchanged save.
+/// The name the root of an existing file carries, so a save writes the file
+/// back under the name it already spells.
+fn root_name_of(text: &str) -> Option<String> {
+    let ast = jackdaw_bsn::parse_bsn_text(text).ok()?;
+    ast.roots.iter().find_map(|&root| {
+        ast.get_patches(root)?
+            .0
+            .iter()
+            .find_map(|&patch| match ast.get_patch(patch) {
+                Some(BsnPatch::Name(name)) => Some(name.clone()),
+                _ => None,
+            })
+    })
+}
+
+/// Write one definition to the file it was opened from or created in, under
+/// the root name that file already carries. An identical rewrite is skipped so
+/// the asset watcher does not reload behind an unchanged save.
 pub fn write_definition_file(
     world: &World,
     name: &str,
     value: &DefinitionValue,
     path: &Path,
 ) -> std::io::Result<PathBuf> {
-    let text = definition_text(world, name, value).unwrap_or_default();
+    let existing = std::fs::read_to_string(path).ok();
+    let name = existing
+        .as_deref()
+        .and_then(root_name_of)
+        .unwrap_or_else(|| name.to_string());
+    let text = definition_text(world, &name, value).unwrap_or_default();
     if text.trim().is_empty() {
         return Err(std::io::Error::other(format!(
             "nothing to write for '{name}'"
         )));
     }
-    if std::fs::read_to_string(path).is_ok_and(|existing| existing == text) {
+    if existing.is_some_and(|existing| existing == text) {
         return Ok(path.to_path_buf());
     }
     if let Some(parent) = path.parent() {
@@ -480,7 +499,7 @@ fn scan_definition_files(
         let Some(definition) = kinds.by_type_path(&type_path).filter(|kind| kind.scanned()) else {
             continue;
         };
-        let name = definition_name_of(&path, &definition.kind);
+        let name = definition_name_of(&path);
         if found
             .iter()
             .any(|(kind, known, _)| kind == &definition.kind && known == &name)
@@ -835,7 +854,7 @@ fn write_schema_field(
             };
             if crate::schema_values::default_field_json(&schema, &field_name).as_ref() == Some(new)
             {
-                crate::schema_values::set_authored(&mut data, &field_name, None);
+                crate::schema_values::set_authored(&mut data, &schema, &field_name, None);
                 continue;
             }
             let Some(value) =
@@ -843,7 +862,7 @@ fn write_schema_field(
             else {
                 return false;
             };
-            crate::schema_values::set_authored(&mut data, &field_name, Some(value));
+            crate::schema_values::set_authored(&mut data, &schema, &field_name, Some(value));
         }
         true
     });
@@ -1124,7 +1143,7 @@ pub fn open_definition_file(world: &mut World, path: &Path) -> bool {
     let Some(definition) = kind_of_file(world, path) else {
         return false;
     };
-    let name = definition_name_of(path, &definition.kind);
+    let name = definition_name_of(path);
 
     let known = world
         .resource::<DefinitionRegistry>()
@@ -1223,7 +1242,7 @@ fn save_definition_at(world: &mut World, path: &Path) -> Option<String> {
         warn!("asset.save: {} is not an asset file", path.display());
         return None;
     };
-    let name = definition_name_of(path, &definition.kind);
+    let name = definition_name_of(path);
     let Some(value) = world
         .resource::<DefinitionRegistry>()
         .get(&definition.kind, &name)
@@ -1549,12 +1568,10 @@ fn create_definition(
         warn!("asset.new: {kind} definitions are created by whoever loads them");
         return None;
     }
-    let (dir, named_by_path) = match dir {
+    let (dir, file) = match dir {
         Some(file) if names_a_file(file) => (
             file.parent().unwrap_or(file).to_path_buf(),
-            file.file_stem()
-                .and_then(|stem| stem.to_str())
-                .map(str::to_owned),
+            Some(file.to_path_buf()),
         ),
         Some(dir) => (dir.to_path_buf(), None),
         None => {
@@ -1565,10 +1582,15 @@ fn create_definition(
             (dir, None)
         }
     };
-    let name = match name.map(str::to_owned).or(named_by_path) {
+    let asked_for = name.map(sanitize_definition_name);
+    let named_by_path = file.as_deref().map(definition_name_of);
+    let name = match named_by_path.or_else(|| asked_for.clone()) {
         Some(name) => sanitize_definition_name(&name),
         None => next_free_name(world, kind, &dir),
     };
+    if asked_for.is_some_and(|asked| asked != name) {
+        warn!("asset.new: the file asked for names this {kind} '{name}'");
+    }
     if world
         .resource::<DefinitionRegistry>()
         .get(kind, &name)
@@ -1577,7 +1599,7 @@ fn create_definition(
         warn!("asset.new: a {kind} named '{name}' already exists");
         return None;
     }
-    let path = definition_file_path(&dir, &name);
+    let path = file.unwrap_or_else(|| definition_file_path(&dir, &name));
     if path.exists() {
         warn!("asset.new: {} is already there", path.display());
         return None;
@@ -1695,7 +1717,7 @@ fn delete_definition(world: &mut World, path: &Path) {
         );
         return;
     }
-    let name = definition_name_of(path, &definition.kind);
+    let name = definition_name_of(path);
     match std::fs::remove_file(path) {
         Ok(()) => info!("Removed {}", path.display()),
         Err(err) if err.kind() == std::io::ErrorKind::NotFound => {}
@@ -1887,6 +1909,40 @@ mod tests {
             .get(&handle.typed::<ItemDef>())
             .expect("the definition is in its store")
             .clone()
+    }
+
+    #[test]
+    fn a_file_names_its_definition_by_the_stem_before_its_first_dot() {
+        for (file, expected) in [
+            ("torch.item.bsn", "torch"),
+            ("torch.bsn", "torch"),
+            ("torch", "torch"),
+            (".torch.item.bsn", "torch"),
+        ] {
+            assert_eq!(
+                definition_name_of(Path::new(file)),
+                expected,
+                "{file} names a definition"
+            );
+        }
+    }
+
+    #[test]
+    fn the_root_name_a_file_spells_is_read_back_however_it_is_written() {
+        assert_eq!(
+            root_name_of("#torch\njackdaw::Item {\n}\n").as_deref(),
+            Some("torch")
+        );
+        assert_eq!(
+            root_name_of("#\"torch.item\"\njackdaw::Item {\n}\n").as_deref(),
+            Some("torch.item"),
+            "a quoted name is the name, without its quotes"
+        );
+        assert_eq!(
+            root_name_of("jackdaw::Item {\n}\n"),
+            None,
+            "a root that names nothing leaves the name to the caller"
+        );
     }
 
     #[test]

--- a/src/inspector/category_strip.rs
+++ b/src/inspector/category_strip.rs
@@ -167,7 +167,10 @@ pub(super) fn spawn_category_strip(
 pub(super) fn paint_category_tabs(
     registry: Res<InspectorRegistry>,
     active: Res<ActiveInspectorCategory>,
-    type_paths: Query<&super::ComponentDisplayTypePath>,
+    type_paths: Query<
+        &super::ComponentDisplayTypePath,
+        Without<super::definition_card::DefinitionCard>,
+    >,
     added_paths: Query<(), Added<super::ComponentDisplayTypePath>>,
     removed_paths: RemovedComponents<super::ComponentDisplayTypePath>,
     tabs: Query<(Entity, &InspectorCategoryTab, &Children)>,
@@ -237,7 +240,13 @@ pub(super) fn paint_category_tabs(
 /// cards by writing the resource unconditionally (marking it changed).
 pub(super) fn resolve_active_on_rebuild(
     registry: Res<InspectorRegistry>,
-    cards: Query<&super::ComponentDisplayTypePath, With<super::ComponentDisplay>>,
+    cards: Query<
+        &super::ComponentDisplayTypePath,
+        (
+            With<super::ComponentDisplay>,
+            Without<super::definition_card::DefinitionCard>,
+        ),
+    >,
     added: Query<(), Added<super::ComponentDisplay>>,
     mut removed: RemovedComponents<super::ComponentDisplay>,
     mut active: ResMut<ActiveInspectorCategory>,

--- a/src/inspector/component_display.rs
+++ b/src/inspector/component_display.rs
@@ -1271,6 +1271,9 @@ pub(crate) fn spawn_component_display(
 /// category AND its short name passes the search text predicate (either the
 /// search field is empty or the name contains the filter string).
 ///
+/// A definition card is the panel's whole contents rather than one component of
+/// an entity, so no category hides it; the search still does.
+///
 /// The system re-runs whenever the search text changes OR the active category
 /// changes. Group-section visibility follows: a group hides when all of its
 /// cards are hidden.
@@ -1278,7 +1281,15 @@ pub(crate) fn filter_inspector_components(
     search_query: Query<&TextEditValue, With<InspectorSearch>>,
     active: Res<ActiveInspectorCategory>,
     registry: Res<jackdaw_api_internal::inspector::InspectorRegistry>,
-    components: Query<(Entity, &ComponentName, &ComponentDisplayTypePath), With<ComponentDisplay>>,
+    components: Query<
+        (
+            Entity,
+            &ComponentName,
+            &ComponentDisplayTypePath,
+            Has<super::definition_card::DefinitionCard>,
+        ),
+        With<ComponentDisplay>,
+    >,
     groups: Query<(Entity, &Children), With<InspectorGroupSection>>,
     mut node_query: Query<&mut Node>,
     changed_search: Query<(), (With<InspectorSearch>, Changed<TextEditValue>)>,
@@ -1299,8 +1310,8 @@ pub(crate) fn filter_inspector_components(
     // Track which component entities are visible.
     let mut visible_components: HashSet<Entity> = HashSet::new();
 
-    for (entity, comp_name, type_path) in &components {
-        let category_ok = registry.category_for(&type_path.0) == active_cat;
+    for (entity, comp_name, type_path, is_definition) in &components {
+        let category_ok = is_definition || registry.category_for(&type_path.0) == active_cat;
         let search_ok = filter.is_empty() || comp_name.0.to_lowercase().contains(&filter);
         let visible = category_ok && search_ok;
 

--- a/src/inspector/definition_card.rs
+++ b/src/inspector/definition_card.rs
@@ -3,7 +3,8 @@
 //! The card is the generic component card with the definition's reflected
 //! fields in its body, so scalars, enum menus and list rows behave exactly as
 //! they do on a component. Its header carries the Save action and says when
-//! the definition has unsaved edits.
+//! the definition has unsaved edits, and the card opens expanded, since it is
+//! all the panel has to show.
 
 use bevy::ecs::system::SystemState;
 use bevy::prelude::*;
@@ -29,8 +30,31 @@ enum CardBody {
     Schema(Box<jackdaw_schema::TypeSchema>, serde_json::Value),
 }
 
+/// Marks the card a definition puts up: it stands for a whole file, so no
+/// category tab files it or hides it.
+#[derive(Component)]
+pub(crate) struct DefinitionCard;
+
+/// Drop the card the inspector already holds for a definition, so filling it
+/// twice in a frame leaves one card rather than two.
+fn despawn_existing_card(world: &mut World, inspector: Entity) {
+    let Some(children) = world.get::<Children>(inspector) else {
+        return;
+    };
+    let cards: Vec<Entity> = children
+        .iter()
+        .filter(|&child| world.get::<DefinitionCard>(child).is_some())
+        .collect();
+    for card in cards {
+        if let Ok(entity) = world.get_entity_mut(card) {
+            entity.despawn();
+        }
+    }
+}
+
 /// Build the card for the definition `source` is editing under `inspector`.
 pub(crate) fn fill_definition_card(world: &mut World, inspector: Entity, source: Entity) {
+    despawn_existing_card(world, inspector);
     let Some((kind, name, type_path, dirty)) =
         world.get::<DefinitionAssetEdit>(source).map(|edit| {
             (
@@ -52,17 +76,29 @@ pub(crate) fn fill_definition_card(world: &mut World, inspector: Entity, source:
         .map_or_else(|| kind.clone(), |definition| definition.label.clone());
     let schema_backed = registered.is_some_and(|definition| definition.schema_backed());
     let body = if schema_backed {
-        let (Some(schema), Some(value)) = (
-            crate::definition_assets::definition_schema(world, &kind),
-            crate::definition_assets::schema_definition_json(world, &kind, &name),
-        ) else {
+        let Some(schema) = crate::definition_assets::definition_schema(world, &kind) else {
+            bevy::log::warn_once!(
+                "this project reports no shape for {type_path}, which its {kind} files hold"
+            );
+            return;
+        };
+        let Some(value) = crate::definition_assets::schema_definition_json(world, &kind, &name)
+        else {
+            bevy::log::warn_once!(
+                "no {kind} named '{name}' is loaded, so its {type_path} card is empty"
+            );
             return;
         };
         CardBody::Schema(Box::new(schema), value)
     } else {
         match definition_snapshot(world, source, &type_path) {
             Some(value) => CardBody::Reflected(value),
-            None => return,
+            None => {
+                bevy::log::warn_once!(
+                    "the editor has no registration for {type_path}, which {kind} files hold"
+                );
+                return;
+            }
         }
     };
 
@@ -70,10 +106,11 @@ pub(crate) fn fill_definition_card(world: &mut World, inspector: Entity, source:
     let server = world.get_resource::<AssetServer>().cloned();
     let icon_font = world.resource::<IconFont>().0.clone();
     let editor_font = world.resource::<EditorFont>().0.clone();
-    let collapse_state =
+    let mut collapse_state =
         super::InspectorCollapseState(world.resource::<super::InspectorCollapseState>().0.clone());
 
     let card_name = format!("{name} ({label})");
+    collapse_state.0.entry(card_name.clone()).or_insert(false);
     let card = {
         let mut state: SystemState<Commands> = SystemState::new(world);
         let Ok(mut commands) = state.get_mut(world) else {
@@ -95,6 +132,7 @@ pub(crate) fn fill_definition_card(world: &mut World, inspector: Entity, source:
                 collapse_state: &collapse_state,
             },
         );
+        commands.entity(card.section).insert(DefinitionCard);
         jackdaw_feathers::utils::attach_or_despawn(&mut commands, inspector, card.section);
         state.apply(world);
         card

--- a/src/schema_values.rs
+++ b/src/schema_values.rs
@@ -192,14 +192,50 @@ fn authored<'a>(data: &'a BsnStructData, name: &str) -> Option<&'a BsnValue> {
 
 /// Write one field into a patch, or drop it when it holds what the type
 /// defaults to.
-pub fn set_authored(data: &mut BsnStructData, name: &str, value: Option<BsnValue>) {
-    data.fields.0.retain(|field| field.name != name);
-    if let Some(value) = value {
-        data.fields.0.push(BsnField {
+///
+/// A field already spelled keeps its place and a new one takes the place the
+/// type declares it in, so one edit rewrites one line.
+pub fn set_authored(
+    data: &mut BsnStructData,
+    schema: &TypeSchema,
+    name: &str,
+    value: Option<BsnValue>,
+) {
+    let Some(value) = value else {
+        data.fields.0.retain(|field| field.name != name);
+        return;
+    };
+    if let Some(field) = data.fields.0.iter_mut().find(|field| field.name == name) {
+        field.value = value;
+        return;
+    }
+    let at = declared_position(data, schema, name);
+    data.fields.0.insert(
+        at,
+        BsnField {
             name: name.to_string(),
             value,
-        });
-    }
+        },
+    );
+}
+
+/// Where a field the patch does not spell yet belongs: before the first field
+/// the type declares after it, and at the end when the type declares neither.
+fn declared_position(data: &BsnStructData, schema: &TypeSchema, name: &str) -> usize {
+    let Some(declared) = schema.fields.iter().position(|field| field.name == name) else {
+        return data.fields.0.len();
+    };
+    data.fields
+        .0
+        .iter()
+        .position(|field| {
+            schema
+                .fields
+                .iter()
+                .position(|known| known.name == field.name)
+                .is_some_and(|known| known > declared)
+        })
+        .unwrap_or(data.fields.0.len())
 }
 
 /// The JSON a BSN value stands for in a field of `type_path`.
@@ -563,6 +599,86 @@ mod tests {
             &parse_path("loot[2].item"),
             Value::String("gem".into())
         ));
+    }
+
+    fn item_schema() -> TypeSchema {
+        serde_json::from_value(serde_json::json!({
+            "type_path": "my_game::content::ItemDef",
+            "short_name": "ItemDef",
+            "module_path": "my_game::content",
+            "category": "",
+            "description": "",
+            "hidden": false,
+            "default_constructible": true,
+            "kind": "Struct",
+            "default": null,
+            "fields": [
+                { "name": "stack_size", "type_path": "u32" },
+                { "name": "rarity", "type_path": "my_game::content::Rarity" },
+                { "name": "weight", "type_path": "f32" }
+            ]
+        }))
+        .expect("the schema reads")
+    }
+
+    fn patch_of(names: &[&str]) -> BsnStructData {
+        BsnStructData {
+            type_path: "my_game::content::ItemDef".to_string(),
+            fields: BsnStructFields(
+                names
+                    .iter()
+                    .map(|name| BsnField {
+                        name: (*name).to_string(),
+                        value: BsnValue::Int(1),
+                    })
+                    .collect(),
+            ),
+        }
+    }
+
+    fn field_names(data: &BsnStructData) -> Vec<&str> {
+        data.fields
+            .0
+            .iter()
+            .map(|field| field.name.as_str())
+            .collect()
+    }
+
+    #[test]
+    fn a_field_the_patch_already_spells_keeps_the_place_it_has() {
+        let mut data = patch_of(&["weight", "stack_size"]);
+        set_authored(&mut data, &item_schema(), "weight", Some(BsnValue::Int(4)));
+
+        assert_eq!(field_names(&data), ["weight", "stack_size"]);
+        assert_eq!(
+            data.fields.0[0].value,
+            BsnValue::Int(4),
+            "and holds what was written to it"
+        );
+    }
+
+    #[test]
+    fn a_field_arriving_takes_the_place_its_type_declares_it_in() {
+        let mut data = patch_of(&["stack_size", "weight"]);
+        set_authored(&mut data, &item_schema(), "rarity", Some(BsnValue::Int(1)));
+
+        assert_eq!(field_names(&data), ["stack_size", "rarity", "weight"]);
+    }
+
+    #[test]
+    fn a_field_the_type_does_not_declare_arrives_at_the_end() {
+        let mut data = patch_of(&["stack_size"]);
+        set_authored(&mut data, &item_schema(), "charges", Some(BsnValue::Int(1)));
+
+        assert_eq!(field_names(&data), ["stack_size", "charges"]);
+    }
+
+    #[test]
+    fn a_field_holding_what_its_type_defaults_to_stops_being_authored() {
+        let mut data = patch_of(&["stack_size", "weight"]);
+        set_authored(&mut data, &item_schema(), "stack_size", None);
+
+        assert_eq!(field_names(&data), ["weight"]);
     }
 
     #[test]

--- a/tests/fixtures/mob_project/jackdaw.toml
+++ b/tests/fixtures/mob_project/jackdaw.toml
@@ -1,0 +1,2 @@
+[jackdaw]
+bevy = "0.19"

--- a/tests/fixtures/mob_project/schema.json
+++ b/tests/fixtures/mob_project/schema.json
@@ -1,0 +1,151 @@
+{
+  "components": [],
+  "resources": [],
+  "events": [],
+  "functions": [],
+  "assets": [
+    {
+      "type_path": "mob_project::content::MobArchetypeDef",
+      "short_name": "MobArchetypeDef",
+      "module_path": "mob_project::content",
+      "category": "",
+      "description": "",
+      "editor_description": "",
+      "hidden": false,
+      "preview": "",
+      "default_constructible": true,
+      "fields": [
+        {
+          "name": "archetype_id",
+          "type_path": "alloc::string::String",
+          "item_type_path": ""
+        },
+        {
+          "name": "name",
+          "type_path": "alloc::string::String",
+          "item_type_path": ""
+        },
+        {
+          "name": "max_health",
+          "type_path": "i32",
+          "item_type_path": ""
+        },
+        {
+          "name": "move_speed",
+          "type_path": "f32",
+          "item_type_path": ""
+        },
+        {
+          "name": "aggro_radius",
+          "type_path": "f32",
+          "item_type_path": ""
+        },
+        {
+          "name": "leash_radius",
+          "type_path": "f32",
+          "item_type_path": ""
+        },
+        {
+          "name": "passive",
+          "type_path": "bool",
+          "item_type_path": ""
+        },
+        {
+          "name": "temper",
+          "type_path": "mob_project::content::Temper",
+          "item_type_path": ""
+        },
+        {
+          "name": "drops",
+          "type_path": "alloc::vec::Vec<mob_project::content::LootDrop>",
+          "item_type_path": "mob_project::content::LootDrop"
+        }
+      ],
+      "kind": "Struct",
+      "default": {
+        "mob_project::content::MobArchetypeDef": {
+          "archetype_id": "",
+          "name": "",
+          "max_health": 0,
+          "move_speed": 0.0,
+          "aggro_radius": 0.0,
+          "leash_radius": 0.0,
+          "passive": false,
+          "temper": "Calm",
+          "drops": []
+        }
+      },
+      "variants": [],
+      "entity_fields": [],
+      "fills_gaps": true,
+      "asset": true
+    },
+    {
+      "type_path": "mob_project::content::LootDrop",
+      "short_name": "LootDrop",
+      "module_path": "mob_project::content",
+      "category": "",
+      "description": "",
+      "editor_description": "",
+      "hidden": false,
+      "preview": "",
+      "default_constructible": true,
+      "fields": [
+        {
+          "name": "family",
+          "type_path": "alloc::string::String",
+          "item_type_path": ""
+        },
+        {
+          "name": "weight",
+          "type_path": "u32",
+          "item_type_path": ""
+        }
+      ],
+      "kind": "Struct",
+      "default": {
+        "mob_project::content::LootDrop": {
+          "family": "",
+          "weight": 1
+        }
+      },
+      "variants": [],
+      "entity_fields": [],
+      "fills_gaps": true,
+      "asset": false
+    },
+    {
+      "type_path": "mob_project::content::Temper",
+      "short_name": "Temper",
+      "module_path": "mob_project::content",
+      "category": "",
+      "description": "",
+      "editor_description": "",
+      "hidden": false,
+      "preview": "",
+      "default_constructible": true,
+      "fields": [],
+      "kind": "Enum",
+      "default": {
+        "mob_project::content::Temper": "Calm"
+      },
+      "variants": [
+        {
+          "name": "Calm",
+          "fields": []
+        },
+        {
+          "name": "Skittish",
+          "fields": []
+        },
+        {
+          "name": "Fierce",
+          "fields": []
+        }
+      ],
+      "entity_fields": [],
+      "fills_gaps": true,
+      "asset": false
+    }
+  ]
+}

--- a/tests/inspector/main.rs
+++ b/tests/inspector/main.rs
@@ -13,5 +13,6 @@ mod definition_card;
 mod inspector_panel_width;
 mod inspector_preview_guard;
 mod inspector_val;
+mod opened_definition_card;
 mod schema_definition_card;
 mod widget_cards;

--- a/tests/inspector/opened_definition_card.rs
+++ b/tests/inspector/opened_definition_card.rs
@@ -1,0 +1,332 @@
+//! The inspector card for a definition opened from a file on disk.
+//!
+//! The project reports the type only as schema, and the file names itself with
+//! a kind segment its kind id never spells, so the card is built from the
+//! schema and the patch the file holds rather than from any registration.
+
+use std::path::{Path, PathBuf};
+
+use bevy::prelude::*;
+use jackdaw::definition_assets::OpenDefinition;
+use jackdaw::selection::Selection;
+use jackdaw_api::prelude::*;
+use jackdaw_api_internal::operator::{CallOperatorSettings, ExecutionContext};
+
+use crate::util;
+
+const MOB_TYPE: &str = "mob_project::content::MobArchetypeDef";
+
+const NODE: &str = "bevy_ui::ui_node::Node";
+
+fn fixture_dir() -> PathBuf {
+    Path::new(env!("CARGO_MANIFEST_DIR")).join("tests/fixtures/mob_project")
+}
+
+/// A hand-authored mob file, in a folder of its own and under a name carrying
+/// a kind segment its kind id never spells.
+const AUTHORED_RAT: &str = "\
+#giant_rat
+mob_project::content::MobArchetypeDef {
+    archetype_id: \"giant_rat\",
+    name: \"Giant Rat\",
+    max_health: 40,
+    move_speed: 4.0,
+    aggro_radius: 8.0,
+    leash_radius: 20.0,
+    temper: mob_project::content::Temper::Fierce,
+    drops: [
+        mob_project::content::LootDrop {
+            family: \"chest\",
+            weight: 6,
+        },
+        mob_project::content::LootDrop {
+            family: \"legs\",
+            weight: 2,
+        },
+    ],
+}
+";
+
+/// A copy of the fixture project, with its schema where a build leaves it and
+/// the rat's file under its assets.
+fn project_copy() -> tempfile::TempDir {
+    let tmp = tempfile::tempdir().expect("tempdir");
+    let fixture = fixture_dir();
+    std::fs::copy(
+        fixture.join("jackdaw.toml"),
+        tmp.path().join("jackdaw.toml"),
+    )
+    .expect("the manifest copies");
+    let jackdaw_dir = tmp.path().join(".jackdaw");
+    std::fs::create_dir_all(&jackdaw_dir).expect("the jackdaw directory is made");
+    std::fs::copy(fixture.join("schema.json"), jackdaw_dir.join("schema.json"))
+        .expect("the schema copies");
+    let mobs = tmp.path().join("assets/content/mobs");
+    std::fs::create_dir_all(&mobs).expect("the directory is made");
+    std::fs::write(
+        mobs.join("giant_rat.mob.bsn"),
+        jackdaw::asset_files::asset_file_text(MOB_TYPE, AUTHORED_RAT),
+    )
+    .expect("the file is written");
+    tmp
+}
+
+fn editor_with_the_rat_open() -> (App, tempfile::TempDir) {
+    let tmp = project_copy();
+    let mut app = util::editor_test_app();
+    app.world_mut()
+        .insert_resource(jackdaw::project::ProjectRoot {
+            root: tmp.path().to_path_buf(),
+            config: default(),
+        });
+    app.world_mut()
+        .spawn(jackdaw::layout::inspector_components_content(default()));
+    app.world_mut()
+        .resource_mut::<NextState<jackdaw::AppState>>()
+        .set(jackdaw::AppState::Editor);
+    app.update();
+    jackdaw::pie::refresh_project_types(app.world_mut());
+    for _ in 0..4 {
+        app.update();
+    }
+
+    let result = app
+        .world_mut()
+        .operator("asset.open")
+        .settings(CallOperatorSettings {
+            execution_context: ExecutionContext::Invoke,
+            creates_history_entry: false,
+        })
+        .param("path", "content/mobs/giant_rat.mob.bsn")
+        .call()
+        .expect("the operator dispatched");
+    assert_eq!(result, OperatorResult::Finished);
+    for _ in 0..8 {
+        app.update();
+    }
+    (app, tmp)
+}
+
+/// Whether a row is on screen: neither it nor anything it sits inside is
+/// switched off.
+fn on_screen(app: &App, entity: Entity) -> bool {
+    let mut current = entity;
+    loop {
+        if app
+            .world()
+            .get::<Node>(current)
+            .is_some_and(|node| node.display == Display::None)
+        {
+            return false;
+        }
+        match app.world().get::<ChildOf>(current) {
+            Some(parent) => current = parent.parent(),
+            None => return true,
+        }
+    }
+}
+
+/// Every control on the panel that writes a field, with the type it writes to.
+fn all_rows(app: &mut App) -> Vec<(Entity, String, String)> {
+    let entities: Vec<Entity> = app
+        .world_mut()
+        .query::<Entity>()
+        .iter(app.world())
+        .collect();
+    entities
+        .into_iter()
+        .filter_map(|entity| {
+            jackdaw::inspector::field_edited_by(app.world(), entity)
+                .map(|(type_path, field)| (entity, type_path.to_string(), field.to_string()))
+        })
+        .collect()
+}
+
+/// Every row on the panel writing a field of `type_path`.
+fn rows_of(app: &mut App, type_path: &str) -> Vec<Entity> {
+    all_rows(app)
+        .into_iter()
+        .filter(|(_, known, _)| known == type_path)
+        .map(|(entity, _, _)| entity)
+        .collect()
+}
+
+fn field_rows(app: &mut App) -> Vec<(Entity, String)> {
+    all_rows(app)
+        .into_iter()
+        .filter(|(_, type_path, _)| type_path == MOB_TYPE)
+        .map(|(entity, _, field)| (entity, field))
+        .collect()
+}
+
+#[track_caller]
+fn call(
+    app: &mut App,
+    id: &'static str,
+    params: &[(&'static str, jackdaw_scene_types::PropertyValue)],
+) {
+    let mut call = app.world_mut().operator(id).settings(CallOperatorSettings {
+        execution_context: ExecutionContext::Invoke,
+        creates_history_entry: false,
+    });
+    for (key, value) in params {
+        call = call.param(*key, value.clone());
+    }
+    let result = call.call().expect("the operator dispatched");
+    assert_eq!(result, OperatorResult::Finished, "{id} did not finish");
+    for _ in 0..4 {
+        app.update();
+    }
+}
+
+/// The name the card carries, as the header spells it and as the operators
+/// that open and close a card ask for it.
+const CARD_NAME: &str = "giant_rat (Mob Archetype)";
+
+fn definition_entity(app: &App) -> Entity {
+    app.world()
+        .resource::<OpenDefinition>()
+        .0
+        .expect("a definition is open")
+}
+
+/// Ask the inspector to build its cards again, saying nothing about the card
+/// the definition put up: the name is one no card carries.
+fn rebuild(app: &mut App) {
+    call(
+        app,
+        "inspector.card",
+        &[
+            ("name", "no card of this name".into()),
+            ("open", true.into()),
+        ],
+    );
+}
+
+#[test]
+fn opening_a_definition_file_fills_the_card_with_a_row_for_every_field() {
+    let (mut app, _tmp) = editor_with_the_rat_open();
+
+    let fields: Vec<String> = field_rows(&mut app)
+        .into_iter()
+        .map(|(_, field)| field)
+        .collect();
+    for expected in [
+        "archetype_id",
+        "name",
+        "max_health",
+        "move_speed",
+        "aggro_radius",
+        "leash_radius",
+        "drops[0].family",
+        "drops[1].weight",
+    ] {
+        assert!(
+            fields.iter().any(|field| field == expected),
+            "the card has a row for {expected}, got {fields:?}"
+        );
+    }
+}
+
+#[test]
+fn the_rows_of_an_opened_definition_are_on_screen() {
+    let (mut app, _tmp) = editor_with_the_rat_open();
+
+    let rows = field_rows(&mut app);
+    assert!(!rows.is_empty(), "the card built rows to show");
+    let hidden: Vec<&String> = rows
+        .iter()
+        .filter(|(entity, _)| !on_screen(&app, *entity))
+        .map(|(_, field)| field)
+        .collect();
+
+    assert!(
+        hidden.is_empty(),
+        "every row the card built is shown, hidden: {hidden:?}"
+    );
+}
+
+#[test]
+fn a_rebuild_replaces_the_card_rather_than_stacking_one_on_it() {
+    let (mut app, _tmp) = editor_with_the_rat_open();
+    let open = definition_entity(&app);
+    let before = field_rows(&mut app).len();
+    assert!(before > 0, "the card built rows to count");
+
+    app.world_mut().resource_mut::<Selection>().entities = vec![open];
+    rebuild(&mut app);
+
+    assert_eq!(
+        field_rows(&mut app).len(),
+        before,
+        "the rebuild left the same rows, not a second set of them"
+    );
+}
+
+#[test]
+fn the_card_opens_expanded_and_keeps_a_collapse_across_a_rebuild() {
+    let (mut app, _tmp) = editor_with_the_rat_open();
+    assert!(
+        field_rows(&mut app)
+            .iter()
+            .all(|(entity, _)| on_screen(&app, *entity)),
+        "the card opens expanded"
+    );
+
+    call(
+        &mut app,
+        "inspector.card",
+        &[("name", CARD_NAME.into()), ("open", false.into())],
+    );
+    let rows = field_rows(&mut app);
+    assert!(!rows.is_empty(), "the card still holds its rows");
+    assert!(
+        rows.iter().all(|(entity, _)| !on_screen(&app, *entity)),
+        "closing the card puts its rows away"
+    );
+
+    rebuild(&mut app);
+
+    let rows = field_rows(&mut app);
+    assert!(!rows.is_empty(), "the rebuilt card still holds its rows");
+    assert!(
+        rows.iter().all(|(entity, _)| !on_screen(&app, *entity)),
+        "and the rebuild leaves it closed"
+    );
+}
+
+#[test]
+fn no_category_tab_hides_the_card_and_an_entity_selected_after_it_gets_its_own() {
+    let (mut app, _tmp) = editor_with_the_rat_open();
+    call(
+        &mut app,
+        "inspector.category",
+        &[("category", "components".into())],
+    );
+
+    let rows = field_rows(&mut app);
+    assert!(!rows.is_empty(), "the card is still up");
+    assert!(
+        rows.iter().all(|(entity, _)| on_screen(&app, *entity)),
+        "a tab the definition has no part in does not hide its rows"
+    );
+
+    let entity = app
+        .world_mut()
+        .spawn((Name::new("lamp"), Node::default()))
+        .id();
+    jackdaw::scene_io::register_entity_in_ast(app.world_mut(), entity);
+    app.world_mut().resource_mut::<Selection>().entities = vec![entity];
+    for _ in 0..8 {
+        app.update();
+    }
+
+    assert!(
+        !rows_of(&mut app, NODE).is_empty(),
+        "the entity's own cards took the panel over"
+    );
+    assert!(
+        field_rows(&mut app).is_empty(),
+        "and the definition's card went with the definition"
+    );
+}

--- a/tests/stage/project_definitions.rs
+++ b/tests/stage/project_definitions.rs
@@ -755,3 +755,198 @@ fn a_colour_field_on_a_project_component_takes_channels() {
         "the colour is authored as a colour, not as the text it was typed as: {spelled}"
     );
 }
+
+/// A hand-authored item file, spelled the way the emitter writes one so a save
+/// that changes nothing changes no line.
+const AUTHORED_TORCH: &str = "\
+#torch
+definition_project::content::ItemDef {
+    stack_size: 12,
+    rarity: definition_project::content::Rarity::Rare,
+    loot: [
+        definition_project::content::LootRoll {
+            item: \"coin\",
+            weight: 3,
+        },
+        definition_project::content::LootRoll {
+            item: \"gem\",
+            weight: 7,
+        },
+    ],
+}
+";
+
+fn authored_torch() -> String {
+    jackdaw::asset_files::asset_file_text(ITEM_TYPE, AUTHORED_TORCH)
+}
+
+/// A project holding that file under a name carrying a kind segment.
+fn editor_on_an_authored_torch() -> (App, tempfile::TempDir, PathBuf) {
+    let tmp = project_copy();
+    let path = tmp.path().join("assets/content/torch.item.bsn");
+    std::fs::create_dir_all(path.parent().expect("a parent")).expect("the directory is made");
+    std::fs::write(&path, authored_torch()).expect("the file is written");
+    let app = editor_on(tmp.path());
+    (app, tmp, path)
+}
+
+#[test]
+fn a_re_saved_definition_keeps_the_root_name_its_file_carries() {
+    let (mut app, _tmp, path) = editor_on_an_authored_torch();
+    call(
+        &mut app,
+        "asset.open",
+        &[("path", path.to_string_lossy().into_owned().into())],
+    );
+
+    call(
+        &mut app,
+        "asset.set",
+        &[("field", "stack_size".into()), ("value", "20".into())],
+    );
+    call(&mut app, "asset.save", &[]);
+
+    let written = std::fs::read_to_string(&path).expect("the file reads");
+    assert!(
+        written.contains("#torch\n"),
+        "the root is still the one the file named, got:\n{written}"
+    );
+}
+
+#[test]
+fn a_new_definition_goes_by_the_file_it_was_asked_for_rather_than_the_name() {
+    let (mut app, tmp) = editor_with_items();
+
+    call(
+        &mut app,
+        "asset.new",
+        &[
+            ("type", "item".into()),
+            ("name", "torch".into()),
+            ("path", "content/lantern.item.bsn".into()),
+        ],
+    );
+
+    assert!(
+        tmp.path().join("assets/content/lantern.item.bsn").is_file(),
+        "the file the caller named is the file that is written"
+    );
+    assert_eq!(
+        app.world()
+            .resource::<DefinitionRegistry>()
+            .names_of("item"),
+        vec!["lantern".to_string()],
+        "and the name is the one a scan would read back from it"
+    );
+}
+
+#[test]
+fn a_re_saved_definition_keeps_a_quoted_root_name_quoted() {
+    let tmp = project_copy();
+    let path = tmp.path().join("assets/content/torch.item.bsn");
+    std::fs::create_dir_all(path.parent().expect("a parent")).expect("the directory is made");
+    let quoted = AUTHORED_TORCH.replace("#torch", "#\"torch.item\"");
+    std::fs::write(
+        &path,
+        jackdaw::asset_files::asset_file_text(ITEM_TYPE, &quoted),
+    )
+    .expect("the file is written");
+    let mut app = editor_on(tmp.path());
+    call(
+        &mut app,
+        "asset.open",
+        &[("path", path.to_string_lossy().into_owned().into())],
+    );
+
+    call(
+        &mut app,
+        "asset.set",
+        &[("field", "stack_size".into()), ("value", "20".into())],
+    );
+    call(&mut app, "asset.save", &[]);
+
+    let written = std::fs::read_to_string(&path).expect("the file reads");
+    assert!(
+        written.contains("#\"torch.item\"\n"),
+        "the name the file spells survives the save, got:\n{written}"
+    );
+}
+
+#[test]
+fn a_definition_is_named_by_the_stem_before_the_first_dot_of_its_file() {
+    let (app, _tmp, _path) = editor_on_an_authored_torch();
+
+    assert_eq!(
+        app.world()
+            .resource::<DefinitionRegistry>()
+            .names_of("item"),
+        vec!["torch".to_string()],
+        "the kind segment the file carries is no part of the name"
+    );
+}
+
+#[test]
+fn a_new_definition_asked_for_by_a_file_path_drops_its_kind_segment() {
+    let (mut app, tmp) = editor_with_items();
+
+    call(
+        &mut app,
+        "asset.new",
+        &[
+            ("type", "item".into()),
+            ("path", "content/lantern.item.bsn".into()),
+        ],
+    );
+
+    let path = tmp.path().join("assets/content/lantern.item.bsn");
+    assert!(path.is_file(), "asset.new writes the file at {path:?}");
+    assert_eq!(
+        app.world()
+            .resource::<DefinitionRegistry>()
+            .names_of("item"),
+        vec!["lantern".to_string()],
+    );
+    let written = std::fs::read_to_string(&path).expect("the file reads");
+    assert!(
+        written.contains("#lantern\n"),
+        "and its root is that name, got:\n{written}"
+    );
+}
+
+#[test]
+fn editing_one_field_of_a_loaded_file_rewrites_one_line() {
+    let (mut app, _tmp, path) = editor_on_an_authored_torch();
+    call(
+        &mut app,
+        "asset.open",
+        &[("path", path.to_string_lossy().into_owned().into())],
+    );
+    let before = authored_torch();
+
+    call(
+        &mut app,
+        "asset.set",
+        &[("field", "stack_size".into()), ("value", "20".into())],
+    );
+    call(&mut app, "asset.save", &[]);
+
+    let after = std::fs::read_to_string(&path).expect("the file reads");
+    let before_lines: Vec<&str> = before.lines().collect();
+    let after_lines: Vec<&str> = after.lines().collect();
+    assert_eq!(
+        before_lines.len(),
+        after_lines.len(),
+        "the file keeps its shape, got:\n{after}"
+    );
+    let changed: Vec<(&str, &str)> = before_lines
+        .iter()
+        .zip(&after_lines)
+        .filter(|(before, after)| before != after)
+        .map(|(before, after)| (*before, *after))
+        .collect();
+    assert_eq!(
+        changed,
+        vec![("    stack_size: 12,", "    stack_size: 20,")],
+        "only the field that was edited moved, got:\n{after}"
+    );
+}


### PR DESCRIPTION
The inspector card for a schema-backed definition rendered nothing. It now shows every field the schema describes, with enums as menus and lists editable, and warns once when a type is missing from the schema.

Saving a definition renamed its root and rewrote the whole file. A save now keeps the root name, emits fields in declared order and keeps list commas, so a one-field edit is a one-line diff.

LLM disclaimer: Claude Code was used to help plan and implement this change, but all code was human reviewed by myself!
