### PR TITLE
Index asset files by path and remove old registries

### DIFF
--- a/book/src/developer-guide/bsn-format.md
+++ b/book/src/developer-guide/bsn-format.md
@@ -104,8 +104,11 @@ intentionally opaque to the config (consumers parse it as the
 
 ## Catalog file
 
-Project-wide named assets live in `assets/catalog.bsn`. Any
-scene in the project can reference them with `@Name`. Legacy
+An asset file is a `.bsn` naming the type it holds, and it can
+sit in any folder under `assets/`; the editor indexes every one
+it finds by the path it sits at. `assets/catalog.bsn` holds only
+what has no file of its own. Any scene in the project can
+reference either with `@Name`. Legacy
 catalogs at `.jsn/catalog.jsn` or `assets/catalog.jsn` are read
 for migration and rewritten to `assets/catalog.bsn` on the
 next save.

--- a/book/src/user-guide/materials-textures.md
+++ b/book/src/user-guide/materials-textures.md
@@ -75,9 +75,11 @@ Two storage tiers:
 
 - Scene-local: the material lives only inside the current
   `.bsn`. References use `#Name`.
-- Project-wide: it lives in `assets/catalog.bsn` and any
-  scene in the project can reference it. References use
-  `@Name`.
+- Project-wide: it lives in a `.bsn` file of its own, in
+  whatever folder you keep it in; the editor finds it by
+  reading what the file holds. A save with no folder in mind
+  puts it under `assets/materials/`. Any scene in the project
+  can reference it, and references use `@Name`.
 
 The browser shows both, with the source labelled.
 

--- a/src/asset_catalog.rs
+++ b/src/asset_catalog.rs
@@ -22,6 +22,9 @@ pub struct AssetCatalog {
     pub id_to_name: HashMap<UntypedAssetId, String>,
     /// Whether the catalog has unsaved changes.
     pub dirty: bool,
+    /// Names of material entries the catalog file still holds inline, which
+    /// the next save writes out as files of their own.
+    pub inline_materials: HashSet<String>,
     /// Set when `catalog.bsn` existed but could not be read or parsed.
     ///
     /// The loaded map is then an unknown fraction of the file, so writing it
@@ -57,6 +60,12 @@ impl AssetCatalog {
     }
 }
 
+/// Whether a catalog entry is a `StandardMaterial`, and so belongs in a file
+/// of its own rather than in the catalog file.
+fn is_material(handle: &UntypedHandle) -> bool {
+    handle.type_id() == std::any::TypeId::of::<StandardMaterial>()
+}
+
 /// Whether catalog text carries no entries: only comments and whitespace. Such
 /// a file loads as an empty catalog rather than as a parse failure.
 fn is_empty_catalog_text(text: &str) -> bool {
@@ -65,42 +74,16 @@ fn is_empty_catalog_text(text: &str) -> bool {
         .all(|line| line.trim().is_empty())
 }
 
-/// Populate [`AssetCatalog`] for the open project: the `assets/materials`
-/// files first, then whatever `catalog.bsn` holds.
+/// Populate [`AssetCatalog`] from whatever `catalog.bsn` holds.
 ///
-/// Inline material entries in `catalog.bsn` load normally and are flagged dirty,
-/// so the next save writes them out as `.material.bsn` files and drops them from
-/// the catalog file.
+/// The project's material files are indexed and named before this runs, so
+/// their linear-space textures have claimed their paths and a filed material
+/// wins its name over an inline entry of the same name.
+///
+/// Inline material entries in `catalog.bsn` load normally and are flagged
+/// dirty, so the next save writes them out as files of their own and drops them
+/// from the catalog file.
 pub fn load_catalog(world: &mut World) {
-    // Materials load first so their linear-space textures claim their paths before the
-    // catalog file's generic applier resolves the same paths as sRGB, and so a saved
-    // material wins its name.
-    let materials = crate::material_assets::load_material_files(world);
-    let count = materials.len();
-    for (name, handle) in materials {
-        world
-            .resource_mut::<AssetCatalog>()
-            .insert(format!("@{name}"), handle);
-        world
-            .resource_mut::<crate::material_assets::SavedMaterials>()
-            .0
-            .insert(name);
-    }
-    if count > 0 {
-        info!("Loaded {count} saved materials");
-    }
-
-    load_catalog_file(world);
-}
-
-/// Whether a catalog entry is a `StandardMaterial`, and so belongs in
-/// `assets/materials` rather than the catalog file.
-fn is_material(handle: &UntypedHandle) -> bool {
-    handle.type_id() == std::any::TypeId::of::<StandardMaterial>()
-}
-
-/// Load `assets/catalog.bsn` (or a legacy location) into [`AssetCatalog`].
-fn load_catalog_file(world: &mut World) {
     let catalog_path = catalog_file_path(world);
     let Some(catalog_path) = catalog_path else {
         info!("No project root, skipping catalog load");
@@ -147,8 +130,8 @@ fn load_catalog_file(world: &mut World) {
                         {
                             migratable += 1;
                             world
-                                .resource_mut::<crate::material_assets::SavedMaterials>()
-                                .0
+                                .resource_mut::<AssetCatalog>()
+                                .inline_materials
                                 .insert(entry.name.clone());
                         } else {
                             warn!(
@@ -318,7 +301,7 @@ fn catalog_save_path(world: &World) -> Option<std::path::PathBuf> {
 #[cfg(test)]
 mod tests {
     use super::*;
-    use crate::material_assets::{MaterialRegistry, SavedMaterials};
+    use crate::material_assets::MaterialRegistry;
     use crate::project::{ProjectConfig, ProjectRoot};
     use bevy::app::App;
     use bevy::asset::{AssetApp, AssetPlugin};
@@ -339,7 +322,6 @@ mod tests {
         });
         app.init_resource::<AssetCatalog>();
         app.init_resource::<MaterialRegistry>();
-        app.init_resource::<SavedMaterials>();
         std::fs::create_dir_all(tmp.path().join("assets")).expect("assets dir");
         (app, tmp)
     }

--- a/src/asset_index.rs
+++ b/src/asset_index.rs
@@ -1,0 +1,678 @@
+//! One index of every asset file the open project holds, keyed by the path the
+//! file sits at under `assets/`.
+//!
+//! A path is the identity. An entry records what the file says it holds, the
+//! kind that claims that type, the value the editor loaded from it and the
+//! modification time the load saw, so a file rewritten by another tool reloads
+//! into the handle references already point at. `by_id` turns a loaded handle
+//! back into the path it came from, and `by_stem` resolves the bare names that
+//! older scenes and sidecars still spell.
+//!
+//! The index is built by one walk of the project's assets when the project
+//! opens and kept in step by a watcher on the same directory. A kind the
+//! editor has compiled in and loads elsewhere, such as an animation graph,
+//! is listed here without a value.
+
+use std::collections::{BTreeMap, HashMap, HashSet};
+use std::path::{Path, PathBuf};
+use std::sync::{Mutex, mpsc};
+use std::time::SystemTime;
+
+use bevy::asset::{ReflectAsset, UntypedAssetId, UntypedHandle};
+use bevy::prelude::*;
+use jackdaw_api::prelude::{AssetKind, AssetKinds};
+use jackdaw_bsn::BsnStructData;
+use path_slash::PathExt as _;
+
+use crate::asset_files::{AssetFileKind, AssetKindCache, walk_document_files};
+use crate::definition_assets::{MATERIAL_KIND, definition_name_of};
+use crate::project::ProjectRoot;
+
+/// What the editor loaded out of an asset file.
+#[derive(Clone, Debug)]
+pub enum AssetValue {
+    /// A value in its type's asset store.
+    Handle(UntypedHandle),
+    /// A value of a type the editor knows only as the project's schema, held
+    /// as the patch its file spells.
+    Schema(Box<BsnStructData>),
+    /// A file whose kind is loaded by the subsystem that owns it.
+    Unloaded,
+}
+
+impl AssetValue {
+    pub fn handle(&self) -> Option<&UntypedHandle> {
+        match self {
+            Self::Handle(handle) => Some(handle),
+            _ => None,
+        }
+    }
+
+    pub fn schema(&self) -> Option<&BsnStructData> {
+        match self {
+            Self::Schema(data) => Some(data),
+            _ => None,
+        }
+    }
+}
+
+/// One asset file, as the index knows it.
+#[derive(Clone, Debug)]
+pub struct AssetEntry {
+    /// Where the file sits, relative to the project's assets directory.
+    pub path: PathBuf,
+    pub kind: String,
+    pub type_path: String,
+    pub file_kind: AssetFileKind,
+    pub value: AssetValue,
+    pub mtime: SystemTime,
+}
+
+impl AssetEntry {
+    /// The bare name the file's stem gives it: everything before the first dot
+    /// of its file name, so `torch.item.bsn` is `torch`.
+    pub fn name(&self) -> String {
+        definition_name_of(&self.path)
+    }
+}
+
+/// Every asset file the open project holds.
+#[derive(Resource, Default)]
+pub struct AssetIndex {
+    entries: BTreeMap<PathBuf, AssetEntry>,
+    by_id: HashMap<UntypedAssetId, PathBuf>,
+    warned_stems: Mutex<HashSet<String>>,
+}
+
+impl AssetIndex {
+    pub fn get(&self, path: &Path) -> Option<&AssetEntry> {
+        self.entries.get(path)
+    }
+
+    pub fn get_mut(&mut self, path: &Path) -> Option<&mut AssetEntry> {
+        self.entries.get_mut(path)
+    }
+
+    pub fn iter(&self) -> impl Iterator<Item = &AssetEntry> {
+        self.entries.values()
+    }
+
+    pub fn of_kind<'a>(&'a self, kind: &'a str) -> impl Iterator<Item = &'a AssetEntry> {
+        self.entries
+            .values()
+            .filter(move |entry| entry.kind == kind)
+    }
+
+    /// The files of a kind, as the paths that name them.
+    pub fn paths_of_kind(&self, kind: &str) -> Vec<String> {
+        self.of_kind(kind)
+            .map(|entry| entry.path.to_slash_lossy().into_owned())
+            .collect()
+    }
+
+    /// The file a loaded handle came from.
+    pub fn path_of_id(&self, id: UntypedAssetId) -> Option<&Path> {
+        self.by_id.get(&id).map(PathBuf::as_path)
+    }
+
+    /// The entry a loaded handle came from.
+    pub fn by_handle(&self, handle: &UntypedHandle) -> Option<&AssetEntry> {
+        self.entries.get(self.by_id.get(&handle.id())?)
+    }
+
+    /// Every file whose stem is `stem`.
+    pub fn stem_paths(&self, stem: &str) -> Vec<PathBuf> {
+        self.entries
+            .values()
+            .filter(|entry| entry.name() == stem)
+            .map(|entry| entry.path.clone())
+            .collect()
+    }
+
+    /// The file a bare name stands for, for the references written before
+    /// paths. A stem two files share stands for neither, and says so once.
+    pub fn by_stem(&self, stem: &str) -> Option<&AssetEntry> {
+        let mut matching = self.entries.values().filter(|entry| entry.name() == stem);
+        let first = matching.next()?;
+        let Some(second) = matching.next() else {
+            return Some(first);
+        };
+        if let Ok(mut warned) = self.warned_stems.lock()
+            && warned.insert(stem.to_string())
+        {
+            warn!(
+                "'{stem}' names both {} and {}; spell the one you mean as a path",
+                first.path.display(),
+                second.path.display()
+            );
+        }
+        None
+    }
+
+    /// The material file holding this name, for the references and the panels
+    /// that still spell a material by its stem.
+    pub fn material_named(&self, name: &str) -> Option<&AssetEntry> {
+        self.by_stem(name)
+            .filter(|entry| entry.kind == MATERIAL_KIND)
+    }
+
+    pub fn insert(&mut self, entry: AssetEntry) {
+        if let Some(handle) = entry.value.handle() {
+            self.by_id.insert(handle.id(), entry.path.clone());
+        }
+        self.entries.insert(entry.path.clone(), entry);
+    }
+
+    pub fn remove(&mut self, path: &Path) -> Option<AssetEntry> {
+        let entry = self.entries.remove(path)?;
+        if let Some(handle) = entry.value.handle() {
+            self.by_id.remove(&handle.id());
+        }
+        Some(entry)
+    }
+
+    /// Drop every entry whose kind is no longer registered.
+    fn retain_kinds(&mut self, kinds: &[String]) {
+        let gone: Vec<PathBuf> = self
+            .entries
+            .values()
+            .filter(|entry| !kinds.contains(&entry.kind))
+            .map(|entry| entry.path.clone())
+            .collect();
+        for path in gone {
+            self.remove(&path);
+        }
+    }
+}
+
+/// What a rescan of the project's assets found.
+#[derive(Default, Debug, PartialEq, Eq)]
+pub struct AssetRescan {
+    /// Files that appeared since the last scan.
+    pub added: Vec<PathBuf>,
+    /// Files that have gone.
+    pub removed: Vec<PathBuf>,
+    /// Files that changed on disk and were read again into the handle they
+    /// already had.
+    pub reloaded: Vec<PathBuf>,
+}
+
+/// The project's assets directory, if one is open.
+pub fn assets_dir(world: &World) -> Option<PathBuf> {
+    world
+        .get_resource::<ProjectRoot>()
+        .map(ProjectRoot::assets_dir)
+}
+
+/// An indexed path as the file it names on disk.
+pub fn absolute_path(world: &World, path: &Path) -> PathBuf {
+    if path.is_absolute() {
+        return path.to_path_buf();
+    }
+    match assets_dir(world) {
+        Some(assets) => assets.join(path),
+        None => path.to_path_buf(),
+    }
+}
+
+/// A file on disk as the path the index keys it by. `None` for a file outside
+/// the project's assets, including one a relative path walks out to.
+pub fn indexed_path(world: &World, path: &Path) -> Option<PathBuf> {
+    let assets = assets_dir(world)?;
+    if let Ok(relative) = path.strip_prefix(&assets) {
+        return Some(relative.to_path_buf());
+    }
+    let stays_under = !path.is_absolute()
+        && !path
+            .components()
+            .any(|part| part == std::path::Component::ParentDir);
+    stays_under.then(|| path.to_path_buf())
+}
+
+/// Whether an indexed path is the project's catalog file, which holds what has
+/// no file of its own and is no asset in its own right.
+pub fn is_catalog_file(path: &Path) -> bool {
+    matches!(path.to_str(), Some("catalog.bsn") | Some("catalog.jsn"))
+}
+
+/// What a file says it holds, and the kind that claims it.
+fn kind_of_file(path: &Path, kinds: &AssetKinds, cache: &mut AssetKindCache) -> Option<AssetKind> {
+    let AssetFileKind::Asset { type_path } = cache.check(path, kinds) else {
+        return None;
+    };
+    kinds.by_type_path(&type_path).cloned()
+}
+
+/// Read one asset file into whatever holds values of its kind.
+///
+/// A material the editor is already using under the name this file's stem
+/// gives it takes the file's value rather than a second handle, so the panels
+/// and the brush faces holding it follow what the file says.
+pub fn load_asset_value(world: &mut World, kind: &AssetKind, path: &Path) -> Option<AssetValue> {
+    if kind.kind == MATERIAL_KIND {
+        let handle = crate::material_assets::load_material_file(world, path)?;
+        let in_use = material_handle_in_use(world, path);
+        return match in_use {
+            Some(in_use) => Some(move_value(world, kind, &handle, &in_use)),
+            None => Some(AssetValue::Handle(handle)),
+        };
+    }
+    if !kind.scanned() {
+        return Some(AssetValue::Unloaded);
+    }
+    crate::definition_assets::read_asset_file(world, kind, path)
+}
+
+/// The handle a material's name already answers to, when no file of its own
+/// has claimed it: a set detected from its textures, or one created and saved
+/// in this session.
+fn material_handle_in_use(world: &World, path: &Path) -> Option<UntypedHandle> {
+    let name = definition_name_of(path);
+    let listed = world
+        .get_resource::<crate::material_assets::MaterialRegistry>()
+        .and_then(|registry| registry.get_by_name(&name))
+        .filter(|entry| entry.handle != Handle::default())
+        .map(|entry| entry.handle.clone().untyped());
+    let named = world
+        .get_resource::<crate::asset_catalog::AssetCatalog>()
+        .and_then(|catalog| catalog.handles.get(&format!("@{name}")).cloned());
+    let handle = listed
+        .or(named)
+        .filter(|handle| handle.type_id() == std::any::TypeId::of::<StandardMaterial>())?;
+    let claimed = world
+        .get_resource::<AssetIndex>()
+        .is_some_and(|index| index.by_handle(&handle).is_some());
+    (!claimed).then_some(handle)
+}
+
+/// Read a changed file back into the handle the loaded one already has, so
+/// everything holding that handle sees the new value.
+fn reload_in_place(
+    world: &mut World,
+    kind: &AssetKind,
+    path: &Path,
+    held: &AssetValue,
+) -> Option<AssetValue> {
+    let fresh = load_asset_value(world, kind, path)?;
+    let (Some(held), Some(fresh_handle)) = (held.handle(), fresh.handle()) else {
+        return Some(fresh);
+    };
+    Some(move_value(world, kind, fresh_handle, held))
+}
+
+/// Move a freshly read value into the handle the editor is already handing
+/// out, leaving the fresh one empty.
+fn move_value(
+    world: &mut World,
+    kind: &AssetKind,
+    fresh: &UntypedHandle,
+    into: &UntypedHandle,
+) -> AssetValue {
+    if fresh.id() == into.id() {
+        return AssetValue::Handle(into.clone());
+    }
+    let registry = world.resource::<AppTypeRegistry>().clone();
+    let reflect_asset = registry
+        .read()
+        .get_with_type_path(&kind.type_path)
+        .and_then(|registration| registration.data::<ReflectAsset>())
+        .cloned();
+    let moved = reflect_asset.and_then(|reflect_asset| {
+        let value = reflect_asset.remove(world, fresh.id())?;
+        reflect_asset
+            .insert(world, into.id(), value.as_partial_reflect())
+            .ok()
+    });
+    match moved {
+        Some(()) => AssetValue::Handle(into.clone()),
+        None => AssetValue::Handle(fresh.clone()),
+    }
+}
+
+/// Walk the project's assets and bring the index up to what is on disk.
+///
+/// A file that appeared is read and indexed. A file that changed is read again
+/// into the handle it already had, unless the card editing it has unsaved
+/// edits, which are what the user meant to keep. A file that has gone leaves
+/// the index and closes its card, unless that card holds unsaved edits and so
+/// has somewhere to write the file back from; its handle stays alive so
+/// whatever already references it keeps rendering.
+pub fn rescan_asset_index(world: &mut World) -> AssetRescan {
+    let mut scan = AssetRescan::default();
+    let Some(assets) = assets_dir(world) else {
+        return scan;
+    };
+    world.get_resource_or_init::<AssetKindCache>();
+    if !world.contains_resource::<AssetIndex>() {
+        world.init_resource::<AssetIndex>();
+    }
+
+    let found = world.resource_scope(|world, mut cache: Mut<AssetKindCache>| {
+        let Some(kinds) = world.get_resource::<AssetKinds>() else {
+            return Vec::new();
+        };
+        walk_document_files(&assets)
+            .into_iter()
+            .filter_map(|path| {
+                let relative = path.strip_prefix(&assets).ok()?.to_path_buf();
+                if is_catalog_file(&relative) {
+                    return None;
+                }
+                let kind = kind_of_file(&path, kinds, &mut cache)?;
+                let mtime = std::fs::metadata(&path)
+                    .and_then(|meta| meta.modified())
+                    .ok()?;
+                Some((relative, kind, mtime))
+            })
+            .collect::<Vec<_>>()
+    });
+
+    let gone: Vec<PathBuf> = world
+        .resource::<AssetIndex>()
+        .iter()
+        .map(|entry| entry.path.clone())
+        .filter(|path| !found.iter().any(|(relative, _, _)| relative == path))
+        .collect();
+    for path in gone {
+        if crate::definition_assets::card_has_unsaved_edits(world, &path) {
+            continue;
+        }
+        if assets.join(&path).is_file() {
+            warn!(
+                "{} no longer holds a type this project knows",
+                path.display()
+            );
+        }
+        world.resource_mut::<AssetIndex>().remove(&path);
+        crate::definition_assets::close_card_for(world, &path);
+        scan.removed.push(path);
+    }
+
+    for (relative, kind, mtime) in found {
+        let held = world
+            .resource::<AssetIndex>()
+            .get(&relative)
+            .map(|entry| (entry.mtime, entry.value.clone(), entry.kind.clone()));
+        let file = assets.join(&relative);
+        let value = match held {
+            Some((known, _, _)) if known == mtime => continue,
+            Some((_, _, known_kind)) if known_kind != kind.kind => {
+                world.resource_mut::<AssetIndex>().remove(&relative);
+                let Some(value) = load_asset_value(world, &kind, &file) else {
+                    continue;
+                };
+                scan.added.push(relative.clone());
+                value
+            }
+            Some((_, held, _)) => {
+                if crate::definition_assets::card_has_unsaved_edits(world, &relative) {
+                    continue;
+                }
+                let Some(value) = reload_in_place(world, &kind, &file, &held) else {
+                    continue;
+                };
+                scan.reloaded.push(relative.clone());
+                value
+            }
+            None => {
+                let Some(value) = load_asset_value(world, &kind, &file) else {
+                    continue;
+                };
+                scan.added.push(relative.clone());
+                value
+            }
+        };
+        publish_name(world, &relative, &kind, &value);
+        world.resource_mut::<AssetIndex>().insert(AssetEntry {
+            path: relative,
+            kind: kind.kind.clone(),
+            type_path: kind.type_path.clone(),
+            file_kind: AssetFileKind::Asset {
+                type_path: kind.type_path.clone(),
+            },
+            value,
+            mtime,
+        });
+    }
+    scan
+}
+
+/// Keep the bare name a material file's stem gives it resolving, for the brush
+/// faces, terrain slots and scenes written before references were paths.
+fn publish_name(world: &mut World, path: &Path, kind: &AssetKind, value: &AssetValue) {
+    if kind.kind != MATERIAL_KIND {
+        return;
+    }
+    let Some(handle) = value.handle() else {
+        return;
+    };
+    let name = definition_name_of(path);
+    world
+        .resource_mut::<crate::asset_catalog::AssetCatalog>()
+        .insert(format!("@{name}"), handle.clone());
+}
+
+/// Record a file the editor itself wrote, holding the value it wrote, and
+/// report the path the index keys it by.
+pub fn index_written(
+    world: &mut World,
+    file: &Path,
+    kind: &AssetKind,
+    value: AssetValue,
+) -> Option<PathBuf> {
+    let indexed = indexed_path(world, file)?;
+    let mtime = std::fs::metadata(file)
+        .and_then(|meta| meta.modified())
+        .unwrap_or(SystemTime::UNIX_EPOCH);
+    publish_name(world, &indexed, kind, &value);
+    world.resource_mut::<AssetIndex>().insert(AssetEntry {
+        path: indexed.clone(),
+        kind: kind.kind.clone(),
+        type_path: kind.type_path.clone(),
+        file_kind: AssetFileKind::Asset {
+            type_path: kind.type_path.clone(),
+        },
+        value,
+        mtime,
+    });
+    Some(indexed)
+}
+
+/// Record that a file was written, so the next scan does not read back what
+/// the editor itself just wrote.
+pub fn note_written(world: &mut World, path: &Path) {
+    let Some(relative) = indexed_path(world, path) else {
+        return;
+    };
+    let Ok(mtime) = std::fs::metadata(path).and_then(|meta| meta.modified()) else {
+        return;
+    };
+    if let Some(entry) = world.resource_mut::<AssetIndex>().get_mut(&relative) {
+        entry.mtime = mtime;
+    }
+}
+
+/// Watches the project's assets so a file written by another tool is indexed
+/// without reopening the project.
+#[derive(Resource)]
+struct AssetFileWatcher {
+    _watcher: notify::RecommendedWatcher,
+    receiver: Mutex<mpsc::Receiver<()>>,
+}
+
+#[derive(Resource, Default)]
+struct AssetScanPending(bool);
+
+pub(crate) fn plugin(app: &mut App) {
+    app.init_resource::<AssetIndex>()
+        .init_resource::<AssetKindCache>()
+        .init_resource::<AssetScanPending>()
+        .add_systems(OnEnter(crate::AppState::Editor), open_asset_index)
+        .add_systems(
+            Update,
+            (
+                follow_asset_kinds.run_if(resource_changed::<AssetKinds>),
+                poll_asset_watcher,
+                apply_asset_scan,
+            )
+                .chain()
+                .run_if(in_state(crate::AppState::Editor)),
+        );
+}
+
+/// Index the open project's assets and start watching them.
+pub fn open_asset_index(world: &mut World) {
+    watch_asset_files(world);
+    let scan = rescan_asset_index(world);
+    if !scan.added.is_empty() {
+        info!("Indexed {} asset files", scan.added.len());
+    }
+}
+
+fn watch_asset_files(world: &mut World) {
+    let Some(assets) = assets_dir(world) else {
+        return;
+    };
+    let (sender, receiver) = mpsc::channel();
+    let watcher =
+        notify::recommended_watcher(move |event: Result<notify::Event, notify::Error>| {
+            use notify::EventKind;
+            if let Ok(event) = event
+                && matches!(
+                    event.kind,
+                    EventKind::Create(_) | EventKind::Remove(_) | EventKind::Modify(_)
+                )
+            {
+                let _ = sender.send(());
+            }
+        });
+    let Ok(mut watcher) = watcher else { return };
+    use notify::Watcher as _;
+    if watcher
+        .watch(&assets, notify::RecursiveMode::Recursive)
+        .is_ok()
+    {
+        world.insert_resource(AssetFileWatcher {
+            _watcher: watcher,
+            receiver: Mutex::new(receiver),
+        });
+    }
+}
+
+fn poll_asset_watcher(
+    watcher: Option<Res<AssetFileWatcher>>,
+    mut pending: ResMut<AssetScanPending>,
+) {
+    let Some(watcher) = watcher else { return };
+    let Ok(receiver) = watcher.receiver.lock() else {
+        return;
+    };
+    if receiver.try_recv().is_ok() {
+        while receiver.try_recv().is_ok() {}
+        pending.0 = true;
+    }
+}
+
+/// Follow the registered kinds: a kind that has gone takes its entries and its
+/// open card with it, and a kind that has arrived gets the assets walked again.
+fn follow_asset_kinds(world: &mut World) {
+    let kinds: Vec<String> = world
+        .get_resource::<AssetKinds>()
+        .map(|kinds| kinds.iter().map(|kind| kind.kind.clone()).collect())
+        .unwrap_or_default();
+    world.resource_mut::<AssetIndex>().retain_kinds(&kinds);
+    crate::definition_assets::close_card_of_missing_kind(world, &kinds);
+    world.resource_mut::<AssetScanPending>().0 = true;
+}
+
+fn apply_asset_scan(world: &mut World) {
+    if !std::mem::take(&mut world.resource_mut::<AssetScanPending>().0) {
+        return;
+    }
+    rescan_asset_index(world);
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn a_stem_two_files_share_resolves_to_neither_and_names_both() {
+        let mut index = AssetIndex::default();
+        for folder in ["content/items", "content/props"] {
+            index.insert(AssetEntry {
+                path: PathBuf::from(folder).join("torch.bsn"),
+                kind: "item".to_string(),
+                type_path: "my_game::ItemDef".to_string(),
+                file_kind: AssetFileKind::Asset {
+                    type_path: "my_game::ItemDef".to_string(),
+                },
+                value: AssetValue::Unloaded,
+                mtime: SystemTime::UNIX_EPOCH,
+            });
+        }
+
+        assert!(
+            index.by_stem("torch").is_none(),
+            "a name two files answer to names neither"
+        );
+        assert_eq!(
+            index.stem_paths("torch"),
+            vec![
+                PathBuf::from("content/items/torch.bsn"),
+                PathBuf::from("content/props/torch.bsn"),
+            ],
+            "and both files are there to be named by their paths"
+        );
+    }
+
+    #[test]
+    fn a_lone_stem_still_resolves() {
+        let mut index = AssetIndex::default();
+        index.insert(AssetEntry {
+            path: PathBuf::from("anywhere/torch.item.bsn"),
+            kind: "item".to_string(),
+            type_path: "my_game::ItemDef".to_string(),
+            file_kind: AssetFileKind::Asset {
+                type_path: "my_game::ItemDef".to_string(),
+            },
+            value: AssetValue::Unloaded,
+            mtime: SystemTime::UNIX_EPOCH,
+        });
+
+        assert_eq!(
+            index.by_stem("torch").map(|entry| entry.path.clone()),
+            Some(PathBuf::from("anywhere/torch.item.bsn"))
+        );
+    }
+
+    #[test]
+    fn a_file_outside_the_projects_assets_is_not_indexed() {
+        let tmp = tempfile::tempdir().expect("tempdir");
+        let mut world = World::new();
+        world.insert_resource(ProjectRoot {
+            root: tmp.path().to_path_buf(),
+            config: crate::project::ProjectConfig::default(),
+        });
+        let assets = tmp.path().join("assets");
+
+        assert_eq!(
+            indexed_path(&world, &assets.join("materials/slate.bsn")),
+            Some(PathBuf::from("materials/slate.bsn"))
+        );
+        assert_eq!(
+            indexed_path(&world, Path::new("materials/slate.bsn")),
+            Some(PathBuf::from("materials/slate.bsn")),
+            "a path already relative to the assets is taken as it stands"
+        );
+        assert_eq!(
+            indexed_path(&world, Path::new("/elsewhere/slate.bsn")),
+            None
+        );
+        assert_eq!(
+            indexed_path(&world, Path::new("../slate.bsn")),
+            None,
+            "a relative path that walks out of the assets names nothing here"
+        );
+    }
+}

--- a/src/definition_assets.rs
+++ b/src/definition_assets.rs
@@ -1,22 +1,20 @@
-//! Definition assets: one reflected value per file, anywhere under the
-//! project's assets.
+//! Editing one asset file: opening it, writing its fields and saving it back.
 //!
 //! A file says which type it holds, so the editor finds a kind's files by
-//! reading them rather than by where they sit. A type the editor has compiled
-//! in loads through [`jackdaw_bsn::load_bsn_assets`] and saves through
-//! [`jackdaw_bsn::serialize_assets_to_bsn`]; a type the open project reported
-//! in its schema is known no other way, so its files load into
-//! [`DefinitionValues`] as the patch they hold and save back through the same
-//! emitter. Either way a file holds only what the value changes from its
-//! default.
+//! reading them rather than by where they sit, and
+//! [`crate::asset_index::AssetIndex`] holds what every one of them loaded to. A
+//! type the editor has compiled in loads through [`jackdaw_bsn::load_bsn_assets`]
+//! and saves through [`jackdaw_bsn::serialize_assets_to_bsn`]; a type the open
+//! project reported in its schema is known no other way, so its files load as
+//! the patch they hold and save back through the same emitter. Either way a
+//! file holds only what the value changes from its default.
 //!
-//! Opening a definition puts it in the inspector: the open definition rides on
-//! an editor entity carrying [`DefinitionAssetEdit`], the field rows read the
-//! value it names instead of a component, and their edits come back here as
+//! Opening an asset puts it in the inspector: the open asset rides on an editor
+//! entity carrying [`DefinitionAssetEdit`], the field rows read the value at
+//! the path it names instead of a component, and their edits come back here as
 //! [`SetDefinitionField`] undo entries.
 
 use std::path::{Path, PathBuf};
-use std::sync::{Mutex, mpsc};
 
 use bevy::asset::{ReflectAsset, UntypedHandle};
 use bevy::prelude::*;
@@ -28,143 +26,46 @@ use jackdaw_commands::CommandHistory;
 
 use crate::EditorEntity;
 use crate::asset_files::{AssetFileKind, asset_file_text, read_asset_kind};
+use crate::asset_index::{AssetEntry, AssetIndex, AssetValue, absolute_path, indexed_path};
 use crate::commands::EditorCommand;
 use crate::prelude::*;
 use crate::project::ProjectRoot;
 
-/// Where a definition's value lives: in its type's asset store, or, for a type
-/// the editor knows only as the project's schema, in [`DefinitionValues`].
-#[derive(Clone, Debug, PartialEq, Eq)]
-pub enum DefinitionValue {
-    Asset(UntypedHandle),
-    Schema { kind: String, name: String },
-}
-
-impl DefinitionValue {
-    /// The handle behind a definition whose type the editor has compiled in.
-    pub fn handle(&self) -> Option<&UntypedHandle> {
-        match self {
-            Self::Asset(handle) => Some(handle),
-            Self::Schema { .. } => None,
-        }
-    }
-
-    fn schema_key(&self) -> Option<(&str, &str)> {
-        match self {
-            Self::Asset(_) => None,
-            Self::Schema { kind, name } => Some((kind, name)),
-        }
-    }
-}
-
-/// Every value whose type the editor knows only as schema, held as the BSN
-/// patch its file spells, by the kind and name of the definition holding it.
-#[derive(Resource, Default)]
-pub struct DefinitionValues {
-    values: std::collections::HashMap<(String, String), BsnStructData>,
-}
-
-impl DefinitionValues {
-    pub fn get(&self, kind: &str, name: &str) -> Option<&BsnStructData> {
-        self.values.get(&(kind.to_string(), name.to_string()))
-    }
-
-    pub fn insert(&mut self, kind: &str, name: &str, data: BsnStructData) {
-        self.values
-            .insert((kind.to_string(), name.to_string()), data);
-    }
-
-    pub fn remove(&mut self, kind: &str, name: &str) {
-        self.values.remove(&(kind.to_string(), name.to_string()));
-    }
-}
-
-/// A definition loaded from a file, by the name its file stem gives it.
-pub struct DefinitionEntry {
-    pub kind: String,
-    pub name: String,
-    pub value: DefinitionValue,
-    pub path: PathBuf,
-}
-
-/// Every loaded definition, across all registered types.
-#[derive(Resource, Default)]
-pub struct DefinitionRegistry {
-    pub entries: Vec<DefinitionEntry>,
-}
-
-impl DefinitionRegistry {
-    pub fn get(&self, kind: &str, name: &str) -> Option<&DefinitionEntry> {
-        self.entries
-            .iter()
-            .find(|entry| entry.kind == kind && entry.name == name)
-    }
-
-    pub fn names_of(&self, kind: &str) -> Vec<String> {
-        let mut names: Vec<String> = self
-            .entries
-            .iter()
-            .filter(|entry| entry.kind == kind)
-            .map(|entry| entry.name.clone())
-            .collect();
-        names.sort();
-        names
-    }
-
-    /// Record a loaded definition, replacing any entry of the same kind and
-    /// name.
-    pub fn insert(&mut self, entry: DefinitionEntry) {
-        self.entries
-            .retain(|known| known.kind != entry.kind || known.name != entry.name);
-        self.entries.push(entry);
-    }
-
-    pub fn remove(&mut self, kind: &str, name: &str) {
-        self.entries
-            .retain(|known| known.kind != kind || known.name != name);
-    }
-
-    /// The definition loaded from a file, whichever kind claims it.
-    pub fn by_path(&self, path: &Path) -> Option<&DefinitionEntry> {
-        self.entries.iter().find(|entry| entry.path == path)
-    }
-}
-
 /// The first `<kind>_N` name with neither an entry nor a file of its own in
 /// the folder the new file lands in.
 fn next_free_name(world: &World, kind: &str, dir: &Path) -> String {
-    let registry = world.resource::<DefinitionRegistry>();
-    let mut index = 1u32;
+    let index = world.resource::<AssetIndex>();
+    let mut counter = 1u32;
     loop {
-        let candidate = format!("{kind}_{index}");
-        let taken = registry.get(kind, &candidate).is_some()
+        let candidate = format!("{kind}_{counter}");
+        let taken = index.of_kind(kind).any(|entry| entry.name() == candidate)
             || definition_file_path(dir, &candidate).exists();
         if !taken {
             return candidate;
         }
-        index += 1;
+        counter += 1;
     }
 }
 
-/// The definition open in the inspector, on its own editor entity.
+/// The asset open in the inspector, on its own editor entity.
 #[derive(Component)]
 #[require(EditorEntity)]
 pub struct DefinitionAssetEdit {
     pub kind: String,
     pub name: String,
     pub type_path: String,
-    pub value: DefinitionValue,
+    /// The file being edited, as the index keys it.
     pub path: PathBuf,
-    /// Whether the definition has been edited since it was loaded or saved.
+    /// Whether the asset has been edited since it was loaded or saved.
     pub dirty: bool,
 }
 
-/// The entity carrying the open definition, if one is open.
+/// The entity carrying the open asset, if one is open.
 #[derive(Resource, Default)]
 pub struct OpenDefinition(pub Option<Entity>);
 
-/// Strip what cannot appear in a file stem, so a definition name always maps
-/// to exactly one file.
+/// Strip what cannot appear in a file stem, so an asset name always maps to
+/// exactly one file.
 pub fn sanitize_definition_name(name: &str) -> String {
     let cleaned: String = name
         .trim()
@@ -192,14 +93,13 @@ fn names_a_file(path: &Path) -> bool {
             .is_some_and(|extension| extension.eq_ignore_ascii_case("bsn"))
 }
 
-/// The file a definition of this name lands in, in a folder of the user's
-/// choosing.
+/// The file an asset of this name lands in, in a folder of the user's choosing.
 pub fn definition_file_path(dir: &Path, name: &str) -> PathBuf {
     dir.join(format!("{}.bsn", sanitize_definition_name(name)))
 }
 
-/// The name a file gives the definition it holds: everything before the first
-/// dot of its file name, so `torch.item.bsn` holds `torch`.
+/// The name a file gives what it holds: everything before the first dot of its
+/// file name, so `torch.item.bsn` holds `torch`.
 pub fn definition_name_of(path: &Path) -> String {
     let file = path
         .file_name()
@@ -209,8 +109,8 @@ pub fn definition_name_of(path: &Path) -> String {
     file.split('.').next().unwrap_or(file).to_string()
 }
 
-/// The folder a new definition lands in: the one the browser is showing when
-/// it is under the project's assets, and the assets directory otherwise.
+/// The folder a new asset lands in: the one the browser is showing when it is
+/// under the project's assets, and the assets directory otherwise.
 pub fn new_definition_dir(world: &World) -> Option<PathBuf> {
     let assets = world.get_resource::<ProjectRoot>()?.assets_dir();
     let showing = world
@@ -222,14 +122,9 @@ pub fn new_definition_dir(world: &World) -> Option<PathBuf> {
     }
 }
 
-/// Load one file into wherever its type's values live. A file that cannot be
-/// read or parsed, or that holds a value of another type, is reported and
-/// skipped.
-pub fn load_definition_file(
-    world: &mut World,
-    definition: &AssetKind,
-    path: &Path,
-) -> Option<DefinitionValue> {
+/// Read one asset file into a value. A file that cannot be read or parsed, or
+/// that holds a value of another type, is reported and skipped.
+pub fn read_asset_file(world: &mut World, kind: &AssetKind, path: &Path) -> Option<AssetValue> {
     let text = match std::fs::read_to_string(path) {
         Ok(text) => text,
         Err(err) => {
@@ -237,10 +132,10 @@ pub fn load_definition_file(
             return None;
         }
     };
-    if definition.schema_backed() {
-        return load_schema_definition(world, definition, path, &text);
+    if kind.schema_backed() {
+        return read_schema_asset(kind, path, &text);
     }
-    let type_id = registered_type_id(world, &definition.type_path)?;
+    let type_id = registered_type_id(world, &kind.type_path)?;
     let entries = match jackdaw_bsn::load_bsn_assets(world, &text) {
         Ok(entries) => entries,
         Err(err) => {
@@ -250,25 +145,15 @@ pub fn load_definition_file(
     };
     let entry = entries.into_iter().next()?;
     if entry.handle.type_id() != type_id {
-        warn!(
-            "{} does not hold a {}",
-            path.display(),
-            definition.type_path
-        );
+        warn!("{} does not hold a {}", path.display(), kind.type_path);
         return None;
     }
-    Some(DefinitionValue::Asset(entry.handle))
+    Some(AssetValue::Handle(entry.handle))
 }
 
-/// Load a file whose type the editor knows only as schema: the patch it holds
-/// goes into [`DefinitionValues`] as it stands.
-fn load_schema_definition(
-    world: &mut World,
-    definition: &AssetKind,
-    path: &Path,
-    text: &str,
-) -> Option<DefinitionValue> {
-    let name = definition_name_of(path);
+/// Read a file whose type the editor knows only as schema: the patch it holds
+/// is the value.
+fn read_schema_asset(kind: &AssetKind, path: &Path, text: &str) -> Option<AssetValue> {
     let ast = match jackdaw_bsn::parse_bsn_text(text) {
         Ok(ast) => ast,
         Err(err) => {
@@ -280,23 +165,17 @@ fn load_schema_definition(
         .roots
         .iter()
         .find_map(|&root| patch_of_root(&ast, root))
-        .unwrap_or_else(|| empty_patch(&definition.type_path));
-    if data.type_path != definition.type_path {
+        .unwrap_or_else(|| empty_patch(&kind.type_path));
+    if data.type_path != kind.type_path {
         warn!(
             "{} holds a {} where a {} was expected",
             path.display(),
             data.type_path,
-            definition.type_path
+            kind.type_path
         );
         return None;
     }
-    world
-        .get_resource_or_init::<DefinitionValues>()
-        .insert(&definition.kind, &name, data);
-    Some(DefinitionValue::Schema {
-        kind: definition.kind.clone(),
-        name,
-    })
+    Some(AssetValue::Schema(Box::new(data)))
 }
 
 /// The struct patch a document root carries, with a bare type reading as a
@@ -335,13 +214,13 @@ fn root_name_of(text: &str) -> Option<String> {
     })
 }
 
-/// Write one definition to the file it was opened from or created in, under
-/// the root name that file already carries. An identical rewrite is skipped so
-/// the asset watcher does not reload behind an unchanged save.
-pub fn write_definition_file(
+/// Write one asset to the file it was opened from or created in, under the
+/// root name that file already carries. An identical rewrite is skipped so the
+/// asset watcher does not reload behind an unchanged save.
+pub fn write_asset_file(
     world: &World,
     name: &str,
-    value: &DefinitionValue,
+    value: &AssetValue,
     path: &Path,
 ) -> std::io::Result<PathBuf> {
     let existing = std::fs::read_to_string(path).ok();
@@ -349,7 +228,7 @@ pub fn write_definition_file(
         .as_deref()
         .and_then(root_name_of)
         .unwrap_or_else(|| name.to_string());
-    let text = definition_text(world, &name, value).unwrap_or_default();
+    let text = asset_text(world, &name, value).unwrap_or_default();
     if text.trim().is_empty() {
         return Err(std::io::Error::other(format!(
             "nothing to write for '{name}'"
@@ -365,12 +244,12 @@ pub fn write_definition_file(
     Ok(path.to_path_buf())
 }
 
-/// The text one definition saves as: the stamp and the header naming its
-/// type, then an asset catalog entry for a compiled type or the patch it holds
-/// for a schema-backed one.
-fn definition_text(world: &World, name: &str, value: &DefinitionValue) -> Option<String> {
+/// The text one asset saves as: the stamp and the header naming its type, then
+/// an asset catalog entry for a compiled type or the patch it holds for a
+/// schema-backed one.
+fn asset_text(world: &World, name: &str, value: &AssetValue) -> Option<String> {
     let body = match value {
-        DefinitionValue::Asset(handle) => jackdaw_bsn::serialize_assets_to_bsn(
+        AssetValue::Handle(handle) => jackdaw_bsn::serialize_assets_to_bsn(
             world,
             &[CatalogAssetRef {
                 name: sanitize_definition_name(name),
@@ -378,23 +257,21 @@ fn definition_text(world: &World, name: &str, value: &DefinitionValue) -> Option
                 asset_id: handle.id(),
             }],
         ),
-        DefinitionValue::Schema { kind, name: stored } => {
-            let data = world
-                .get_resource::<DefinitionValues>()?
-                .get(kind, stored)?;
-            emit_definition_patch(&sanitize_definition_name(name), data.clone())
+        AssetValue::Schema(data) => {
+            emit_definition_patch(&sanitize_definition_name(name), (**data).clone())
         }
+        AssetValue::Unloaded => return None,
     };
     if body.trim().is_empty() {
         return None;
     }
-    Some(asset_file_text(&definition_type_path(world, value)?, &body))
+    Some(asset_file_text(&asset_type_path(world, value)?, &body))
 }
 
-/// The type a definition's value holds, as its files name it.
-fn definition_type_path(world: &World, value: &DefinitionValue) -> Option<String> {
+/// The type an asset's value holds, as its files name it.
+fn asset_type_path(world: &World, value: &AssetValue) -> Option<String> {
     match value {
-        DefinitionValue::Asset(handle) => {
+        AssetValue::Handle(handle) => {
             let registry = world.resource::<AppTypeRegistry>().read();
             Some(
                 registry
@@ -404,13 +281,8 @@ fn definition_type_path(world: &World, value: &DefinitionValue) -> Option<String
                     .to_string(),
             )
         }
-        DefinitionValue::Schema { kind, name } => Some(
-            world
-                .get_resource::<DefinitionValues>()?
-                .get(kind, name)?
-                .type_path
-                .clone(),
-        ),
+        AssetValue::Schema(data) => Some(data.type_path.clone()),
+        AssetValue::Unloaded => None,
     }
 }
 
@@ -427,29 +299,17 @@ fn emit_definition_patch(name: &str, data: BsnStructData) -> String {
     jackdaw_bsn::emit_scene(&ast)
 }
 
-/// Put a fresh default value where this kind's values live.
-pub fn default_definition_value(
-    world: &mut World,
-    definition: &AssetKind,
-    name: &str,
-) -> Option<DefinitionValue> {
-    if definition.schema_backed() {
-        world.get_resource_or_init::<DefinitionValues>().insert(
-            &definition.kind,
-            name,
-            empty_patch(&definition.type_path),
-        );
-        return Some(DefinitionValue::Schema {
-            kind: definition.kind.clone(),
-            name: name.to_string(),
-        });
+/// A fresh default value of a registered kind.
+pub fn default_asset_value(world: &mut World, kind: &AssetKind) -> Option<AssetValue> {
+    if kind.schema_backed() {
+        return Some(AssetValue::Schema(Box::new(empty_patch(&kind.type_path))));
     }
     let registry = world.resource::<AppTypeRegistry>().clone();
     let registry = registry.read();
-    let registration = registry.get_with_type_path(&definition.type_path)?;
+    let registration = registry.get_with_type_path(&kind.type_path)?;
     let reflect_asset = registration.data::<ReflectAsset>()?;
     let value = registration.data::<ReflectDefault>()?.default();
-    Some(DefinitionValue::Asset(
+    Some(AssetValue::Handle(
         reflect_asset.add(world, value.as_partial_reflect()),
     ))
 }
@@ -459,125 +319,18 @@ fn registered_type_id(world: &World, type_path: &str) -> Option<std::any::TypeId
     Some(registry.get_with_type_path(type_path)?.type_id())
 }
 
-fn registered_types(world: &World) -> Vec<AssetKind> {
+// -- Reading and writing an asset's fields ----------------------------------
+
+/// The value at an indexed path, if the index loaded one.
+fn value_at(world: &World, path: &Path) -> Option<AssetValue> {
     world
-        .get_resource::<AssetKinds>()
-        .map(|types| types.iter().cloned().collect())
-        .unwrap_or_default()
+        .get_resource::<AssetIndex>()?
+        .get(path)
+        .map(|entry| entry.value.clone())
 }
-
-/// What a rescan of the project's asset files found.
-#[derive(Default, Debug, PartialEq, Eq)]
-pub struct DefinitionRescan {
-    /// `(kind, name)` of files that appeared since the last scan.
-    pub added: Vec<(String, String)>,
-    /// `(kind, name)` of entries whose file has gone.
-    pub removed: Vec<(String, String)>,
-}
-
-/// Every definition file the project holds, as `(kind, name, path)`, read from
-/// what each file says it is. A name a file of the same kind already took is
-/// reported and left out, so one name means one file.
-fn scan_definition_files(
-    world: &World,
-    cache: &mut crate::asset_files::AssetKindCache,
-) -> Vec<(String, String, PathBuf)> {
-    let Some(assets) = world
-        .get_resource::<ProjectRoot>()
-        .map(ProjectRoot::assets_dir)
-    else {
-        return Vec::new();
-    };
-    let Some(kinds) = world.get_resource::<AssetKinds>() else {
-        return Vec::new();
-    };
-    let mut found: Vec<(String, String, PathBuf)> = Vec::new();
-    for path in crate::asset_files::walk_document_files(&assets) {
-        let AssetFileKind::Asset { type_path } = cache.check(&path, kinds) else {
-            continue;
-        };
-        let Some(definition) = kinds.by_type_path(&type_path).filter(|kind| kind.scanned()) else {
-            continue;
-        };
-        let name = definition_name_of(&path);
-        if found
-            .iter()
-            .any(|(kind, known, _)| kind == &definition.kind && known == &name)
-        {
-            warn!(
-                "two {} files are called '{name}'; {} stays unopened",
-                definition.kind,
-                path.display()
-            );
-            continue;
-        }
-        found.push((definition.kind.clone(), name, path));
-    }
-    found
-}
-
-/// Scan the project's assets: files that appeared are loaded, entries whose
-/// file has gone are dropped.
-///
-/// A file changed in place is not reloaded, and a definition open in the
-/// inspector keeps its value when its file disappears: the loaded value is
-/// what the editor is editing, and its Save writes the file again.
-pub fn rescan_definitions(world: &mut World) -> DefinitionRescan {
-    let mut scan = DefinitionRescan::default();
-    world.get_resource_or_init::<crate::asset_files::AssetKindCache>();
-    let found = world.resource_scope(
-        |world, mut cache: Mut<crate::asset_files::AssetKindCache>| {
-            scan_definition_files(world, &mut cache)
-        },
-    );
-    for definition in registered_types(world) {
-        if !definition.scanned() {
-            continue;
-        }
-        let files: Vec<(String, PathBuf)> = found
-            .iter()
-            .filter(|(kind, _, _)| kind == &definition.kind)
-            .map(|(_, name, path)| (name.clone(), path.clone()))
-            .collect();
-        let known = world
-            .resource::<DefinitionRegistry>()
-            .names_of(&definition.kind);
-
-        for gone in known
-            .iter()
-            .filter(|name| !files.iter().any(|(found, _)| found == *name))
-        {
-            world
-                .resource_mut::<DefinitionRegistry>()
-                .remove(&definition.kind, gone);
-            scan.removed.push((definition.kind.clone(), gone.clone()));
-        }
-
-        for (name, path) in files {
-            if known.contains(&name) {
-                continue;
-            }
-            let Some(value) = load_definition_file(world, &definition, &path) else {
-                continue;
-            };
-            world
-                .resource_mut::<DefinitionRegistry>()
-                .insert(DefinitionEntry {
-                    kind: definition.kind.clone(),
-                    name: name.clone(),
-                    value,
-                    path,
-                });
-            scan.added.push((definition.kind.clone(), name));
-        }
-    }
-    scan
-}
-
-// -- Reading and writing a definition's fields ------------------------------
 
 /// The asset a definition-editing entity stands for, reflected out of its
-/// store. `None` when the entity is not editing a definition of `type_path`.
+/// store. `None` when the entity is not editing an asset of `type_path`.
 pub fn definition_value<'w>(
     world: &'w World,
     entity: Entity,
@@ -588,14 +341,30 @@ pub fn definition_value<'w>(
     if edit.type_path != type_path {
         return None;
     }
+    let handle = world
+        .get_resource::<AssetIndex>()?
+        .get(&edit.path)?
+        .value
+        .handle()?;
     let reflect_asset = registry
         .get_with_type_path(type_path)?
         .data::<ReflectAsset>()?;
-    reflect_asset.get(world, edit.value.handle()?.id())
+    reflect_asset.get(world, handle.id())
 }
 
-/// The schema the project reported for a definition kind's type, when the
-/// editor knows the type no other way.
+/// The file the open card is editing, as the index keys it.
+pub fn open_definition_path(world: &World) -> Option<PathBuf> {
+    let entity = world.get_resource::<OpenDefinition>()?.0?;
+    Some(world.get::<DefinitionAssetEdit>(entity)?.path.clone())
+}
+
+/// The value the open card is editing.
+pub fn open_definition_value(world: &World) -> Option<AssetValue> {
+    value_at(world, &open_definition_path(world)?)
+}
+
+/// The schema the project reported for a kind's type, when the editor knows
+/// the type no other way.
 pub fn definition_schema(world: &World, kind: &str) -> Option<jackdaw_schema::TypeSchema> {
     let definition = definition_of_kind(world, kind)?;
     world
@@ -604,25 +373,26 @@ pub fn definition_schema(world: &World, kind: &str) -> Option<jackdaw_schema::Ty
         .cloned()
 }
 
-/// The whole of a schema-backed definition as JSON: what its file authors,
-/// over what its type defaults to.
-pub fn schema_definition_json(world: &World, kind: &str, name: &str) -> Option<serde_json::Value> {
+/// The whole of a schema-backed asset as JSON: what its file authors, over
+/// what its type defaults to.
+pub fn schema_definition_json(world: &World, kind: &str, path: &Path) -> Option<serde_json::Value> {
     let schema = definition_schema(world, kind)?;
-    let data = world.get_resource::<DefinitionValues>()?.get(kind, name)?;
+    let value = value_at(world, path)?;
+    let data = value.schema()?;
     let types = world.get_resource::<crate::project_types::ProjectTypes>()?;
     Some(crate::schema_values::value_json(
         world, types, &schema, data,
     ))
 }
 
-/// Whether this entity is editing a definition of `type_path`.
+/// Whether this entity is editing an asset of `type_path`.
 fn edits_definition(world: &World, entity: Entity, type_path: &str) -> bool {
     world
         .get::<DefinitionAssetEdit>(entity)
         .is_some_and(|edit| edit.type_path == type_path)
 }
 
-/// The open definition's entity, while the inspector is showing it and it is
+/// The open asset's entity, while the inspector is showing it and it is
 /// editing `type_path`. Selecting a scene entity again hands the same type's
 /// edits back to the scene.
 fn open_edit_of(world: &World, type_path: &str) -> Option<Entity> {
@@ -651,23 +421,25 @@ fn field_as_json(
     if edit.type_path != type_path {
         return None;
     }
-    definition_field_json(world, &edit.value, type_path, field_path)
+    definition_field_json(world, &edit.path, type_path, field_path)
 }
 
-/// One field of a definition, whichever way its value is held.
+/// One field of the asset at a path, whichever way its value is held.
 fn definition_field_json(
     world: &World,
-    value: &DefinitionValue,
+    path: &Path,
     type_path: &str,
     field_path: &str,
 ) -> Option<serde_json::Value> {
-    match value {
-        DefinitionValue::Asset(handle) => asset_field_json(world, handle, type_path, field_path),
-        DefinitionValue::Schema { kind, name } => {
-            let whole = schema_definition_json(world, kind, name)?;
+    let kind = world.get_resource::<AssetIndex>()?.get(path)?.kind.clone();
+    match value_at(world, path)? {
+        AssetValue::Handle(handle) => asset_field_json(world, &handle, type_path, field_path),
+        AssetValue::Schema(_) => {
+            let whole = schema_definition_json(world, &kind, path)?;
             let steps = crate::schema_values::parse_path(field_path);
             crate::schema_values::json_at(&whole, &steps).cloned()
         }
+        AssetValue::Unloaded => None,
     }
 }
 
@@ -697,25 +469,27 @@ fn asset_field_json(
     crate::inspector::reflect_fields::reflect_to_json(field, &registry)
 }
 
-/// Write one field of a definition, and mark whatever card is editing it as
-/// having unsaved changes.
+/// Write one field of the asset at a path, and mark whatever card is editing
+/// it as having unsaved changes.
 fn write_field(
     world: &mut World,
-    value: &DefinitionValue,
+    path: &Path,
     type_path: &str,
     field_path: &str,
     json: &serde_json::Value,
 ) -> bool {
+    let Some(value) = value_at(world, path) else {
+        return false;
+    };
     let written = match value {
-        DefinitionValue::Asset(handle) => {
-            write_asset_field(world, handle, type_path, field_path, json)
+        AssetValue::Handle(handle) => {
+            write_asset_field(world, &handle, type_path, field_path, json)
         }
-        DefinitionValue::Schema { kind, name } => {
-            write_schema_field(world, kind, name, field_path, json)
-        }
+        AssetValue::Schema(_) => write_schema_field(world, path, field_path, json),
+        AssetValue::Unloaded => false,
     };
     if written {
-        mark_dirty(world, value);
+        mark_dirty(world, path);
     }
     written
 }
@@ -803,21 +577,27 @@ fn report_missing_asset(path: &str) {
 
 /// Write one field of a value the editor knows only as schema. A field set
 /// back to what its type defaults to stops being authored at all, so the file
-/// keeps holding only what the definition changes.
+/// keeps holding only what the asset changes.
 fn write_schema_field(
     world: &mut World,
-    kind: &str,
-    name: &str,
+    path: &Path,
     field_path: &str,
     json: &serde_json::Value,
 ) -> bool {
-    let Some(schema) = definition_schema(world, kind) else {
-        warn!("this project reported no schema for its {kind} definitions");
+    let Some(kind) = world
+        .get_resource::<AssetIndex>()
+        .and_then(|index| index.get(path))
+        .map(|entry| entry.kind.clone())
+    else {
         return false;
     };
-    let Some(mut data) = world
-        .get_resource::<DefinitionValues>()
-        .and_then(|values| values.get(kind, name))
+    let Some(schema) = definition_schema(world, &kind) else {
+        warn!("this project reported no schema for its {kind} files");
+        return false;
+    };
+    let Some(mut data) = value_at(world, path)
+        .as_ref()
+        .and_then(AssetValue::schema)
         .cloned()
     else {
         return false;
@@ -866,25 +646,62 @@ fn write_schema_field(
         }
         true
     });
-    if written {
-        world
-            .get_resource_or_init::<DefinitionValues>()
-            .insert(kind, name, data);
+    if written && let Some(entry) = world.resource_mut::<AssetIndex>().get_mut(path) {
+        entry.value = AssetValue::Schema(Box::new(data));
     }
     written
 }
 
-/// The entity editing this value, if one is open.
-fn edit_of_value(world: &mut World, value: &DefinitionValue) -> Option<Entity> {
+/// The entity editing the file at this path, if one is open.
+fn open_card_for(world: &mut World, path: &Path) -> Option<Entity> {
     let mut edits = world.query::<(Entity, &DefinitionAssetEdit)>();
     edits
         .iter(world)
-        .find(|(_, edit)| edit.value == *value)
+        .find(|(_, edit)| edit.path == path)
         .map(|(entity, _)| entity)
 }
 
-fn mark_dirty(world: &mut World, value: &DefinitionValue) {
-    let Some(entity) = edit_of_value(world, value) else {
+/// Whether the card editing this file holds edits that are not on disk.
+pub fn card_has_unsaved_edits(world: &World, path: &Path) -> bool {
+    let Some(entity) = world
+        .get_resource::<OpenDefinition>()
+        .and_then(|open| open.0)
+    else {
+        return false;
+    };
+    world
+        .get::<DefinitionAssetEdit>(entity)
+        .is_some_and(|edit| edit.path == path && edit.dirty)
+}
+
+/// Close the card editing this file, for a file that has left the project.
+pub fn close_card_for(world: &mut World, path: &Path) {
+    let editing = world
+        .get_resource::<OpenDefinition>()
+        .and_then(|open| open.0)
+        .and_then(|entity| world.get::<DefinitionAssetEdit>(entity))
+        .is_some_and(|edit| edit.path == path);
+    if editing {
+        close_open_definition(world);
+    }
+}
+
+/// Close the card when the kind it was opened under is no longer registered.
+pub fn close_card_of_missing_kind(world: &mut World, kinds: &[String]) {
+    let open_kind = world
+        .get_resource::<OpenDefinition>()
+        .and_then(|open| open.0)
+        .and_then(|entity| world.get::<DefinitionAssetEdit>(entity))
+        .map(|edit| edit.kind.clone());
+    if let Some(kind) = open_kind
+        && !kinds.contains(&kind)
+    {
+        close_open_definition(world);
+    }
+}
+
+fn mark_dirty(world: &mut World, path: &Path) {
+    let Some(entity) = open_card_for(world, path) else {
         return;
     };
     if let Some(mut edit) = world.get_mut::<DefinitionAssetEdit>(entity) {
@@ -892,12 +709,12 @@ fn mark_dirty(world: &mut World, value: &DefinitionValue) {
     }
 }
 
-/// Set one field of a definition, as one undo entry.
+/// Set one field of an asset, as one undo entry.
 ///
-/// Keyed by the value rather than by the entity the definition was open on, so
-/// undo still reaches it after the card has been closed and reopened.
+/// Keyed by the file rather than by the entity the asset was open on, so undo
+/// still reaches it after the card has been closed and reopened.
 pub struct SetDefinitionField {
-    pub value: DefinitionValue,
+    pub path: PathBuf,
     pub type_path: String,
     pub field_path: String,
     pub old_json: serde_json::Value,
@@ -908,12 +725,12 @@ pub struct SetDefinitionField {
 }
 
 impl SetDefinitionField {
-    /// Write the value, reporting whether the definition took it.
+    /// Write the value, reporting whether the asset took it.
     fn apply(&self, world: &mut World, json: &serde_json::Value) -> bool {
-        if !write_field(world, &self.value, &self.type_path, &self.field_path, json) {
+        if !write_field(world, &self.path, &self.type_path, &self.field_path, json) {
             return false;
         }
-        let open = edit_of_value(world, &self.value);
+        let open = open_card_for(world, &self.path);
         if self.rebuilds_rows
             && let Some(open) = open
             && let Some(mut pending) =
@@ -941,11 +758,11 @@ impl EditorCommand for SetDefinitionField {
     }
 }
 
-/// Commit a field edit to the open definition, pushing one undo entry.
+/// Commit a field edit to the open asset, pushing one undo entry.
 ///
-/// Returns whether the edit landed on a definition; a caller whose edit is
-/// refused here writes to the selection as usual. A value the definition will
-/// not take mints no history, so undo does not walk back over a no-op.
+/// Returns whether the edit landed on an asset; a caller whose edit is refused
+/// here writes to the selection as usual. A value the asset will not take mints
+/// no history, so undo does not walk back over a no-op.
 pub(crate) fn commit_definition_field(
     world: &mut World,
     type_path: &str,
@@ -955,9 +772,9 @@ pub(crate) fn commit_definition_field(
     let Some(entity) = open_edit_of(world, type_path) else {
         return false;
     };
-    let Some(value) = world
+    let Some(path) = world
         .get::<DefinitionAssetEdit>(entity)
-        .map(|edit| edit.value.clone())
+        .map(|edit| edit.path.clone())
     else {
         return false;
     };
@@ -967,7 +784,7 @@ pub(crate) fn commit_definition_field(
     let old_json = take_baseline(world, type_path, field_path).unwrap_or(current);
     let rebuilds_rows = field_rebuilds_rows(world, entity, type_path, field_path);
     let command = SetDefinitionField {
-        value,
+        path,
         type_path: type_path.to_string(),
         field_path: field_path.to_string(),
         old_json,
@@ -983,8 +800,8 @@ pub(crate) fn commit_definition_field(
     true
 }
 
-/// Write a field of the open definition without an undo entry, for the ticks
-/// of a drag.
+/// Write a field of the open asset without an undo entry, for the ticks of a
+/// drag.
 pub(crate) fn preview_definition_field(
     world: &mut World,
     type_path: &str,
@@ -994,14 +811,14 @@ pub(crate) fn preview_definition_field(
     let Some(entity) = open_edit_of(world, type_path) else {
         return false;
     };
-    let Some(value) = world
+    let Some(path) = world
         .get::<DefinitionAssetEdit>(entity)
-        .map(|edit| edit.value.clone())
+        .map(|edit| edit.path.clone())
     else {
         return false;
     };
     remember_baseline(world, entity, type_path, field_path);
-    write_field(world, &value, type_path, field_path, new_json)
+    write_field(world, &path, type_path, field_path, new_json)
 }
 
 /// Record what the field held before a drag's first tick.
@@ -1041,7 +858,7 @@ fn take_baseline(
 fn field_rebuilds_rows(world: &World, entity: Entity, type_path: &str, field_path: &str) -> bool {
     if let Some(kind) = world
         .get::<DefinitionAssetEdit>(entity)
-        .filter(|edit| edit.value.schema_key().is_some())
+        .filter(|edit| is_schema_backed(world, &edit.path))
         .map(|edit| edit.kind.clone())
     {
         return schema_field_rebuilds_rows(world, &kind, field_path);
@@ -1063,8 +880,17 @@ fn field_rebuilds_rows(world: &World, entity: Entity, type_path: &str, field_pat
     })
 }
 
-/// The elements of a list field on a schema-backed definition, as the JSON a
-/// field edit takes. `None` when the entity is editing something else.
+/// Whether the file at this path holds a value the editor knows only as the
+/// project's schema.
+fn is_schema_backed(world: &World, path: &Path) -> bool {
+    world
+        .get_resource::<AssetIndex>()
+        .and_then(|index| index.get(path))
+        .is_some_and(|entry| entry.value.schema().is_some())
+}
+
+/// The elements of a list field on a schema-backed asset, as the JSON a field
+/// edit takes. `None` when the entity is editing something else.
 pub(crate) fn schema_list_items(
     world: &World,
     entity: Entity,
@@ -1072,16 +898,15 @@ pub(crate) fn schema_list_items(
     field_path: &str,
 ) -> Option<Vec<serde_json::Value>> {
     let edit = world.get::<DefinitionAssetEdit>(entity)?;
-    if edit.type_path != type_path {
+    if edit.type_path != type_path || !is_schema_backed(world, &edit.path) {
         return None;
     }
-    edit.value.schema_key()?;
-    let held = definition_field_json(world, &edit.value, type_path, field_path)?;
+    let held = definition_field_json(world, &edit.path, type_path, field_path)?;
     held.as_array().cloned()
 }
 
-/// A fresh element for a list field on a schema-backed definition, from what
-/// its item type defaults to.
+/// A fresh element for a list field on a schema-backed asset, from what its
+/// item type defaults to.
 pub(crate) fn schema_default_list_item(
     world: &World,
     entity: Entity,
@@ -1089,10 +914,9 @@ pub(crate) fn schema_default_list_item(
     field_path: &str,
 ) -> Option<serde_json::Value> {
     let edit = world.get::<DefinitionAssetEdit>(entity)?;
-    if edit.type_path != type_path {
+    if edit.type_path != type_path || !is_schema_backed(world, &edit.path) {
         return None;
     }
-    edit.value.schema_key()?;
     let types = world.get_resource::<crate::project_types::ProjectTypes>()?;
     let steps = crate::schema_values::parse_path(field_path);
     let field_type = crate::schema_values::field_type_path(types, type_path, &steps)?;
@@ -1136,61 +960,67 @@ pub fn kind_of_file(world: &World, path: &Path) -> Option<AssetKind> {
     kinds.by_type_path(&type_path).cloned()
 }
 
-/// Load a definition file, or reuse the loaded one, and put it in the
-/// inspector. A kind loaded elsewhere is only ever shown through the value its
-/// owner published.
+/// The entry for a file, reading and indexing it if the walk has not reached it
+/// yet.
+fn entry_for_file(world: &mut World, path: &Path) -> Option<AssetEntry> {
+    let indexed = indexed_path(world, path)?;
+    if crate::asset_index::is_catalog_file(&indexed) {
+        return None;
+    }
+    if let Some(entry) = world
+        .get_resource::<AssetIndex>()
+        .and_then(|index| index.get(&indexed))
+    {
+        return Some(entry.clone());
+    }
+    let file = absolute_path(world, &indexed);
+    let kind = kind_of_file(world, &file)?;
+    let value = crate::asset_index::load_asset_value(world, &kind, &file)?;
+    let mtime = std::fs::metadata(&file)
+        .and_then(|meta| meta.modified())
+        .ok()?;
+    let entry = AssetEntry {
+        path: indexed,
+        kind: kind.kind.clone(),
+        type_path: kind.type_path.clone(),
+        file_kind: AssetFileKind::Asset {
+            type_path: kind.type_path,
+        },
+        value,
+        mtime,
+    };
+    world.resource_mut::<AssetIndex>().insert(entry.clone());
+    Some(entry)
+}
+
+/// Load an asset file, or reuse the loaded one, and put it in the inspector.
 pub fn open_definition_file(world: &mut World, path: &Path) -> bool {
-    let Some(definition) = kind_of_file(world, path) else {
+    let Some(entry) = entry_for_file(world, path) else {
         return false;
     };
-    let name = definition_name_of(path);
-
-    let known = world
-        .resource::<DefinitionRegistry>()
-        .get(&definition.kind, &name)
-        .map(|entry| entry.value.clone());
-    let value = match known {
-        Some(value) => value,
-        None => {
-            if !definition.scanned() {
-                warn!("No {} named '{name}' is loaded", definition.kind);
-                return false;
-            }
-            let Some(value) = load_definition_file(world, &definition, path) else {
-                return false;
-            };
-            world
-                .resource_mut::<DefinitionRegistry>()
-                .insert(DefinitionEntry {
-                    kind: definition.kind.clone(),
-                    name: name.clone(),
-                    value: value.clone(),
-                    path: path.to_path_buf(),
-                });
-            value
-        }
+    let Some(kind) = definition_of_kind(world, &entry.kind) else {
+        return false;
     };
-
-    show_definition(world, &definition, &name, value, path.to_path_buf());
+    if matches!(entry.value, AssetValue::Unloaded) {
+        warn!(
+            "{} is opened by the panel that loads its kind",
+            path.display()
+        );
+        return false;
+    }
+    show_definition(world, &kind, &entry.name(), entry.path);
     true
 }
 
-fn show_definition(
-    world: &mut World,
-    definition: &AssetKind,
-    name: &str,
-    value: DefinitionValue,
-    path: PathBuf,
-) {
+fn show_definition(world: &mut World, kind: &AssetKind, name: &str, path: PathBuf) {
     close_open_definition(world);
     let entity = world
         .spawn((
-            Name::new(format!("{} ({})", name, definition.label)),
+            Name::new(format!("{} ({})", name, kind.label)),
             DefinitionAssetEdit {
-                kind: definition.kind.clone(),
+                kind: kind.kind.clone(),
                 name: name.to_string(),
-                type_path: definition.type_path.clone(),
-                value,
+                type_path: kind.type_path.clone(),
                 path,
                 dirty: false,
             },
@@ -1200,8 +1030,8 @@ fn show_definition(
     crate::selection::select_only(world, entity);
 }
 
-/// Drop the editing entity for whatever definition was open. The definition
-/// itself stays loaded and registered.
+/// Drop the editing entity for whatever asset was open. The asset itself stays
+/// loaded and indexed.
 pub fn close_open_definition(world: &mut World) {
     let Some(entity) = world.resource_mut::<OpenDefinition>().0.take() else {
         return;
@@ -1217,77 +1047,40 @@ pub fn close_open_definition(world: &mut World) {
     }
 }
 
-/// Write the open definition back to its file, reporting the name it saved
-/// under.
+/// Write the open asset back to its file, reporting the name it saved under.
 fn save_open_definition(world: &mut World, entity: Entity) -> Option<String> {
-    let (kind, name, value, path) = world.get::<DefinitionAssetEdit>(entity).map(|edit| {
-        (
-            edit.kind.clone(),
-            edit.name.clone(),
-            edit.value.clone(),
-            edit.path.clone(),
-        )
-    })?;
-    save_definition(world, &kind, &name, &value, &path)
+    let path = world
+        .get::<DefinitionAssetEdit>(entity)
+        .map(|edit| edit.path.clone())?;
+    save_indexed_asset(world, &path)
 }
 
-/// Write the definition a file path names back to that file, without taking
-/// the inspector off whatever it is showing.
+/// Write the asset a file path names back to that file, without taking the
+/// inspector off whatever it is showing.
 fn save_definition_at(world: &mut World, path: &Path) -> Option<String> {
-    if let Some(entry) = world.resource::<DefinitionRegistry>().by_path(path) {
-        let (kind, name, value) = (entry.kind.clone(), entry.name.clone(), entry.value.clone());
-        return save_definition(world, &kind, &name, &value, path);
-    }
-    let Some(definition) = kind_of_file(world, path) else {
+    let Some(entry) = entry_for_file(world, path) else {
         warn!("asset.save: {} is not an asset file", path.display());
         return None;
     };
-    let name = definition_name_of(path);
-    let Some(value) = world
-        .resource::<DefinitionRegistry>()
-        .get(&definition.kind, &name)
-        .map(|entry| entry.value.clone())
-    else {
-        warn!(
-            "asset.save: no {} named '{name}' is loaded",
-            definition.kind
-        );
-        return None;
-    };
-    save_definition(world, &definition.kind, &name, &value, path)
+    save_indexed_asset(world, &entry.path)
 }
 
-/// Write one definition back to the file it came from and record where it
-/// landed.
-fn save_definition(
-    world: &mut World,
-    kind: &str,
-    name: &str,
-    value: &DefinitionValue,
-    path: &Path,
-) -> Option<String> {
-    let path = match write_definition_file(world, name, value, path) {
-        Ok(path) => path,
-        Err(err) => {
-            warn!("asset.save: failed to write '{name}': {err}");
-            return None;
-        }
-    };
-    if let Some(open) = edit_of_value(world, value)
+/// Write one indexed asset back to the file it came from.
+fn save_indexed_asset(world: &mut World, path: &Path) -> Option<String> {
+    let entry = world.get_resource::<AssetIndex>()?.get(path)?.clone();
+    let name = entry.name();
+    let file = absolute_path(world, path);
+    if let Err(err) = write_asset_file(world, &name, &entry.value, &file) {
+        warn!("asset.save: failed to write '{name}': {err}");
+        return None;
+    }
+    crate::asset_index::note_written(world, &file);
+    if let Some(open) = open_card_for(world, path)
         && let Some(mut edit) = world.get_mut::<DefinitionAssetEdit>(open)
     {
         edit.dirty = false;
-        edit.path = path.clone();
     }
-    world
-        .resource_mut::<DefinitionRegistry>()
-        .insert(DefinitionEntry {
-            kind: kind.to_string(),
-            name: name.to_string(),
-            value: value.clone(),
-            path,
-        });
-    Some(name.to_string())
+    Some(name)
 }
 
 // -- Operators --------------------------------------------------------------
@@ -1302,7 +1095,7 @@ pub(crate) fn add_to_extension(ctx: &mut ExtensionContext) {
 }
 
 /// The kind saved materials list under, so a material is browsed, opened and
-/// edited through the same registry as any other asset.
+/// edited through the same index as any other asset.
 pub const MATERIAL_KIND: &str = "material";
 
 /// The kind an animation graph file holds.
@@ -1311,8 +1104,7 @@ pub const ANIMATION_GRAPH_KIND: &str = "animation_graph";
 /// The kind a packed prefab holds.
 pub const PREFAB_KIND: &str = "prefab";
 
-/// The types the editor has compiled in, each loaded by the panel that owns
-/// it rather than by the asset scan.
+/// The types the editor has compiled in.
 fn compiled_kinds() -> [AssetKind; 3] {
     use jackdaw_api_internal::lucide_icons::Icon;
     [
@@ -1340,168 +1132,8 @@ pub(crate) fn plugin(app: &mut App) {
             kinds.register(kind);
         }
     }
-    app.init_resource::<DefinitionRegistry>()
-        .init_resource::<crate::asset_files::AssetKindCache>()
-        .init_resource::<DefinitionValues>()
-        .init_resource::<DefinitionEditSession>()
-        .init_resource::<OpenDefinition>()
-        .init_resource::<DefinitionScanPending>()
-        .add_systems(OnEnter(crate::AppState::Editor), watch_definition_files)
-        .add_systems(
-            Update,
-            (
-                follow_registered_types.run_if(resource_changed::<AssetKinds>),
-                poll_definition_watcher,
-                apply_definition_scan,
-            )
-                .chain()
-                .run_if(in_state(crate::AppState::Editor)),
-        )
-        .add_systems(
-            Update,
-            mirror_material_definitions
-                .run_if(resource_exists_and_changed::<crate::material_assets::MaterialRegistry>),
-        );
-}
-
-/// Publish the saved materials into the definition registry, so the material
-/// directory browses and opens like any other kind.
-fn mirror_material_definitions(world: &mut World) {
-    if definition_of_kind(world, MATERIAL_KIND).is_none() {
-        return;
-    }
-    let saved: Vec<(String, UntypedHandle)> = world
-        .resource::<crate::material_assets::MaterialRegistry>()
-        .saved_entries()
-        .map(|entry| {
-            (
-                sanitize_definition_name(&entry.name),
-                entry.handle.clone().untyped(),
-            )
-        })
-        .collect();
-    let paths: Vec<PathBuf> = {
-        let Some(project) = world.get_resource::<ProjectRoot>() else {
-            return;
-        };
-        saved
-            .iter()
-            .map(|(name, _)| crate::material_assets::material_file_path(project, name))
-            .collect()
-    };
-
-    let mut registry = world.resource_mut::<DefinitionRegistry>();
-    registry.entries.retain(|entry| entry.kind != MATERIAL_KIND);
-    for ((name, handle), path) in saved.into_iter().zip(paths) {
-        registry.insert(DefinitionEntry {
-            kind: MATERIAL_KIND.to_string(),
-            name,
-            value: DefinitionValue::Asset(handle),
-            path,
-        });
-    }
-}
-
-/// Watches the project's assets directory so a definition file written by
-/// another tool registers without reopening the project.
-#[derive(Resource)]
-struct DefinitionFileWatcher {
-    _watcher: notify::RecommendedWatcher,
-    receiver: Mutex<mpsc::Receiver<()>>,
-}
-
-#[derive(Resource, Default)]
-struct DefinitionScanPending(bool);
-
-fn watch_definition_files(
-    project: Option<Res<ProjectRoot>>,
-    mut pending: ResMut<DefinitionScanPending>,
-    mut commands: Commands,
-) {
-    pending.0 = true;
-    let Some(assets) = project.map(|project| project.assets_dir()) else {
-        return;
-    };
-    let (sender, receiver) = mpsc::channel();
-    let watcher =
-        notify::recommended_watcher(move |event: Result<notify::Event, notify::Error>| {
-            use notify::EventKind;
-            if let Ok(event) = event
-                && matches!(
-                    event.kind,
-                    EventKind::Create(_)
-                        | EventKind::Remove(_)
-                        | EventKind::Modify(notify::event::ModifyKind::Name(_))
-                )
-            {
-                let _ = sender.send(());
-            }
-        });
-    if let Ok(mut watcher) = watcher {
-        use notify::Watcher as _;
-        if watcher
-            .watch(&assets, notify::RecursiveMode::Recursive)
-            .is_ok()
-        {
-            commands.insert_resource(DefinitionFileWatcher {
-                _watcher: watcher,
-                receiver: Mutex::new(receiver),
-            });
-        }
-    }
-}
-
-fn poll_definition_watcher(
-    watcher: Option<Res<DefinitionFileWatcher>>,
-    mut pending: ResMut<DefinitionScanPending>,
-) {
-    let Some(watcher) = watcher else { return };
-    let Ok(receiver) = watcher.receiver.lock() else {
-        return;
-    };
-    if receiver.try_recv().is_ok() {
-        while receiver.try_recv().is_ok() {}
-        pending.0 = true;
-    }
-}
-
-/// Follow the registered types: a kind that has gone takes its loaded entries
-/// and its open card with it, and a kind that has arrived gets its directory
-/// scanned.
-fn follow_registered_types(world: &mut World) {
-    let kinds: Vec<String> = registered_types(world)
-        .into_iter()
-        .map(|definition| definition.kind)
-        .collect();
-    world
-        .resource_mut::<DefinitionRegistry>()
-        .entries
-        .retain(|entry| kinds.contains(&entry.kind));
-    world
-        .get_resource_or_init::<DefinitionValues>()
-        .values
-        .retain(|(kind, _), _| kinds.contains(kind));
-    let open_kind = world
-        .resource::<OpenDefinition>()
-        .0
-        .and_then(|entity| world.get::<DefinitionAssetEdit>(entity))
-        .map(|edit| edit.kind.clone());
-    if let Some(kind) = open_kind
-        && !kinds.contains(&kind)
-    {
-        close_open_definition(world);
-    }
-    world.resource_mut::<DefinitionScanPending>().0 = true;
-}
-
-fn apply_definition_scan(world: &mut World) {
-    if !std::mem::take(&mut world.resource_mut::<DefinitionScanPending>().0) {
-        return;
-    }
-    let scan = rescan_definitions(world);
-    if !scan.added.is_empty() {
-        info!("Loaded {} definition files", scan.added.len());
-    }
+    app.init_resource::<DefinitionEditSession>()
+        .init_resource::<OpenDefinition>();
 }
 
 fn definition_of_kind(world: &World, kind: &str) -> Option<AssetKind> {
@@ -1511,11 +1143,11 @@ fn definition_of_kind(world: &World, kind: &str) -> Option<AssetKind> {
         .cloned()
 }
 
-/// Create a definition file of a registered type and open it.
+/// Create an asset file of a registered type and open it.
 #[operator(
     id = "asset.new",
-    label = "New Definition",
-    description = "Create a definition file of a registered type and open it in the inspector.",
+    label = "New Asset",
+    description = "Create an asset file of a registered type and open it in the inspector.",
     allows_undo = false,
     params(
         r#type(String, doc = "Kind of asset to create, as its type registered it."),
@@ -1545,27 +1177,26 @@ pub fn asset_new(params: In<OperatorParameters>, mut commands: Commands) -> Oper
 }
 
 fn new_definition(world: &mut World, kind: &str, name: Option<&str>, dir: Option<&Path>) {
-    let Some((definition, name, value, path)) = create_definition(world, kind, name, dir) else {
+    let Some((definition, name, path)) = create_definition(world, kind, name, dir) else {
         return;
     };
-    show_definition(world, &definition, &name, value, path);
+    show_definition(world, &definition, &name, path);
     report_to_caller(world, format!("Created {kind} '{name}'"));
 }
 
-/// Write a fresh default value of a registered kind to its file and register
-/// it.
+/// Write a fresh default value of a registered kind to its file and index it.
 fn create_definition(
     world: &mut World,
     kind: &str,
     name: Option<&str>,
     dir: Option<&Path>,
-) -> Option<(AssetKind, String, DefinitionValue, PathBuf)> {
+) -> Option<(AssetKind, String, PathBuf)> {
     let Some(definition) = definition_of_kind(world, kind) else {
-        warn!("asset.new: '{kind}' is not a registered definition type");
+        warn!("asset.new: '{kind}' is not a registered asset type");
         return None;
     };
     if !definition.scanned() {
-        warn!("asset.new: {kind} definitions are created by whoever loads them");
+        warn!("asset.new: {kind} files are created by the panel that loads them");
         return None;
     }
     let (dir, file) = match dir {
@@ -1592,9 +1223,9 @@ fn create_definition(
         warn!("asset.new: the file asked for names this {kind} '{name}'");
     }
     if world
-        .resource::<DefinitionRegistry>()
-        .get(kind, &name)
-        .is_some()
+        .resource::<AssetIndex>()
+        .of_kind(kind)
+        .any(|entry| entry.name() == name)
     {
         warn!("asset.new: a {kind} named '{name}' already exists");
         return None;
@@ -1604,36 +1235,35 @@ fn create_definition(
         warn!("asset.new: {} is already there", path.display());
         return None;
     }
-    let Some(value) = default_definition_value(world, &definition, &name) else {
+    let Some(value) = default_asset_value(world, &definition) else {
         warn!(
             "asset.new: {} has no registered default",
             definition.type_path
         );
         return None;
     };
-    let path = match write_definition_file(world, &name, &value, &path) {
+    let path = match write_asset_file(world, &name, &value, &path) {
         Ok(path) => path,
         Err(err) => {
             warn!("asset.new: failed to write '{name}': {err}");
             return None;
         }
     };
-    world
-        .resource_mut::<DefinitionRegistry>()
-        .insert(DefinitionEntry {
-            kind: definition.kind.clone(),
-            name: name.clone(),
-            value: value.clone(),
-            path: path.clone(),
-        });
-    Some((definition, name, value, path))
+    let Some(indexed) = crate::asset_index::index_written(world, &path, &definition, value) else {
+        warn!(
+            "asset.new: {} is outside this project's assets",
+            path.display()
+        );
+        return None;
+    };
+    Some((definition, name, indexed))
 }
 
-/// Open a definition file in the inspector.
+/// Open an asset file in the inspector.
 #[operator(
     id = "asset.open",
-    label = "Open Definition",
-    description = "Open a definition file in the inspector.",
+    label = "Open Asset",
+    description = "Open an asset file in the inspector.",
     allows_undo = false,
     params(path(String, doc = "File to open, as a path under the project."))
 )]
@@ -1645,22 +1275,19 @@ pub fn asset_open(params: In<OperatorParameters>, mut commands: Commands) -> Ope
     commands.queue(move |world: &mut World| {
         let path = resolve_project_path(world, &path);
         if !open_definition_file(world, &path) {
-            warn!("asset.open: {} is not a definition file", path.display());
+            warn!("asset.open: {} is not an asset file", path.display());
         }
     });
     OperatorResult::Finished
 }
 
-/// Write a definition back to its file.
+/// Write an asset back to its file.
 #[operator(
     id = "asset.save",
-    label = "Save Definition",
-    description = "Write the open definition back to its file.",
+    label = "Save Asset",
+    description = "Write the open asset back to its file.",
     allows_undo = false,
-    params(path(
-        String,
-        doc = "Definition file to save. Defaults to the open definition."
-    ))
+    params(path(String, doc = "Asset file to save. Defaults to the open asset."))
 )]
 pub fn asset_save(params: In<OperatorParameters>, mut commands: Commands) -> OperatorResult {
     let path = params.as_str("path").map(PathBuf::from);
@@ -1672,7 +1299,7 @@ pub fn asset_save(params: In<OperatorParameters>, mut commands: Commands) -> Ope
             }
             None => {
                 let Some(entity) = world.resource::<OpenDefinition>().0 else {
-                    warn!("asset.save: no definition is open");
+                    warn!("asset.save: no asset is open");
                     return;
                 };
                 save_open_definition(world, entity)
@@ -1685,13 +1312,13 @@ pub fn asset_save(params: In<OperatorParameters>, mut commands: Commands) -> Ope
     OperatorResult::Finished
 }
 
-/// Delete a definition file and forget what it held.
+/// Delete an asset file and forget what it held.
 #[operator(
     id = "asset.delete",
-    label = "Delete Definition",
-    description = "Delete a definition file and drop it from this project.",
+    label = "Delete Asset",
+    description = "Delete an asset file and drop it from this project.",
     allows_undo = false,
-    params(path(String, doc = "Definition file to delete."))
+    params(path(String, doc = "Asset file to delete."))
 )]
 pub fn asset_delete(params: In<OperatorParameters>, mut commands: Commands) -> OperatorResult {
     let Some(path) = params.as_str("path").map(PathBuf::from) else {
@@ -1717,7 +1344,6 @@ fn delete_definition(world: &mut World, path: &Path) {
         );
         return;
     }
-    let name = definition_name_of(path);
     match std::fs::remove_file(path) {
         Ok(()) => info!("Removed {}", path.display()),
         Err(err) if err.kind() == std::io::ErrorKind::NotFound => {}
@@ -1726,34 +1352,21 @@ fn delete_definition(world: &mut World, path: &Path) {
             return;
         }
     }
-    world
-        .resource_mut::<DefinitionRegistry>()
-        .remove(&definition.kind, &name);
-    world
-        .get_resource_or_init::<DefinitionValues>()
-        .remove(&definition.kind, &name);
-    let open_is_gone = world
-        .resource::<OpenDefinition>()
-        .0
-        .and_then(|entity| world.get::<DefinitionAssetEdit>(entity))
-        .is_some_and(|edit| edit.kind == definition.kind && edit.name == name);
-    if open_is_gone {
-        close_open_definition(world);
-    }
+    let Some(indexed) = indexed_path(world, path) else {
+        return;
+    };
+    world.resource_mut::<AssetIndex>().remove(&indexed);
+    close_card_for(world, &indexed);
 }
 
-/// Set a field of the open definition, for edits driven from outside the
-/// inspector.
+/// Set a field of the open asset, for edits driven from outside the inspector.
 #[operator(
     id = "asset.set",
-    label = "Set Definition Field",
-    description = "Set a field of the open definition.",
+    label = "Set Asset Field",
+    description = "Set a field of the open asset.",
     allows_undo = false,
     params(
-        field(
-            String,
-            doc = "Field path on the definition, for example 'stack_size'."
-        ),
+        field(String, doc = "Field path on the asset, for example 'stack_size'."),
         value(
             String,
             doc = "Value to set: JSON, a plain scalar, an asset path for a slot \
@@ -1777,7 +1390,7 @@ pub fn asset_set(params: In<OperatorParameters>, mut commands: Commands) -> Oper
 
 fn set_definition_field(world: &mut World, field: &str, value: &str) {
     let Some(entity) = world.resource::<OpenDefinition>().0 else {
-        warn!("asset.set: no definition is open");
+        warn!("asset.set: no asset is open");
         return;
     };
     let Some(type_path) = world
@@ -1802,13 +1415,13 @@ fn set_definition_field(world: &mut World, field: &str, value: &str) {
     }
 }
 
-/// Report the definitions of a kind this project holds.
+/// Report the files of a kind this project holds.
 #[operator(
     id = "asset.list",
-    label = "List Definitions",
-    description = "Report the definitions of a registered type this project holds.",
+    label = "List Assets",
+    description = "Report the files of a registered asset type this project holds.",
     allows_undo = false,
-    params(r#type(String, doc = "Kind of definition to list."))
+    params(r#type(String, doc = "Kind of asset to list."))
 )]
 pub fn asset_list(params: In<OperatorParameters>, mut commands: Commands) -> OperatorResult {
     let Some(kind) = params.as_str("type").map(str::to_owned) else {
@@ -1817,11 +1430,11 @@ pub fn asset_list(params: In<OperatorParameters>, mut commands: Commands) -> Ope
     };
     commands.queue(move |world: &mut World| {
         if definition_of_kind(world, &kind).is_none() {
-            warn!("asset.list: '{kind}' is not a registered definition type");
+            warn!("asset.list: '{kind}' is not a registered asset type");
             return;
         }
-        let names = world.resource::<DefinitionRegistry>().names_of(&kind);
-        report_to_caller(world, format!("{kind}: {}", names.join(", ")));
+        let paths = world.resource::<AssetIndex>().paths_of_kind(&kind);
+        report_to_caller(world, format!("{kind}: {}", paths.join(", ")));
     });
     OperatorResult::Finished
 }
@@ -1845,74 +1458,9 @@ fn resolve_project_path(world: &World, path: &Path) -> PathBuf {
 #[cfg(test)]
 mod tests {
     use super::*;
-    use bevy::asset::{Asset, AssetPlugin};
-    use bevy::reflect::Reflect;
-
-    #[derive(Reflect, Clone, Default, PartialEq, Debug)]
-    #[reflect(Default)]
-    struct LootRoll {
-        item: String,
-        weight: u32,
-    }
-
-    #[derive(Reflect, Clone, Default, PartialEq, Debug)]
-    #[reflect(Default)]
-    enum Rarity {
-        #[default]
-        Common,
-        Rare,
-    }
-
-    #[derive(Asset, Reflect, Clone, Default)]
-    #[reflect(Default)]
-    struct ItemDef {
-        stack_size: u32,
-        rarity: Rarity,
-        loot: Vec<LootRoll>,
-    }
-
-    fn item_type() -> AssetKind {
-        AssetKind::extension("item", "Item", "jackdaw::definition_assets::tests::ItemDef")
-    }
-
-    fn item_file(tmp: &tempfile::TempDir, name: &str) -> PathBuf {
-        let dir = tmp.path().join("assets/content/items");
-        std::fs::create_dir_all(&dir).expect("the directory is made");
-        definition_file_path(&dir, name)
-    }
-
-    fn definition_app() -> (App, tempfile::TempDir) {
-        let tmp = tempfile::tempdir().expect("tempdir");
-        let mut app = App::new();
-        app.add_plugins((bevy::app::TaskPoolPlugin::default(), AssetPlugin::default()));
-        app.init_asset::<ItemDef>();
-        app.register_asset_reflect::<ItemDef>();
-        app.register_type::<ItemDef>();
-        app.register_type::<LootRoll>();
-        app.register_type::<Rarity>();
-        app.init_resource::<AssetKinds>();
-        app.init_resource::<DefinitionRegistry>();
-        app.insert_resource(ProjectRoot {
-            root: tmp.path().to_path_buf(),
-            config: crate::project::ProjectConfig::default(),
-        });
-        app.world_mut()
-            .resource_mut::<AssetKinds>()
-            .register(item_type());
-        (app, tmp)
-    }
-
-    fn item_of(app: &App, value: &DefinitionValue) -> ItemDef {
-        let handle = value.handle().expect("a compiled definition").clone();
-        app.world()
-            .resource::<Assets<ItemDef>>()
-            .get(&handle.typed::<ItemDef>())
-            .expect("the definition is in its store")
-            .clone()
-    }
 
     #[test]
-    fn a_file_names_its_definition_by_the_stem_before_its_first_dot() {
+    fn a_file_names_what_it_holds_by_the_stem_before_its_first_dot() {
         for (file, expected) in [
             ("torch.item.bsn", "torch"),
             ("torch.bsn", "torch"),
@@ -1922,7 +1470,7 @@ mod tests {
             assert_eq!(
                 definition_name_of(Path::new(file)),
                 expected,
-                "{file} names a definition"
+                "{file} names an asset"
             );
         }
     }
@@ -1942,155 +1490,6 @@ mod tests {
             root_name_of("jackdaw::Item {\n}\n"),
             None,
             "a root that names nothing leaves the name to the caller"
-        );
-    }
-
-    #[test]
-    fn a_written_definition_reloads_from_the_folder_it_was_written_in() {
-        let (mut app, tmp) = definition_app();
-        let handle = app
-            .world_mut()
-            .resource_mut::<Assets<ItemDef>>()
-            .add(ItemDef {
-                stack_size: 20,
-                rarity: Rarity::Rare,
-                loot: vec![LootRoll {
-                    item: "coin".into(),
-                    weight: 3,
-                }],
-            });
-
-        let path = item_file(&tmp, "torch");
-        write_definition_file(
-            app.world(),
-            "torch",
-            &DefinitionValue::Asset(handle.untyped()),
-            &path,
-        )
-        .expect("the file is written");
-        assert!(path.is_file());
-
-        let scan = rescan_definitions(app.world_mut());
-        assert_eq!(scan.added, vec![("item".to_string(), "torch".to_string())]);
-
-        let loaded = app
-            .world()
-            .resource::<DefinitionRegistry>()
-            .get("item", "torch")
-            .expect("the scan registered it")
-            .value
-            .clone();
-        let item = item_of(&app, &loaded);
-        assert_eq!(item.stack_size, 20);
-        assert_eq!(item.rarity, Rarity::Rare);
-        assert_eq!(
-            item.loot,
-            vec![LootRoll {
-                item: "coin".into(),
-                weight: 3
-            }]
-        );
-    }
-
-    #[test]
-    fn a_file_deleted_on_disk_drops_its_entry_on_the_next_scan() {
-        let (mut app, tmp) = definition_app();
-        let handle = app
-            .world_mut()
-            .resource_mut::<Assets<ItemDef>>()
-            .add(ItemDef::default());
-        let path = item_file(&tmp, "torch");
-        write_definition_file(
-            app.world(),
-            "torch",
-            &DefinitionValue::Asset(handle.untyped()),
-            &path,
-        )
-        .expect("the file is written");
-        rescan_definitions(app.world_mut());
-
-        std::fs::remove_file(&path).expect("the file is removed");
-        let scan = rescan_definitions(app.world_mut());
-
-        assert_eq!(
-            scan.removed,
-            vec![("item".to_string(), "torch".to_string())]
-        );
-        assert!(
-            app.world()
-                .resource::<DefinitionRegistry>()
-                .get("item", "torch")
-                .is_none()
-        );
-    }
-
-    #[test]
-    fn a_definition_is_found_in_whatever_folder_it_was_written_in() {
-        let (mut app, tmp) = definition_app();
-        let handle = app
-            .world_mut()
-            .resource_mut::<Assets<ItemDef>>()
-            .add(ItemDef {
-                stack_size: 7,
-                ..Default::default()
-            });
-        let deep = tmp.path().join("assets/somewhere/else");
-        std::fs::create_dir_all(&deep).expect("the directory is made");
-        write_definition_file(
-            app.world(),
-            "torch",
-            &DefinitionValue::Asset(handle.untyped()),
-            &definition_file_path(&deep, "torch"),
-        )
-        .expect("the file is written");
-
-        let scan = rescan_definitions(app.world_mut());
-
-        assert_eq!(scan.added, vec![("item".to_string(), "torch".to_string())]);
-        let loaded = app
-            .world()
-            .resource::<DefinitionRegistry>()
-            .get("item", "torch")
-            .expect("the scan registered it")
-            .value
-            .clone();
-        assert_eq!(item_of(&app, &loaded).stack_size, 7);
-    }
-
-    #[test]
-    fn a_file_a_kind_would_call_the_same_name_is_left_unopened() {
-        let (mut app, tmp) = definition_app();
-        let handle = app
-            .world_mut()
-            .resource_mut::<Assets<ItemDef>>()
-            .add(ItemDef::default());
-        let value = DefinitionValue::Asset(handle.untyped());
-        write_definition_file(app.world(), "torch", &value, &item_file(&tmp, "torch"))
-            .expect("the file is written");
-        let elsewhere = tmp.path().join("assets/other");
-        std::fs::create_dir_all(&elsewhere).expect("the directory is made");
-        write_definition_file(
-            app.world(),
-            "torch",
-            &value,
-            &definition_file_path(&elsewhere, "torch"),
-        )
-        .expect("the second file is written");
-
-        let scan = rescan_definitions(app.world_mut());
-
-        assert_eq!(
-            scan.added,
-            vec![("item".to_string(), "torch".to_string())],
-            "one name means one file"
-        );
-        assert_eq!(
-            app.world()
-                .resource::<DefinitionRegistry>()
-                .get("item", "torch")
-                .map(|entry| entry.path.clone()),
-            Some(item_file(&tmp, "torch")),
-            "the first file the walk reaches is the one that opens"
         );
     }
 

--- a/src/inspector/definition_card.rs
+++ b/src/inspector/definition_card.rs
@@ -55,12 +55,13 @@ fn despawn_existing_card(world: &mut World, inspector: Entity) {
 /// Build the card for the definition `source` is editing under `inspector`.
 pub(crate) fn fill_definition_card(world: &mut World, inspector: Entity, source: Entity) {
     despawn_existing_card(world, inspector);
-    let Some((kind, name, type_path, dirty)) =
+    let Some((kind, name, type_path, path, dirty)) =
         world.get::<DefinitionAssetEdit>(source).map(|edit| {
             (
                 edit.kind.clone(),
                 edit.name.clone(),
                 edit.type_path.clone(),
+                edit.path.clone(),
                 edit.dirty,
             )
         })
@@ -82,7 +83,7 @@ pub(crate) fn fill_definition_card(world: &mut World, inspector: Entity, source:
             );
             return;
         };
-        let Some(value) = crate::definition_assets::schema_definition_json(world, &kind, &name)
+        let Some(value) = crate::definition_assets::schema_definition_json(world, &kind, &path)
         else {
             bevy::log::warn_once!(
                 "no {kind} named '{name}' is loaded, so its {type_path} card is empty"

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -14,6 +14,7 @@ pub mod app_ops;
 pub mod asset_browser;
 pub mod asset_catalog;
 pub mod asset_files;
+pub mod asset_index;
 pub mod asset_ingest;
 pub mod authored_widgets;
 pub mod boot_ops;
@@ -469,6 +470,7 @@ impl Plugin for EditorCorePlugin {
         ))
         .add_plugins(native_dialog::NativeDialogPlugin)
         .add_plugins(definition_assets::plugin)
+        .add_plugins(asset_index::plugin)
         .add_plugins(model_thumbnail::plugin)
         .add_plugins(boot_ops::plugin)
         .add_plugins(fps_overlay::plugin)
@@ -2758,19 +2760,17 @@ fn cleanup_editor(world: &mut World) {
         }
     }
 
-    // 5. Reset resources. The catalog, the durable-name set and the
-    // material registry all describe the project being closed.
+    // 5. Reset resources. The catalog, the asset index and the material
+    // registry all describe the project being closed.
     world.insert_resource(scene_io::SceneFilePath::default());
     world.insert_resource(scene_io::SceneDirtyState::default());
     world.insert_resource(Selection::default());
     world.insert_resource(commands::CommandHistory::default());
     world.insert_resource(asset_catalog::AssetCatalog::default());
-    world.insert_resource(material_assets::SavedMaterials::default());
     world.insert_resource(material_assets::MaterialRegistry::default());
     project_definitions::forget_project_definitions(world);
     world.insert_resource(asset_files::AssetKindCache::default());
-    world.insert_resource(definition_assets::DefinitionRegistry::default());
-    world.insert_resource(definition_assets::DefinitionValues::default());
+    world.insert_resource(asset_index::AssetIndex::default());
     world.insert_resource(definition_assets::OpenDefinition::default());
 
     // 6. Remove project root

--- a/src/material_assets.rs
+++ b/src/material_assets.rs
@@ -1,9 +1,10 @@
-//! Saved material assets: `assets/materials/<name>.material.bsn`.
+//! Saved material assets: one reflected `StandardMaterial` per `.bsn` file.
 //!
-//! A saved material is one reflected `StandardMaterial` in its own `.bsn`
-//! file, named by the file stem. Every editor surface that shows or edits
-//! materials reads the same [`MaterialRegistry`] and dispatches the same
-//! operators from this module; nothing here depends on a particular panel.
+//! A material file can sit in any folder; [`crate::asset_index::AssetIndex`]
+//! finds it by reading what it holds. `materials/` is only where a save puts a
+//! material the user has not filed elsewhere. Every editor surface that shows
+//! or edits materials reads the same [`MaterialRegistry`] and dispatches the
+//! same operators from this module; nothing here depends on a particular panel.
 //!
 //! # Saved vs unsaved
 //!
@@ -17,13 +18,12 @@
 //!
 //! # The catalog file
 //!
-//! `assets/materials/` *is* the material index: the file stems are the
-//! `@Name`s. `assets/catalog.bsn` holds only what has no file of its own:
-//! catalog entries of other asset types, and inline material entries. Inline
-//! material entries load normally and are rewritten as `.material.bsn` files
-//! on the next save, which removes them from `catalog.bsn`.
+//! The index *is* the material list: a file's stem is the `@Name` older scenes
+//! spell. `assets/catalog.bsn` holds only what has no file of its own: catalog
+//! entries of other asset types, and inline material entries. Inline material
+//! entries load normally and are rewritten as files on the next save, which
+//! removes them from `catalog.bsn`.
 
-use std::collections::HashSet;
 use std::path::{Path, PathBuf};
 
 use bevy::asset::{UntypedAssetId, UntypedHandle};
@@ -53,14 +53,6 @@ const LINEAR_SLOTS: [&str; 4] = [
     "occlusion_texture",
     "depth_map",
 ];
-
-/// Material names that are durable: backed by a `.material.bsn` file, or by an
-/// inline `catalog.bsn` entry awaiting migration.
-///
-/// Outlives registry rebuilds, so a rescan keeps a detected set ephemeral and a
-/// saved material of the same name saved.
-#[derive(Resource, Default)]
-pub struct SavedMaterials(pub HashSet<String>);
 
 /// The materials editor surfaces browse, in display order.
 ///
@@ -195,7 +187,8 @@ pub fn material_to_bsn(world: &World, name: &str, asset_id: UntypedAssetId) -> S
     )
 }
 
-/// Write `assets/materials/<name>.material.bsn` for a live material.
+/// Write a live material back to the file the index holds it at, or to
+/// `assets/materials/<name>.material.bsn` when it has none yet.
 pub fn write_material_file(
     world: &World,
     name: &str,
@@ -204,11 +197,17 @@ pub fn write_material_file(
     let project = world
         .get_resource::<ProjectRoot>()
         .ok_or_else(|| std::io::Error::other("no project root"))?;
-    let path = material_file_path(project, name);
-    crate::definition_assets::write_definition_file(
+    let stem = sanitize_material_name(name);
+    let filed = world
+        .get_resource::<crate::asset_index::AssetIndex>()
+        .and_then(|index| index.by_handle(&handle.clone().untyped()))
+        .filter(|entry| entry.name() == stem)
+        .map(|entry| project.assets_dir().join(&entry.path));
+    let path = filed.unwrap_or_else(|| material_file_path(project, name));
+    crate::definition_assets::write_asset_file(
         world,
-        &sanitize_material_name(name),
-        &crate::definition_assets::DefinitionValue::Asset(handle.clone().untyped()),
+        &stem,
+        &crate::asset_index::AssetValue::Handle(handle.clone().untyped()),
         &path,
     )
 }
@@ -218,30 +217,16 @@ pub fn remove_material_file(world: &World, name: &str) {
     let Some(project) = world.get_resource::<ProjectRoot>() else {
         return;
     };
-    let path = material_file_path(project, name);
+    let filed = world
+        .get_resource::<crate::asset_index::AssetIndex>()
+        .and_then(|index| index.material_named(name))
+        .map(|entry| project.assets_dir().join(&entry.path));
+    let path = filed.unwrap_or_else(|| material_file_path(project, name));
     match std::fs::remove_file(&path) {
         Ok(()) => info!("Removed {}", path.display()),
         Err(err) if err.kind() == std::io::ErrorKind::NotFound => {}
         Err(err) => warn!("Failed to remove {}: {err}", path.display()),
     }
-}
-
-/// Every `assets/materials/*.material.bsn` as `(name, path)`, sorted by path
-/// so scan order is stable.
-pub fn material_files(world: &World) -> Vec<(String, PathBuf)> {
-    let Some(project) = world.get_resource::<ProjectRoot>() else {
-        return Vec::new();
-    };
-    let Ok(read_dir) = std::fs::read_dir(materials_dir(project)) else {
-        return Vec::new();
-    };
-    let mut files: Vec<(String, PathBuf)> = read_dir
-        .flatten()
-        .map(|e| e.path())
-        .filter_map(|path| Some((material_name_from_file(&path)?, path)))
-        .collect();
-    files.sort_by(|a, b| a.1.cmp(&b.1));
-    files
 }
 
 /// Load one material file. A file that fails to read or parse is reported and
@@ -260,86 +245,6 @@ pub fn load_material_file(world: &mut World, path: &Path) -> Option<UntypedHandl
         warn!("No material found in {}", path.display());
     }
     handle
-}
-
-/// Load every `assets/materials/*.material.bsn`, returning `(name, handle)`
-/// pairs keyed by file stem.
-pub fn load_material_files(world: &mut World) -> Vec<(String, UntypedHandle)> {
-    material_files(world)
-        .into_iter()
-        .filter_map(|(name, path)| Some((name, load_material_file(world, &path)?)))
-        .collect()
-}
-
-/// What a rescan of `assets/materials` found.
-#[derive(Default, Debug, PartialEq, Eq)]
-pub struct MaterialRescan {
-    /// Names whose file appeared since the last scan. Loaded and marked saved.
-    pub added: Vec<String>,
-    /// Names whose file has gone. Demoted to unsaved; see
-    /// [`rescan_material_files`] for what that keeps and what it drops.
-    pub demoted: Vec<String>,
-}
-
-/// Rescan `assets/materials` while the editor is up. Files that appeared since
-/// the last scan load and register as they would at project open.
-///
-/// A file that has disappeared demotes its material to *unsaved*:
-///
-/// - **Memory**: the material is kept. Faces and terrain slots reference it
-///   by name, and dropping it would orphan them over a file that may be
-///   moving rather than gone.
-/// - **Disk**: it is not recreated. Leaving it saved would have the next
-///   `persist_materials` write the file back, undoing the user's deletion. A
-///   scene that references it embeds it inline, staying self-contained.
-/// - **Marker**: it lists as unsaved wherever materials are shown.
-///   `material.save` promotes it again and writes a fresh file.
-///
-/// The material file has no asset-server handle behind it, so a file changed
-/// on disk is not reloaded here; its images are, through the asset server's
-/// own watcher.
-pub fn rescan_material_files(world: &mut World) -> MaterialRescan {
-    let files = material_files(world);
-    let known = world.resource::<SavedMaterials>().0.clone();
-    let on_disk: HashSet<&String> = files.iter().map(|(name, _)| name).collect();
-
-    let mut scan = MaterialRescan::default();
-    for gone in known.iter().filter(|name| !on_disk.contains(name)) {
-        info!("Material file for '{gone}' is gone; keeping it as an unsaved material");
-        world.resource_mut::<SavedMaterials>().0.remove(gone);
-        scan.demoted.push(gone.clone());
-    }
-    scan.demoted.sort();
-
-    for (name, path) in files {
-        if known.contains(&name) {
-            continue;
-        }
-        let Some(handle) = load_material_file(world, &path) else {
-            continue;
-        };
-        world
-            .resource_mut::<AssetCatalog>()
-            .insert(format!("@{name}"), handle);
-        world
-            .resource_mut::<SavedMaterials>()
-            .0
-            .insert(name.clone());
-        scan.added.push(name);
-    }
-    if !scan.added.is_empty() {
-        info!("Loaded {} new saved materials", scan.added.len());
-    }
-    scan
-}
-
-/// The material name a file path denotes, or `None` if it is not a material
-/// file.
-pub fn material_name_from_file(path: &Path) -> Option<String> {
-    path.file_name()
-        .and_then(|n| n.to_str())
-        .and_then(|n| n.strip_suffix(MATERIAL_FILE_SUFFIX))
-        .map(str::to_owned)
 }
 
 /// Build a material from `.bsn` text, rehydrating its texture slots through
@@ -727,16 +632,20 @@ fn write_and_promote(
         return;
     }
 
-    if let Err(err) = write_material_file(world, name, handle) {
-        warn!("material.save: failed to write '{name}': {err}");
-        return;
-    }
+    let file = match write_material_file(world, name, handle) {
+        Ok(file) => file,
+        Err(err) => {
+            warn!("material.save: failed to write '{name}': {err}");
+            return;
+        }
+    };
 
     let renamed = current.is_some_and(|old| old != name);
     if renamed && let Some(old) = current {
         remove_material_file(world, old);
-        world.resource_mut::<SavedMaterials>().0.remove(old);
+        forget_material_file(world, old);
     }
+    index_material_file(world, &file, handle);
 
     let mut registry = world.resource_mut::<MaterialRegistry>();
     if let Some(entry) = registry.entries.iter_mut().find(|e| e.handle == *handle) {
@@ -753,10 +662,46 @@ fn write_and_promote(
         .insert(format!("@{name}"), handle.clone().untyped());
     world.resource_mut::<AssetCatalog>().dirty = true;
     world
-        .resource_mut::<SavedMaterials>()
-        .0
-        .insert(name.to_owned());
+        .resource_mut::<AssetCatalog>()
+        .inline_materials
+        .remove(name);
     info!("Saved material '{name}'");
+}
+
+/// Record a material file the editor just wrote, so the index holds it under
+/// the handle that was saved rather than reading a second copy back.
+fn index_material_file(world: &mut World, file: &Path, handle: &Handle<StandardMaterial>) {
+    let Some(kind) = world
+        .get_resource::<jackdaw_api::prelude::AssetKinds>()
+        .and_then(|kinds| kinds.by_kind(crate::definition_assets::MATERIAL_KIND))
+        .cloned()
+    else {
+        return;
+    };
+    crate::asset_index::index_written(
+        world,
+        file,
+        &kind,
+        crate::asset_index::AssetValue::Handle(handle.clone().untyped()),
+    );
+}
+
+/// Drop whatever the index held for a material name, for a file that has been
+/// removed or renamed away.
+fn forget_material_file(world: &mut World, name: &str) {
+    let filed = world
+        .get_resource::<crate::asset_index::AssetIndex>()
+        .and_then(|index| index.material_named(name))
+        .map(|entry| entry.path.clone());
+    if let Some(path) = filed {
+        world
+            .resource_mut::<crate::asset_index::AssetIndex>()
+            .remove(&path);
+    }
+    world
+        .resource_mut::<AssetCatalog>()
+        .inline_materials
+        .remove(name);
 }
 
 /// The material a confirmed delete will remove, and the dialog asking about it.
@@ -886,7 +831,7 @@ fn on_material_delete_confirmed(
 /// Remove every trace of a material name from this project.
 fn delete_material(world: &mut World, name: &str) {
     remove_material_file(world, name);
-    world.resource_mut::<SavedMaterials>().0.remove(name);
+    forget_material_file(world, name);
 
     let mut registry = world.resource_mut::<MaterialRegistry>();
     let removed = registry
@@ -1093,16 +1038,6 @@ mod tests {
         assert_eq!(sanitize_material_name("../escape"), ".._escape");
     }
 
-    #[test]
-    fn material_file_names_round_trip_through_their_stem() {
-        let path = PathBuf::from("/p/assets/materials/grass_05.material.bsn");
-        assert_eq!(material_name_from_file(&path).as_deref(), Some("grass_05"));
-        assert_eq!(
-            material_name_from_file(Path::new("/p/assets/catalog.bsn")),
-            None
-        );
-    }
-
     fn params(pairs: &[(&str, &str)]) -> OperatorParameters {
         let mut params = OperatorParameters::default();
         for (key, value) in pairs {
@@ -1122,9 +1057,36 @@ mod tests {
             config: crate::project::ProjectConfig::default(),
         });
         app.init_resource::<MaterialRegistry>();
-        app.init_resource::<SavedMaterials>();
         app.init_resource::<AssetCatalog>();
+        app.init_resource::<crate::asset_index::AssetIndex>();
+        app.init_resource::<crate::asset_files::AssetKindCache>();
+        app.init_resource::<jackdaw_api::prelude::AssetKinds>();
+        app.world_mut()
+            .resource_mut::<jackdaw_api::prelude::AssetKinds>()
+            .register(jackdaw_api::prelude::AssetKind::compiled(
+                crate::definition_assets::MATERIAL_KIND,
+                "Material",
+                STANDARD_MATERIAL,
+            ));
         (app, tmp)
+    }
+
+    /// The handle the index holds a material under.
+    fn filed_handle(app: &App, name: &str) -> Handle<StandardMaterial> {
+        app.world()
+            .resource::<crate::asset_index::AssetIndex>()
+            .material_named(name)
+            .and_then(|entry| entry.value.handle().cloned())
+            .expect("the index holds the material")
+            .typed::<StandardMaterial>()
+    }
+
+    /// Where the index holds a material, if it holds one.
+    fn filed_at(app: &App, name: &str) -> Option<PathBuf> {
+        app.world()
+            .resource::<crate::asset_index::AssetIndex>()
+            .material_named(name)
+            .map(|entry| entry.path.clone())
     }
 
     #[test]
@@ -1153,9 +1115,10 @@ mod tests {
                 .contains("t/grass_basecolor.png")
         );
         assert!(app.world().resource::<MaterialRegistry>().is_saved("grass"));
-        assert!(
-            app.world().resource::<SavedMaterials>().0.contains("grass"),
-            "the name must stay durable across registry rebuilds"
+        assert_eq!(
+            filed_at(&app, "grass"),
+            Some(PathBuf::from("materials/grass.material.bsn")),
+            "the index must hold the file the save wrote"
         );
         assert!(
             app.world()
@@ -1287,9 +1250,11 @@ mod tests {
             Some("@meadow"),
             "new saves must emit the new name"
         );
-        let saved = app.world().resource::<SavedMaterials>();
-        assert!(saved.0.contains("meadow"));
-        assert!(!saved.0.contains("grass"));
+        assert_eq!(
+            filed_at(&app, "meadow"),
+            Some(PathBuf::from("materials/meadow.material.bsn"))
+        );
+        assert_eq!(filed_at(&app, "grass"), None);
     }
 
     #[test]
@@ -1334,7 +1299,7 @@ mod tests {
     }
 
     #[test]
-    fn saved_material_files_reload_by_their_stem() {
+    fn a_saved_material_file_reloads_through_the_index() {
         let (mut app, tmp) = project_app();
         let handle = {
             let normal = textured(&mut app, "t/rock_normal.png", false);
@@ -1348,13 +1313,16 @@ mod tests {
         };
         write_material_file(app.world(), "rock", &handle).expect("write");
 
-        let loaded = load_material_files(app.world_mut());
-        assert_eq!(loaded.len(), 1);
-        assert_eq!(loaded[0].0, "rock");
+        let scan = crate::asset_index::rescan_asset_index(app.world_mut());
+        assert_eq!(
+            scan.added,
+            vec![PathBuf::from("materials/rock.material.bsn")]
+        );
+        let reloaded = filed_handle(&app, "rock");
         let material = app
             .world()
             .resource::<Assets<StandardMaterial>>()
-            .get(&loaded[0].1.clone().typed::<StandardMaterial>())
+            .get(&reloaded)
             .expect("reloaded material")
             .clone();
         assert!((material.perceptual_roughness - 0.31).abs() < f32::EPSILON);
@@ -1397,16 +1365,15 @@ mod tests {
                 ..default()
             });
         write_material_file(app.world(), "slate", &handle).expect("write");
-        assert!(
-            !app.world().resource::<SavedMaterials>().0.contains("slate"),
-            "nothing has scanned yet",
+        assert_eq!(filed_at(&app, "slate"), None, "nothing has scanned yet");
+
+        let scan = crate::asset_index::rescan_asset_index(app.world_mut());
+
+        assert_eq!(
+            scan.added,
+            vec![PathBuf::from("materials/slate.material.bsn")]
         );
-
-        let scan = rescan_material_files(app.world_mut());
-
-        assert_eq!(scan.added, vec!["slate".to_string()]);
-        assert!(scan.demoted.is_empty());
-        assert!(app.world().resource::<SavedMaterials>().0.contains("slate"));
+        assert!(scan.removed.is_empty());
         let loaded = app
             .world()
             .resource::<AssetCatalog>()
@@ -1424,9 +1391,76 @@ mod tests {
         assert!((roughness - 0.42).abs() < f32::EPSILON);
 
         assert_eq!(
-            rescan_material_files(app.world_mut()),
-            MaterialRescan::default(),
-            "a second rescan re-registers nothing",
+            crate::asset_index::rescan_asset_index(app.world_mut()),
+            crate::asset_index::AssetRescan::default(),
+            "a second scan reads nothing again",
+        );
+    }
+
+    /// A catalog holding one inline material reads exactly like a material
+    /// file, and indexing it would list the catalog as a material and write a
+    /// save back over it.
+    #[test]
+    fn the_catalog_file_is_not_indexed_as_a_material() {
+        let (mut app, tmp) = project_app();
+        let handle = app
+            .world_mut()
+            .resource_mut::<Assets<StandardMaterial>>()
+            .add(StandardMaterial::default());
+        let catalog = tmp.path().join("assets/catalog.bsn");
+        std::fs::create_dir_all(catalog.parent().expect("the assets directory"))
+            .expect("the directory is made");
+        let entry = material_to_bsn(app.world(), "slate", handle.id().untyped());
+        std::fs::write(&catalog, entry).expect("the catalog is written");
+
+        let scan = crate::asset_index::rescan_asset_index(app.world_mut());
+
+        assert!(scan.added.is_empty(), "got {:?}", scan.added);
+        assert!(
+            app.world()
+                .resource::<crate::asset_index::AssetIndex>()
+                .get(Path::new("catalog.bsn"))
+                .is_none(),
+            "the catalog holds what has no file of its own"
+        );
+    }
+
+    /// A material filed outside `materials/` is still the material that name
+    /// stands for, so the panel lists it and a save goes back to its own file.
+    #[test]
+    fn a_material_filed_in_another_folder_is_indexed_by_its_path() {
+        let (mut app, tmp) = project_app();
+        let handle = app
+            .world_mut()
+            .resource_mut::<Assets<StandardMaterial>>()
+            .add(StandardMaterial {
+                perceptual_roughness: 0.17,
+                ..default()
+            });
+        let elsewhere = tmp.path().join("assets/zones/hedgerow");
+        std::fs::create_dir_all(&elsewhere).expect("the directory is made");
+        crate::definition_assets::write_asset_file(
+            app.world(),
+            "slate",
+            &crate::asset_index::AssetValue::Handle(handle.clone().untyped()),
+            &elsewhere.join("slate.material.bsn"),
+        )
+        .expect("the material file is written");
+
+        crate::asset_index::rescan_asset_index(app.world_mut());
+
+        assert_eq!(
+            filed_at(&app, "slate"),
+            Some(PathBuf::from("zones/hedgerow/slate.material.bsn")),
+            "the index keys it by where it sits"
+        );
+        let filed = filed_handle(&app, "slate");
+        write_material_file(app.world(), "slate", &filed).expect("write");
+        assert!(
+            !tmp.path()
+                .join("assets/materials/slate.material.bsn")
+                .exists(),
+            "a save goes back to the file the material came from"
         );
     }
 
@@ -1438,7 +1472,7 @@ mod tests {
             .resource_mut::<Assets<StandardMaterial>>()
             .add(StandardMaterial::default());
         write_material_file(app.world(), name, &handle).expect("write");
-        rescan_material_files(app.world_mut());
+        crate::asset_index::rescan_asset_index(app.world_mut());
         app.world_mut()
             .resource_mut::<MaterialRegistry>()
             .add_saved(name.to_string(), handle);
@@ -1457,9 +1491,12 @@ mod tests {
     fn a_deleted_file_demotes_its_material_instead_of_dropping_it() {
         let (mut app, _tmp) = deleted_behind_our_back("slate");
 
-        let scan = rescan_material_files(app.world_mut());
+        let scan = crate::asset_index::rescan_asset_index(app.world_mut());
 
-        assert_eq!(scan.demoted, vec!["slate".to_string()]);
+        assert_eq!(
+            scan.removed,
+            vec![PathBuf::from("materials/slate.material.bsn")]
+        );
         assert!(scan.added.is_empty());
         assert!(
             app.world()
@@ -1468,8 +1505,9 @@ mod tests {
                 .contains_key("@slate"),
             "the loaded material outlives its file",
         );
-        assert!(
-            !app.world().resource::<SavedMaterials>().0.contains("slate"),
+        assert_eq!(
+            filed_at(&app, "slate"),
+            None,
             "nothing on disk backs it any more",
         );
     }
@@ -1479,8 +1517,8 @@ mod tests {
     #[test]
     fn a_deleted_file_is_not_written_back_by_the_next_persist() {
         let (mut app, tmp) = deleted_behind_our_back("slate");
-        rescan_material_files(app.world_mut());
-        // The browser rebuilds the registry from `SavedMaterials`; stand in for that here.
+        crate::asset_index::rescan_asset_index(app.world_mut());
+        // The browser rebuilds the registry from the index; stand in for that here.
         app.world_mut().resource_mut::<MaterialRegistry>().entries = Vec::new();
         let handle = app
             .world()
@@ -1504,7 +1542,10 @@ mod tests {
 
         // An explicit save writes the file again.
         write_and_promote(app.world_mut(), &handle, Some("slate"), "slate");
-        assert!(app.world().resource::<SavedMaterials>().0.contains("slate"));
+        assert_eq!(
+            filed_at(&app, "slate"),
+            Some(PathBuf::from("materials/slate.material.bsn"))
+        );
         assert!(
             tmp.path()
                 .join("assets/materials/slate.material.bsn")
@@ -1536,12 +1577,7 @@ mod tests {
                 .join("assets/materials/meadow.material.bsn")
                 .exists()
         );
-        assert!(
-            !app.world()
-                .resource::<SavedMaterials>()
-                .0
-                .contains("meadow")
-        );
+        assert_eq!(filed_at(&app, "meadow"), None);
         assert!(
             app.world()
                 .resource::<MaterialRegistry>()

--- a/src/material_browser.rs
+++ b/src/material_browser.rs
@@ -38,7 +38,6 @@ impl Plugin for MaterialBrowserPlugin {
             .init_resource::<MaterialBrowserState>()
             .init_resource::<MaterialPreviewState>()
             .init_resource::<MaterialRegistry>()
-            .init_resource::<crate::material_assets::SavedMaterials>()
             .add_systems(
                 OnEnter(crate::AppState::Editor),
                 (
@@ -46,11 +45,15 @@ impl Plugin for MaterialBrowserPlugin {
                     rebuild_material_registry,
                     |world: &mut World| crate::asset_catalog::save_catalog(world),
                 )
-                    .chain(),
+                    .chain()
+                    .after(crate::asset_index::open_asset_index),
             )
             .add_systems(
                 Update,
                 (
+                    follow_asset_index
+                        .run_if(resource_changed::<crate::asset_index::AssetIndex>)
+                        .before(rescan_material_definitions),
                     rescan_material_definitions,
                     save_catalog_if_dirty,
                     apply_material_filter,
@@ -239,13 +242,14 @@ fn collect_texture_paths(dir: &Path, paths: &mut Vec<String>) {
     }
 }
 
-/// Rebuild [`MaterialRegistry`] from the catalog plus a fresh scan of both
-/// `assets/materials` and the texture sets under `assets/`.
+/// Rebuild [`MaterialRegistry`] from the asset index plus a fresh scan of the
+/// texture sets under `assets/`.
 ///
-/// Saved materials are listed first and win their base name: a detected set
-/// whose name already belongs to a saved material is skipped. Detected sets
-/// enter the in-memory catalog (so `@Name` face references resolve and scene
-/// saves emit them) but stay unsaved until `material.save` writes a file.
+/// Materials with a file of their own are listed first and win their base name,
+/// wherever their file sits: a detected set whose name already belongs to one is
+/// skipped. Detected sets enter the in-memory catalog (so `@Name` face
+/// references resolve and scene saves emit them) but stay unsaved until
+/// `material.save` writes a file.
 fn rebuild_material_registry(world: &mut World) {
     let assets_dir = world
         .get_resource::<crate::project::ProjectRoot>()
@@ -254,30 +258,37 @@ fn rebuild_material_registry(world: &mut World) {
     world.resource_mut::<MaterialBrowserState>().scan_directory = assets_dir.clone();
     world.resource_mut::<MaterialRegistry>().entries.clear();
 
-    // Material files written since the last scan (by another tool, by hand, or by a second
-    // editor) become saved materials here, without reopening the project.
-    crate::material_assets::rescan_material_files(world);
-
-    let durable = world
-        .resource::<crate::material_assets::SavedMaterials>()
-        .0
-        .clone();
     let mut saved: Vec<(String, Handle<StandardMaterial>)> = world
-        .resource::<crate::asset_catalog::AssetCatalog>()
-        .handles
-        .iter()
-        .filter(|(name, handle)| {
-            handle.type_id() == std::any::TypeId::of::<StandardMaterial>()
-                && durable.contains(name.trim_start_matches(['@', '#']))
-        })
-        .map(|(name, handle)| {
-            (
-                name.trim_start_matches(['@', '#']).to_string(),
-                handle.clone().typed::<StandardMaterial>(),
-            )
+        .resource::<crate::asset_index::AssetIndex>()
+        .of_kind(crate::definition_assets::MATERIAL_KIND)
+        .filter_map(|entry| {
+            let handle = entry.value.handle()?;
+            (handle.type_id() == std::any::TypeId::of::<StandardMaterial>())
+                .then(|| (entry.name(), handle.clone().typed::<StandardMaterial>()))
         })
         .collect();
+    let inline = world
+        .resource::<crate::asset_catalog::AssetCatalog>()
+        .inline_materials
+        .clone();
+    saved.extend(
+        world
+            .resource::<crate::asset_catalog::AssetCatalog>()
+            .handles
+            .iter()
+            .filter(|(name, handle)| {
+                handle.type_id() == std::any::TypeId::of::<StandardMaterial>()
+                    && inline.contains(name.trim_start_matches(['@', '#']))
+            })
+            .map(|(name, handle)| {
+                (
+                    name.trim_start_matches(['@', '#']).to_string(),
+                    handle.clone().typed::<StandardMaterial>(),
+                )
+            }),
+    );
     saved.sort_by(|a, b| a.0.cmp(&b.0));
+    saved.dedup_by(|a, b| a.0 == b.0);
     for (name, handle) in saved {
         world
             .resource_mut::<MaterialRegistry>()
@@ -362,6 +373,12 @@ fn on_material_grid_added(
     mut state: ResMut<MaterialBrowserState>,
 ) {
     info!("MaterialBrowserGrid added, triggering rescan");
+    state.needs_rescan = true;
+}
+
+/// A file indexed, reloaded or removed since the last frame changes what the
+/// panel has to list.
+fn follow_asset_index(mut state: ResMut<MaterialBrowserState>) {
     state.needs_rescan = true;
 }
 
@@ -1422,10 +1439,49 @@ mod tests {
             config: crate::project::ProjectConfig::default(),
         });
         app.init_resource::<MaterialRegistry>();
-        app.init_resource::<crate::material_assets::SavedMaterials>();
         app.init_resource::<crate::asset_catalog::AssetCatalog>();
         app.init_resource::<MaterialBrowserState>();
+        app.init_resource::<crate::asset_index::AssetIndex>();
+        app.init_resource::<crate::asset_files::AssetKindCache>();
+        app.init_resource::<jackdaw_api::prelude::AssetKinds>();
+        app.world_mut()
+            .resource_mut::<jackdaw_api::prelude::AssetKinds>()
+            .register(jackdaw_api::prelude::AssetKind::compiled(
+                crate::definition_assets::MATERIAL_KIND,
+                "Material",
+                StandardMaterial::type_path(),
+            ));
         (app, tmp)
+    }
+
+    /// The panel lists what the index holds, so a material filed anywhere under
+    /// the project shows up beside the ones in `materials/`.
+    #[test]
+    fn a_material_filed_outside_the_materials_folder_is_listed() {
+        let (mut app, tmp) = project_browser_app();
+        let handle = app
+            .world_mut()
+            .resource_mut::<Assets<StandardMaterial>>()
+            .add(StandardMaterial::default());
+        let elsewhere = tmp.path().join("assets/zones/hedgerow");
+        std::fs::create_dir_all(&elsewhere).expect("the directory is made");
+        crate::definition_assets::write_asset_file(
+            app.world(),
+            "bramble",
+            &crate::asset_index::AssetValue::Handle(handle.untyped()),
+            &elsewhere.join("bramble.material.bsn"),
+        )
+        .expect("the material file is written");
+
+        crate::asset_index::rescan_asset_index(app.world_mut());
+        rebuild_material_registry(app.world_mut());
+
+        assert!(
+            app.world()
+                .resource::<MaterialRegistry>()
+                .is_saved("bramble"),
+            "a material is listed by what it is, not by where it sits",
+        );
     }
 
     /// A material whose file went missing stays in the list so its name resolves, and lists
@@ -1439,6 +1495,7 @@ mod tests {
             .add(StandardMaterial::default());
         crate::material_assets::write_material_file(app.world(), "slate", &handle).expect("write");
 
+        crate::asset_index::rescan_asset_index(app.world_mut());
         rebuild_material_registry(app.world_mut());
         assert!(
             app.world().resource::<MaterialRegistry>().is_saved("slate"),
@@ -1447,6 +1504,7 @@ mod tests {
 
         std::fs::remove_file(tmp.path().join("assets/materials/slate.material.bsn"))
             .expect("remove");
+        crate::asset_index::rescan_asset_index(app.world_mut());
         rebuild_material_registry(app.world_mut());
 
         let registry = app.world().resource::<MaterialRegistry>();

--- a/tests/inspector/definition_card.rs
+++ b/tests/inspector/definition_card.rs
@@ -71,16 +71,8 @@ fn app_with_open_definition() -> (App, tempfile::TempDir) {
 }
 
 fn open_mob(app: &App) -> MobDef {
-    let entity = app
-        .world()
-        .resource::<OpenDefinition>()
-        .0
-        .expect("a definition is open");
-    let handle = app
-        .world()
-        .get::<DefinitionAssetEdit>(entity)
-        .expect("the entity is editing a definition")
-        .value
+    let handle = jackdaw::definition_assets::open_definition_value(app.world())
+        .expect("a definition is open")
         .handle()
         .expect("a compiled definition")
         .clone();

--- a/tests/inspector/schema_definition_card.rs
+++ b/tests/inspector/schema_definition_card.rs
@@ -71,7 +71,9 @@ fn app_with_open_item() -> (App, tempfile::TempDir) {
 }
 
 fn open_item(app: &App) -> serde_json::Value {
-    jackdaw::definition_assets::schema_definition_json(app.world(), "item", "torch")
+    let path = jackdaw::definition_assets::open_definition_path(app.world())
+        .expect("a definition is open");
+    jackdaw::definition_assets::schema_definition_json(app.world(), "item", &path)
         .expect("the definition reads back")
 }
 

--- a/tests/scenes/jsn_to_bsn.rs
+++ b/tests/scenes/jsn_to_bsn.rs
@@ -708,7 +708,6 @@ fn catalog_round_trips_as_bsn() {
         // Saving and loading a catalog both go through the material files,
         // which this minimal app has to supply the bookkeeping for.
         app.init_resource::<jackdaw::material_assets::MaterialRegistry>();
-        app.init_resource::<jackdaw::material_assets::SavedMaterials>();
         app.world_mut().insert_resource(ProjectRoot::new(
             root.to_path_buf(),
             jackdaw::project::ProjectConfig::default(),

--- a/tests/stage/definition_assets.rs
+++ b/tests/stage/definition_assets.rs
@@ -1,8 +1,9 @@
-//! Definition assets: a registered asset type edited as files in the project.
+//! Asset files: a registered asset type edited as files in the project.
 //!
-//! A definition type claims a directory and a suffix, and its files are
-//! created, edited, saved and listed through the same operators whether the
-//! edit comes from the inspector or from a caller with no viewport.
+//! A file says what it holds and can sit in any folder; its path is what the
+//! index keys it by. Files are created, edited, saved and listed through the
+//! same operators whether the edit comes from the inspector or from a caller
+//! with no viewport.
 
 use crate::util;
 
@@ -10,9 +11,8 @@ use std::path::PathBuf;
 
 use bevy::asset::{Asset, Assets};
 use bevy::prelude::*;
-use jackdaw::definition_assets::{
-    DefinitionAssetEdit, DefinitionRegistry, DefinitionValue, MATERIAL_KIND, OpenDefinition,
-};
+use jackdaw::asset_index::{AssetIndex, AssetValue};
+use jackdaw::definition_assets::{MATERIAL_KIND, OpenDefinition};
 use jackdaw_api::prelude::*;
 use jackdaw_api_internal::operator::{CallOperatorSettings, ExecutionContext};
 use jackdaw_commands::CommandHistory;
@@ -93,28 +93,43 @@ fn call(app: &mut App, id: &'static str, params: &[(&'static str, PropertyValue)
     app.update();
 }
 
+/// Save a live material through the operator that owns it, which is what puts
+/// it in the index, the catalog and the panel's list at once.
+#[track_caller]
+fn save_material(app: &mut App, name: &'static str, handle: &Handle<StandardMaterial>) {
+    app.world_mut()
+        .resource_mut::<jackdaw::material_assets::MaterialRegistry>()
+        .add(name.to_string(), handle.clone());
+    app.world_mut()
+        .insert_resource(jackdaw::material_preview::MaterialPreviewState {
+            active_material: Some(handle.clone()),
+            ..default()
+        });
+    call(app, "material.save", &[("material", name.into())]);
+    app.update();
+}
+
 fn open_item(app: &App) -> ItemDef {
-    let entity = app
-        .world()
-        .resource::<OpenDefinition>()
-        .0
+    let value = jackdaw::definition_assets::open_definition_value(app.world())
         .expect("a definition is open");
-    let value = app
-        .world()
-        .get::<DefinitionAssetEdit>(entity)
-        .expect("the entity is editing a definition")
-        .value
-        .clone();
     item_of(app, &value)
 }
 
-fn item_of(app: &App, value: &DefinitionValue) -> ItemDef {
+fn item_of(app: &App, value: &AssetValue) -> ItemDef {
     let handle = value.handle().expect("a compiled definition").clone();
     app.world()
         .resource::<Assets<ItemDef>>()
         .get(&handle.typed::<ItemDef>())
         .expect("the definition is in its store")
         .clone()
+}
+
+/// The value the index holds for a file under the project's assets.
+fn indexed(app: &App, relative: &str) -> Option<AssetValue> {
+    app.world()
+        .resource::<AssetIndex>()
+        .get(std::path::Path::new(relative))
+        .map(|entry| entry.value.clone())
 }
 
 #[test]
@@ -172,19 +187,14 @@ fn a_definition_is_created_edited_and_saved_through_its_operators() {
     assert!(written.contains("Rare"), "got:\n{written}");
     assert!(written.contains("coin"), "got:\n{written}");
 
+    let relative = "content/items/torch.bsn";
     app.world_mut()
-        .resource_mut::<DefinitionRegistry>()
-        .remove("item", "torch");
-    let scan = jackdaw::definition_assets::rescan_definitions(app.world_mut());
-    assert_eq!(scan.added, vec![("item".to_string(), "torch".to_string())]);
+        .resource_mut::<AssetIndex>()
+        .remove(std::path::Path::new(relative));
+    let scan = jackdaw::asset_index::rescan_asset_index(app.world_mut());
+    assert_eq!(scan.added, vec![std::path::PathBuf::from(relative)]);
     let reloaded = {
-        let value = app
-            .world()
-            .resource::<DefinitionRegistry>()
-            .get("item", "torch")
-            .expect("the scan found it")
-            .value
-            .clone();
+        let value = indexed(&app, relative).expect("the walk found it");
         item_of(&app, &value)
     };
     assert_eq!(reloaded.stack_size, 12);
@@ -232,13 +242,7 @@ fn undo_reaches_the_definition_after_its_card_is_closed() {
         "asset.set",
         &[("field", "stack_size".into()), ("value", "12".into())],
     );
-    let value = app
-        .world()
-        .resource::<DefinitionRegistry>()
-        .get("item", "torch")
-        .expect("the definition is registered")
-        .value
-        .clone();
+    let value = indexed(&app, "torch.bsn").expect("the file is indexed");
 
     jackdaw::definition_assets::close_open_definition(app.world_mut());
     app.update();
@@ -252,7 +256,7 @@ fn undo_reaches_the_definition_after_its_card_is_closed() {
     assert_eq!(
         item_of(&app, &value).stack_size,
         0,
-        "the entry is keyed by the value, so it outlives the card"
+        "the entry is keyed by the file, so it outlives the card"
     );
 }
 
@@ -303,10 +307,10 @@ fn a_definition_saves_back_to_the_file_it_was_opened_from() {
         .world_mut()
         .resource_mut::<Assets<ItemDef>>()
         .add(ItemDef::default());
-    let flat = jackdaw::definition_assets::write_definition_file(
+    let flat = jackdaw::definition_assets::write_asset_file(
         app.world(),
         "sword",
-        &DefinitionValue::Asset(handle.untyped()),
+        &AssetValue::Handle(handle.untyped()),
         &item_path(&tmp, "sword"),
     )
     .expect("the file is written");
@@ -359,12 +363,185 @@ fn deleting_a_definition_closes_its_card_and_drops_the_entry() {
 
     assert!(!path.exists(), "the file is gone");
     assert!(app.world().resource::<OpenDefinition>().0.is_none());
-    assert!(
-        app.world()
-            .resource::<DefinitionRegistry>()
-            .get("item", "torch")
-            .is_none()
+    assert!(indexed(&app, "content/items/torch.bsn").is_none());
+}
+
+/// A file another tool rewrites is read back into the handle the editor
+/// already handed out, so faces, fields and cards keep pointing at it.
+#[test]
+fn a_file_edited_on_disk_reloads_into_the_handle_it_already_had() {
+    let (mut app, tmp) = editor_with_items();
+    call(
+        &mut app,
+        "asset.new",
+        &[
+            ("type", "item".into()),
+            ("name", "torch".into()),
+            (
+                "path",
+                items_dir(&tmp).to_string_lossy().into_owned().into(),
+            ),
+        ],
     );
+    let relative = "content/items/torch.bsn";
+    let before = indexed(&app, relative)
+        .and_then(|value| value.handle().map(bevy::asset::UntypedHandle::id))
+        .expect("the new file is indexed");
+
+    std::thread::sleep(std::time::Duration::from_millis(10));
+    std::fs::write(
+        item_path(&tmp, "torch"),
+        format!("#torch\n{} {{ stack_size: 9 }}\n", ItemDef::type_path()),
+    )
+    .expect("the file is rewritten");
+    let scan = jackdaw::asset_index::rescan_asset_index(app.world_mut());
+
+    assert_eq!(scan.reloaded, vec![std::path::PathBuf::from(relative)]);
+    let after = indexed(&app, relative)
+        .and_then(|value| value.handle().map(bevy::asset::UntypedHandle::id))
+        .expect("the file is still indexed");
+    assert_eq!(before, after, "the handle outlives the edit");
+    assert_eq!(
+        open_item(&app).stack_size,
+        9,
+        "and now holds what the file says"
+    );
+}
+
+/// A file that leaves the project takes its card with it; whatever already
+/// holds the handle keeps rendering.
+#[test]
+fn a_file_deleted_on_disk_closes_its_card() {
+    let (mut app, tmp) = editor_with_items();
+    call(
+        &mut app,
+        "asset.new",
+        &[
+            ("type", "item".into()),
+            ("name", "torch".into()),
+            (
+                "path",
+                items_dir(&tmp).to_string_lossy().into_owned().into(),
+            ),
+        ],
+    );
+    assert!(app.world().resource::<OpenDefinition>().0.is_some());
+
+    std::fs::remove_file(item_path(&tmp, "torch")).expect("the file is removed");
+    let scan = jackdaw::asset_index::rescan_asset_index(app.world_mut());
+
+    assert_eq!(
+        scan.removed,
+        vec![std::path::PathBuf::from("content/items/torch.bsn")]
+    );
+    assert!(
+        app.world().resource::<OpenDefinition>().0.is_none(),
+        "there is nothing left to save the card back to"
+    );
+}
+
+/// Edits the user has not saved yet are the point of the card, so a file that
+/// goes out from under a dirty one leaves both standing and its save writes
+/// the file again.
+#[test]
+fn a_file_deleted_under_a_dirty_card_leaves_the_card_open() {
+    let (mut app, tmp) = editor_with_items();
+    call(
+        &mut app,
+        "asset.new",
+        &[
+            ("type", "item".into()),
+            ("name", "torch".into()),
+            (
+                "path",
+                items_dir(&tmp).to_string_lossy().into_owned().into(),
+            ),
+        ],
+    );
+    call(
+        &mut app,
+        "asset.set",
+        &[("field", "stack_size".into()), ("value", "12".into())],
+    );
+
+    std::fs::remove_file(item_path(&tmp, "torch")).expect("the file is removed");
+    let scan = jackdaw::asset_index::rescan_asset_index(app.world_mut());
+
+    assert!(scan.removed.is_empty(), "got {:?}", scan.removed);
+    assert!(app.world().resource::<OpenDefinition>().0.is_some());
+    assert_eq!(open_item(&app).stack_size, 12, "the edit is still there");
+
+    call(&mut app, "asset.save", &[]);
+    let written = std::fs::read_to_string(item_path(&tmp, "torch")).expect("the file reads");
+    assert!(written.contains("stack_size: 12"), "got:\n{written}");
+}
+
+/// A file rewritten to hold a type nothing registers is no longer an asset of
+/// this project, whatever the index held for it before.
+#[test]
+fn a_file_that_stops_naming_a_known_type_leaves_the_index() {
+    let (mut app, tmp) = editor_with_items();
+    call(
+        &mut app,
+        "asset.new",
+        &[
+            ("type", "item".into()),
+            ("name", "torch".into()),
+            (
+                "path",
+                items_dir(&tmp).to_string_lossy().into_owned().into(),
+            ),
+        ],
+    );
+    let relative = "content/items/torch.bsn";
+    assert!(indexed(&app, relative).is_some());
+
+    std::thread::sleep(std::time::Duration::from_millis(10));
+    std::fs::write(
+        item_path(&tmp, "torch"),
+        "#torch\nmy_game::content::LanternDef { }\n",
+    )
+    .expect("the file is rewritten");
+    let scan = jackdaw::asset_index::rescan_asset_index(app.world_mut());
+
+    assert_eq!(scan.removed, vec![std::path::PathBuf::from(relative)]);
+    assert!(indexed(&app, relative).is_none());
+    assert!(
+        item_path(&tmp, "torch").is_file(),
+        "the file itself is the user's to keep"
+    );
+}
+
+/// A file's folder is no part of what it is; the index keys it by the path it
+/// sits at.
+#[test]
+fn an_asset_file_in_any_folder_is_indexed_by_its_path() {
+    let (mut app, tmp) = editor_with_items();
+    let handle = app
+        .world_mut()
+        .resource_mut::<Assets<ItemDef>>()
+        .add(ItemDef {
+            stack_size: 7,
+            ..Default::default()
+        });
+    let deep = tmp.path().join("assets/somewhere/else");
+    std::fs::create_dir_all(&deep).expect("the directory is made");
+    jackdaw::definition_assets::write_asset_file(
+        app.world(),
+        "torch",
+        &AssetValue::Handle(handle.untyped()),
+        &deep.join("torch.bsn"),
+    )
+    .expect("the file is written");
+
+    let scan = jackdaw::asset_index::rescan_asset_index(app.world_mut());
+
+    assert_eq!(
+        scan.added,
+        vec![std::path::PathBuf::from("somewhere/else/torch.bsn")]
+    );
+    let value = indexed(&app, "somewhere/else/torch.bsn").expect("the walk found it");
+    assert_eq!(item_of(&app, &value).stack_size, 7);
 }
 
 #[test]
@@ -406,11 +583,9 @@ fn unregistering_a_definition_type_drops_its_entries_and_closes_the_card() {
         app.world().resource::<OpenDefinition>().0.is_none(),
         "the card goes with the type that registered it"
     );
-    assert!(
-        app.world()
-            .resource::<DefinitionRegistry>()
-            .names_of("item")
-            .is_empty()
+    assert_eq!(
+        app.world().resource::<AssetIndex>().of_kind("item").count(),
+        0
     );
 }
 
@@ -445,10 +620,10 @@ fn a_definition_file_reports_the_kind_its_type_belongs_to() {
         .resource_mut::<Assets<ItemDef>>()
         .add(ItemDef::default());
     let path = item_path(&tmp, "torch");
-    jackdaw::definition_assets::write_definition_file(
+    jackdaw::definition_assets::write_asset_file(
         app.world(),
         "torch",
-        &DefinitionValue::Asset(handle.untyped()),
+        &AssetValue::Handle(handle.untyped()),
         &path,
     )
     .expect("the file is written");
@@ -467,10 +642,10 @@ fn a_definition_file_reports_the_kind_its_type_belongs_to() {
     );
 }
 
-/// Materials are loaded with their textures by the material browser, and the
-/// definition registry lists them alongside every other kind.
+/// Materials are loaded with their textures like any other asset file, and the
+/// index lists them alongside every other kind.
 #[test]
-fn the_material_directory_still_loads_and_lists_as_a_definition() {
+fn a_material_file_is_indexed_alongside_every_other_kind() {
     let (mut app, tmp) = editor_with_items();
     let handle = app
         .world_mut()
@@ -487,23 +662,22 @@ fn the_material_directory_still_loads_and_lists_as_a_definition() {
             .is_file()
     );
 
-    let scan = jackdaw::material_assets::rescan_material_files(app.world_mut());
-    assert_eq!(scan.added, vec!["slate".to_string()]);
-    app.world_mut()
-        .resource_mut::<jackdaw::material_assets::MaterialRegistry>()
-        .add_saved("slate".to_string(), handle);
-    app.update();
+    let scan = jackdaw::asset_index::rescan_asset_index(app.world_mut());
+    assert_eq!(
+        scan.added,
+        vec![std::path::PathBuf::from("materials/slate.material.bsn")]
+    );
 
     let entry_path = app
         .world()
-        .resource::<DefinitionRegistry>()
-        .get(MATERIAL_KIND, "slate")
-        .expect("the material lists as a definition")
-        .path
-        .clone();
+        .resource::<AssetIndex>()
+        .of_kind(MATERIAL_KIND)
+        .map(|entry| entry.path.clone())
+        .next()
+        .expect("the material lists like any other asset");
     assert_eq!(
         entry_path,
-        tmp.path().join("assets/materials/slate.material.bsn")
+        std::path::PathBuf::from("materials/slate.material.bsn")
     );
 }
 
@@ -514,17 +688,7 @@ fn a_material_saved_by_its_own_operator_carries_what_asset_set_wrote() {
         .world_mut()
         .resource_mut::<Assets<StandardMaterial>>()
         .add(StandardMaterial::default());
-    jackdaw::material_assets::write_material_file(app.world(), "slate", &handle)
-        .expect("the material file is written");
-    app.world_mut()
-        .resource_mut::<jackdaw::material_assets::MaterialRegistry>()
-        .add_saved("slate".to_string(), handle.clone());
-    app.world_mut()
-        .insert_resource(jackdaw::material_preview::MaterialPreviewState {
-            active_material: Some(handle),
-            ..default()
-        });
-    app.update();
+    save_material(&mut app, "slate", &handle);
 
     call(
         &mut app,
@@ -553,12 +717,7 @@ fn a_material_is_opened_and_its_fields_set_through_the_definition_operators() {
         .world_mut()
         .resource_mut::<Assets<StandardMaterial>>()
         .add(StandardMaterial::default());
-    jackdaw::material_assets::write_material_file(app.world(), "slate", &handle)
-        .expect("the material file is written");
-    app.world_mut()
-        .resource_mut::<jackdaw::material_assets::MaterialRegistry>()
-        .add_saved("slate".to_string(), handle.clone());
-    app.update();
+    save_material(&mut app, "slate", &handle);
 
     call(
         &mut app,
@@ -602,17 +761,7 @@ fn asset_set_fills_a_texture_slot_from_a_path_and_the_save_keeps_it() {
         .world_mut()
         .resource_mut::<Assets<StandardMaterial>>()
         .add(StandardMaterial::default());
-    jackdaw::material_assets::write_material_file(app.world(), "slate", &handle)
-        .expect("the material file is written");
-    app.world_mut()
-        .resource_mut::<jackdaw::material_assets::MaterialRegistry>()
-        .add_saved("slate".to_string(), handle.clone());
-    app.world_mut()
-        .insert_resource(jackdaw::material_preview::MaterialPreviewState {
-            active_material: Some(handle.clone()),
-            ..default()
-        });
-    app.update();
+    save_material(&mut app, "slate", &handle);
 
     call(
         &mut app,
@@ -663,12 +812,7 @@ fn asset_set_takes_a_colour_as_channels_and_undo_puts_the_old_one_back() {
         .world_mut()
         .resource_mut::<Assets<StandardMaterial>>()
         .add(StandardMaterial::default());
-    jackdaw::material_assets::write_material_file(app.world(), "slate", &handle)
-        .expect("the material file is written");
-    app.world_mut()
-        .resource_mut::<jackdaw::material_assets::MaterialRegistry>()
-        .add_saved("slate".to_string(), handle.clone());
-    app.update();
+    save_material(&mut app, "slate", &handle);
 
     call(
         &mut app,

--- a/tests/stage/project_definitions.rs
+++ b/tests/stage/project_definitions.rs
@@ -9,7 +9,8 @@
 use std::path::{Path, PathBuf};
 
 use bevy::prelude::*;
-use jackdaw::definition_assets::{DefinitionRegistry, DefinitionValues, OpenDefinition};
+use jackdaw::asset_index::{AssetEntry, AssetIndex};
+use jackdaw::definition_assets::OpenDefinition;
 use jackdaw_api::prelude::*;
 use jackdaw_api_internal::AssetKindSource;
 use jackdaw_api_internal::operator::{CallOperatorSettings, ExecutionContext, OperatorReports};
@@ -106,21 +107,24 @@ fn material_schema() -> jackdaw_schema::TypeSchema {
     }
 }
 
+/// The names the index gives a kind's files, sorted.
+fn names_of(app: &App, kind: &str) -> Vec<String> {
+    let mut names: Vec<String> = app
+        .world()
+        .resource::<AssetIndex>()
+        .of_kind(kind)
+        .map(AssetEntry::name)
+        .collect();
+    names.sort();
+    names
+}
+
 /// The open definition as JSON: what its file authors over what its type
 /// defaults to.
 fn open_item(app: &App) -> serde_json::Value {
-    let entity = app
-        .world()
-        .resource::<OpenDefinition>()
-        .0
+    let path = jackdaw::definition_assets::open_definition_path(app.world())
         .expect("a definition is open");
-    let name = app
-        .world()
-        .get::<jackdaw::definition_assets::DefinitionAssetEdit>(entity)
-        .expect("the entity is editing a definition")
-        .name
-        .clone();
-    jackdaw::definition_assets::schema_definition_json(app.world(), "item", &name)
+    jackdaw::definition_assets::schema_definition_json(app.world(), "item", &path)
         .expect("the definition reads back")
 }
 
@@ -319,9 +323,7 @@ fn a_new_definition_asked_for_by_file_path_takes_that_name_and_folder() {
     let path = tmp.path().join("assets/content/lantern.bsn");
     assert!(path.is_file(), "asset.new writes the file at {path:?}");
     assert_eq!(
-        app.world()
-            .resource::<DefinitionRegistry>()
-            .names_of("item"),
+        names_of(&app, "item"),
         vec!["lantern".to_string()],
         "the file the caller named is the name it goes by"
     );
@@ -366,10 +368,7 @@ fn an_asset_file_in_another_folder_is_found_by_the_scan() {
     let reopened = editor_on(tmp.path());
 
     assert_eq!(
-        reopened
-            .world()
-            .resource::<DefinitionRegistry>()
-            .names_of("item"),
+        names_of(&reopened, "item"),
         vec!["lantern".to_string()],
         "a file says what it is wherever it sits"
     );
@@ -398,16 +397,16 @@ fn a_saved_definition_is_listed_and_read_back_when_the_project_is_opened_again()
 
     let reopened = editor_on(tmp.path());
     assert_eq!(
-        reopened
-            .world()
-            .resource::<DefinitionRegistry>()
-            .names_of("item"),
+        names_of(&reopened, "item"),
         vec!["torch".to_string()],
         "the scan lists what the project holds"
     );
-    let read_back =
-        jackdaw::definition_assets::schema_definition_json(reopened.world(), "item", "torch")
-            .expect("the definition reads back");
+    let read_back = jackdaw::definition_assets::schema_definition_json(
+        reopened.world(),
+        "item",
+        std::path::Path::new("torch.bsn"),
+    )
+    .expect("the definition reads back");
     assert_eq!(read_back["stack_size"], 12);
     assert_eq!(read_back["rarity"], "Rare");
 }
@@ -582,10 +581,8 @@ fn a_kind_whose_type_leaves_the_schema_takes_its_entries_and_its_card_with_it() 
     );
     assert!(app.world().resource::<OpenDefinition>().0.is_none());
     assert!(
-        app.world()
-            .resource::<DefinitionValues>()
-            .get("item", "torch")
-            .is_none()
+        names_of(&app, "item").is_empty(),
+        "and the index lets go of what its files held"
     );
 }
 
@@ -669,9 +666,7 @@ fn a_kind_reports_what_the_project_holds() {
     );
 
     assert_eq!(
-        app.world()
-            .resource::<DefinitionRegistry>()
-            .names_of("item"),
+        names_of(&app, "item"),
         vec!["lantern".to_string(), "torch".to_string()]
     );
 
@@ -682,8 +677,8 @@ fn a_kind_reports_what_the_project_holds() {
     call(&mut app, "asset.list", &[("type", "item".into())]);
     assert_eq!(
         app.world().resource::<OperatorReports>().0,
-        vec!["item: lantern, torch".to_string()],
-        "asset.list answers for a kind the schema brought"
+        vec!["item: lantern.bsn, torch.bsn".to_string()],
+        "asset.list answers for a kind the schema brought, by path"
     );
 }
 
@@ -832,9 +827,7 @@ fn a_new_definition_goes_by_the_file_it_was_asked_for_rather_than_the_name() {
         "the file the caller named is the file that is written"
     );
     assert_eq!(
-        app.world()
-            .resource::<DefinitionRegistry>()
-            .names_of("item"),
+        names_of(&app, "item"),
         vec!["lantern".to_string()],
         "and the name is the one a scan would read back from it"
     );
@@ -877,9 +870,7 @@ fn a_definition_is_named_by_the_stem_before_the_first_dot_of_its_file() {
     let (app, _tmp, _path) = editor_on_an_authored_torch();
 
     assert_eq!(
-        app.world()
-            .resource::<DefinitionRegistry>()
-            .names_of("item"),
+        names_of(&app, "item"),
         vec!["torch".to_string()],
         "the kind segment the file carries is no part of the name"
     );
@@ -900,12 +891,7 @@ fn a_new_definition_asked_for_by_a_file_path_drops_its_kind_segment() {
 
     let path = tmp.path().join("assets/content/lantern.item.bsn");
     assert!(path.is_file(), "asset.new writes the file at {path:?}");
-    assert_eq!(
-        app.world()
-            .resource::<DefinitionRegistry>()
-            .names_of("item"),
-        vec!["lantern".to_string()],
-    );
+    assert_eq!(names_of(&app, "item"), vec!["lantern".to_string()],);
     let written = std::fs::read_to_string(&path).expect("the file reads");
     assert!(
         written.contains("#lantern\n"),


### PR DESCRIPTION
Asset files are now held in one index keyed by their path under assets, built by a walk at project open and kept current by a file watcher. A material or definition can sit in any folder and saves back to the file it came from.

A file rewritten by another tool reloads into the handle the editor already handed out. Bare names in older scenes still resolve through the file stem, with a warning when two files share one. asset.list reports paths.

LLM disclaimer: Claude Code was used to help plan and implement this change, but all code was human reviewed by myself!
