### PR TITLE
Render editor views in one format and rebin detail tiles on pipeline change

### DIFF
--- a/crates/jackdaw_terrain/src/render/detail.rs
+++ b/crates/jackdaw_terrain/src/render/detail.rs
@@ -26,8 +26,9 @@ use bevy::render::mesh::allocator::MeshAllocator;
 use bevy::render::mesh::{RenderMesh, RenderMeshBufferInfo};
 use bevy::render::render_asset::RenderAssets;
 use bevy::render::render_phase::{
-    AddRenderCommand, BinnedRenderPhaseType, DrawFunctions, PhaseItem, RenderCommand,
-    RenderCommandResult, SetItemPipeline, TrackedRenderPass, ViewBinnedRenderPhases,
+    AddRenderCommand, BinnedRenderPhase, BinnedRenderPhaseType, DrawFunctions, InputUniformIndex,
+    PhaseItem, RenderCommand, RenderCommandResult, SetItemPipeline, TrackedRenderPass,
+    ViewBinnedRenderPhases,
 };
 use bevy::render::render_resource::{
     AsBindGroup, BindGroup, BindGroupLayoutDescriptor, BufferUsages, Extent3d, PipelineCache,
@@ -993,9 +994,31 @@ pub struct DetailInstanceBuffer {
 #[derive(Resource, Default)]
 pub struct DetailBindGroups(HashMap<DetailKey, BindGroup>);
 
-/// The tiles each view has in its bin. A binned phase retains what it is given.
+/// The bin a tile was last placed in: its batch set key and its bin key.
+type DetailBin = (Opaque3dBatchSetKey, Opaque3dBinKey);
+
+/// The bin each view holds each tile in, a binned phase retaining what it is
+/// given across frames.
 #[derive(Resource, Default)]
-struct QueuedDetailTiles(HashMap<bevy::render::view::RetainedViewEntity, HashSet<MainEntity>>);
+struct QueuedDetailTiles(
+    HashMap<bevy::render::view::RetainedViewEntity, HashMap<MainEntity, DetailBin>>,
+);
+
+/// Place a tile in `bin`, taking it out of the bin it was last placed in when
+/// that differs.
+fn rebin_tile(
+    phase: &mut BinnedRenderPhase<Opaque3d>,
+    last: Option<&DetailBin>,
+    ids: (Entity, MainEntity),
+    bin: DetailBin,
+    uniform_index: InputUniformIndex,
+) {
+    if last.is_some_and(|last| *last != bin) {
+        phase.remove(ids.1);
+    }
+    let draws_its_own_instances = BinnedRenderPhaseType::NonMesh;
+    phase.add(bin.0, bin.1, ids, uniform_index, draws_its_own_instances);
+}
 
 /// The detail pipeline: the mesh pipeline with a per-instance vertex buffer, a
 /// bind group of its own, and both stages replaced.
@@ -1152,7 +1175,6 @@ fn queue_detail_tiles(
     tiles: Query<(Entity, &MainEntity), With<DetailTile>>,
 ) {
     let draw_function = draw_functions.read().id::<DrawDetail>();
-    let draws_its_own_instances = BinnedRenderPhaseType::NonMesh;
     let live: HashSet<_> = views.iter().map(|view| view.retained_view_entity).collect();
     queued.0.retain(|view, _| live.contains(view));
 
@@ -1165,7 +1187,7 @@ fn queue_detail_tiles(
         };
 
         let held = queued.0.entry(view.retained_view_entity).or_default();
-        let mut present = HashSet::new();
+        let mut present = HashMap::new();
 
         for (entity, main_entity) in &tiles {
             let Some(instance) = mesh_instances.render_mesh_queue_data(*main_entity) else {
@@ -1187,8 +1209,7 @@ fn queue_detail_tiles(
             else {
                 continue;
             };
-            present.insert(*main_entity);
-            phase.add(
+            let bin = (
                 Opaque3dBatchSetKey {
                     draw_function,
                     pipeline: pipeline_id,
@@ -1199,13 +1220,18 @@ fn queue_detail_tiles(
                 Opaque3dBinKey {
                     asset_id: instance.mesh_asset_id().into(),
                 },
-                (entity, *main_entity),
-                instance.current_uniform_index,
-                draws_its_own_instances,
             );
+            rebin_tile(
+                phase,
+                held.get(main_entity),
+                (entity, *main_entity),
+                bin.clone(),
+                instance.current_uniform_index,
+            );
+            present.insert(*main_entity, bin);
         }
 
-        for gone in held.difference(&present) {
+        for gone in held.keys().filter(|tile| !present.contains_key(*tile)) {
             phase.remove(*gone);
         }
         *held = present;
@@ -2123,6 +2149,57 @@ mod tests {
         for location in &locations {
             assert!(*location >= 4, "slot {location} is already the mesh's");
         }
+    }
+
+    #[test]
+    fn requeuing_a_tile_under_a_new_pipeline_leaves_one_bin_entry() {
+        use bevy::render::batching::gpu_preprocessing::GpuPreprocessingMode;
+        use bevy::render::mesh::allocator::MeshSlabs;
+        use bevy::render::render_phase::DrawFunctionId;
+        use bevy::render::render_resource::CachedRenderPipelineId;
+        use bevy::render::view::RetainedViewEntity;
+
+        let bin = |pipeline| {
+            (
+                Opaque3dBatchSetKey {
+                    draw_function: DrawFunctionId(0),
+                    pipeline: CachedRenderPipelineId::new(pipeline),
+                    material_bind_group_index: None,
+                    slabs: MeshSlabs::default(),
+                    lightmap_slab: None,
+                },
+                Opaque3dBinKey {
+                    asset_id: AssetId::<Mesh>::invalid().into(),
+                },
+            )
+        };
+        let view = RetainedViewEntity::new(Entity::PLACEHOLDER.into(), None, 0);
+        let tile = MainEntity::from(Entity::PLACEHOLDER);
+        let ids = (Entity::PLACEHOLDER, tile);
+
+        let mut phases = ViewBinnedRenderPhases::<Opaque3d>::default();
+        phases.prepare_for_new_frame(view, GpuPreprocessingMode::None);
+        let phase = phases.get_mut(&view).unwrap();
+        rebin_tile(phase, None, ids, bin(0), InputUniformIndex::default());
+
+        phases.prepare_for_new_frame(view, GpuPreprocessingMode::None);
+        let phase = phases.get_mut(&view).unwrap();
+        rebin_tile(
+            phase,
+            Some(&bin(0)),
+            ids,
+            bin(1),
+            InputUniformIndex::default(),
+        );
+
+        let placed: Vec<_> = phase
+            .non_mesh_items
+            .iter()
+            .filter(|(_, items)| items.entities.contains_key(&tile))
+            .map(|(key, _)| key.clone())
+            .collect();
+        assert_eq!(placed.len(), 1, "the tile is left in its old bin as well");
+        assert!(placed[0] == bin(1), "the tile is not in its new bin");
     }
 
     #[test]

--- a/src/model_thumbnail.rs
+++ b/src/model_thumbnail.rs
@@ -34,7 +34,6 @@ use bevy::{
     gltf::GltfAssetLabel,
     image::{CompressedImageFormats, ImageSampler, ImageType},
     prelude::*,
-    render::render_resource::TextureFormat,
     render::view::screenshot::{Screenshot, ScreenshotCaptured},
     ui::UiGlobalTransform,
     world_serialization::{WorldAsset, WorldAssetRoot},
@@ -340,6 +339,17 @@ struct ThumbnailSubject;
 #[derive(Resource)]
 struct ThumbnailTarget(Handle<Image>);
 
+/// The image the thumbnail stage renders into, in a format `write_png` reads
+/// back.
+pub(crate) fn thumbnail_target_image() -> Image {
+    Image::new_target_texture(
+        THUMBNAIL_SIZE,
+        THUMBNAIL_SIZE,
+        crate::viewport::EDITOR_VIEW_FORMAT,
+        None,
+    )
+}
+
 fn setup_thumbnail_stage(
     mut commands: Commands,
     mut images: ResMut<Assets<Image>>,
@@ -349,17 +359,7 @@ fn setup_thumbnail_stage(
 ) {
     let layer = RenderLayers::layer(THUMBNAIL_LAYER);
 
-    // `Bgra8UnormSrgb` rather than the material preview's `Rgba8Unorm`:
-    // these pixels come back through `ScreenshotCaptured`, and
-    // `Image::try_into_dynamic` (which `screenshot::write_png` calls)
-    // rejects a non-srgb `Rgba8Unorm`. This is the format the viewport's own
-    // capture path already proves out.
-    let target = images.add(Image::new_target_texture(
-        THUMBNAIL_SIZE,
-        THUMBNAIL_SIZE,
-        TextureFormat::Bgra8UnormSrgb,
-        None,
-    ));
+    let target = images.add(thumbnail_target_image());
     commands.insert_resource(ThumbnailTarget(target.clone()));
 
     thumbnails.cache_dir = project.map(|p| p.jackdaw_dir().join("thumbnails"));

--- a/src/viewport.rs
+++ b/src/viewport.rs
@@ -414,6 +414,30 @@ pub fn build_viewport_panel(world: &mut World, parent: Entity) {
     crate::viewport_host::build_viewport_panel_in(world, parent, intent);
 }
 
+/// The colour format every editor view renders in: the one bevy falls back to
+/// for a camera whose target image has no texture yet.
+pub(crate) const EDITOR_VIEW_FORMAT: TextureFormat = TextureFormat::Rgba8UnormSrgb;
+
+/// The image a 3D viewport panel renders into.
+fn viewport_target_image() -> Image {
+    let size = Extent3d {
+        width: DEFAULT_VIEWPORT_WIDTH,
+        height: DEFAULT_VIEWPORT_HEIGHT,
+        depth_or_array_layers: 1,
+    };
+    let mut image = Image::new_fill(
+        size,
+        TextureDimension::D2,
+        &[0, 0, 0, 255],
+        EDITOR_VIEW_FORMAT,
+        default(),
+    );
+    image.texture_descriptor.usage =
+        TextureUsages::TEXTURE_BINDING | TextureUsages::COPY_DST | TextureUsages::RENDER_ATTACHMENT;
+    image.sampler = ImageSampler::linear();
+    image
+}
+
 /// Build the panel's 3D presentation: a camera rendering into its own image,
 /// the toolbar/`SceneViewport` column that projects it, and the floating chrome
 /// that overlays it. Returns the column, which the mode switch shows and hides.
@@ -421,26 +445,8 @@ pub fn build_viewport_panel(world: &mut World, parent: Entity) {
 /// The despawn observer on `parent` (via [`ViewportPanelHost`]) cleans up the
 /// camera when the panel content is torn down.
 pub(crate) fn build_3d_presentation(world: &mut World, parent: Entity) -> Entity {
-    // Allocate a render-target image dedicated to this viewport. The
-    // size is a starting point; `ViewportNode` will resize the camera
-    // viewport to match the SceneViewport UI node automatically.
     let image_handle = {
-        let size = Extent3d {
-            width: DEFAULT_VIEWPORT_WIDTH,
-            height: DEFAULT_VIEWPORT_HEIGHT,
-            depth_or_array_layers: 1,
-        };
-        let mut image = Image::new_fill(
-            size,
-            TextureDimension::D2,
-            &[0, 0, 0, 255],
-            TextureFormat::Bgra8UnormSrgb,
-            default(),
-        );
-        image.texture_descriptor.usage = TextureUsages::TEXTURE_BINDING
-            | TextureUsages::COPY_DST
-            | TextureUsages::RENDER_ATTACHMENT;
-        image.sampler = ImageSampler::linear();
+        let image = viewport_target_image();
         world.resource_mut::<Assets<Image>>().add(image)
     };
 
@@ -1258,6 +1264,31 @@ mod tests {
         let mut map = HoverMap::default();
         map.insert(PointerId::Mouse, hits);
         map
+    }
+
+    #[test]
+    fn editor_views_render_into_the_same_format() {
+        assert_eq!(EDITOR_VIEW_FORMAT, TextureFormat::Rgba8UnormSrgb);
+        for (view, image) in [
+            ("3d viewport", viewport_target_image()),
+            (
+                "model thumbnail",
+                crate::model_thumbnail::thumbnail_target_image(),
+            ),
+            (
+                "2d viewport",
+                crate::viewport_2d::viewport_2d_target_image(),
+            ),
+            (
+                "parked ui scene",
+                crate::viewport_2d::parked_ui_target_image(),
+            ),
+        ] {
+            assert_eq!(
+                image.texture_descriptor.format, EDITOR_VIEW_FORMAT,
+                "{view} renders in a format of its own"
+            );
+        }
     }
 
     #[test]

--- a/src/viewport_2d.rs
+++ b/src/viewport_2d.rs
@@ -18,7 +18,7 @@ use bevy::{
         pointer::{Location, PointerId, PointerInput, PointerLocation, PointerPress},
     },
     prelude::*,
-    render::render_resource::{Extent3d, TextureDimension, TextureFormat, TextureUsages},
+    render::render_resource::{Extent3d, TextureDimension, TextureUsages},
     ui::{Checked, UiGlobalTransform, UiSystems, UiTargetCamera},
     ui_widgets::{ValueChange, observe},
 };
@@ -728,10 +728,8 @@ fn aim_ui_roots<'a>(
     }
 }
 
-/// Spawn the parking camera: where an authored UI scene root points while no 2D
-/// viewport panel is open. Inactive and targeting a 1x1 image, so a parked root
-/// resolves against a single pixel and `DefaultUiCamera` never picks it up.
-fn park_ui_scene_roots(commands: &mut Commands, images: &mut Assets<Image>) -> Entity {
+/// The single pixel a parked UI scene root resolves against.
+pub(crate) fn parked_ui_target_image() -> Image {
     let mut image = Image::new_fill(
         Extent3d {
             width: 1,
@@ -740,12 +738,19 @@ fn park_ui_scene_roots(commands: &mut Commands, images: &mut Assets<Image>) -> E
         },
         TextureDimension::D2,
         &[0, 0, 0, 255],
-        TextureFormat::Bgra8UnormSrgb,
+        crate::viewport::EDITOR_VIEW_FORMAT,
         default(),
     );
     image.texture_descriptor.usage =
         TextureUsages::TEXTURE_BINDING | TextureUsages::COPY_DST | TextureUsages::RENDER_ATTACHMENT;
-    let handle = images.add(image);
+    image
+}
+
+/// Spawn the parking camera: where an authored UI scene root points while no 2D
+/// viewport panel is open. Inactive and targeting a 1x1 image, so a parked root
+/// resolves against a single pixel and `DefaultUiCamera` never picks it up.
+fn park_ui_scene_roots(commands: &mut Commands, images: &mut Assets<Image>) -> Entity {
+    let handle = images.add(parked_ui_target_image());
 
     commands
         .spawn((
@@ -1525,6 +1530,26 @@ pub fn build_viewport_2d_panel(world: &mut World, parent: Entity) {
     );
 }
 
+/// The image a 2D viewport panel renders into, at the size
+/// `size_targets_to_reference` starts from.
+pub(crate) fn viewport_2d_target_image() -> Image {
+    let mut image = Image::new_fill(
+        Extent3d {
+            width: DEFAULT_VIEWPORT_WIDTH,
+            height: DEFAULT_VIEWPORT_HEIGHT,
+            depth_or_array_layers: 1,
+        },
+        TextureDimension::D2,
+        &[0, 0, 0, 255],
+        crate::viewport::EDITOR_VIEW_FORMAT,
+        default(),
+    );
+    image.texture_descriptor.usage =
+        TextureUsages::TEXTURE_BINDING | TextureUsages::COPY_DST | TextureUsages::RENDER_ATTACHMENT;
+    image.sampler = ImageSampler::linear();
+    image
+}
+
 /// Build the panel's 2D presentation: a camera plus a render-target image
 /// dedicated to this panel, then a column holding a header row above a
 /// [`Scene2dStageArea`], with the [`Scene2dViewport`] stage placed inside it
@@ -1534,28 +1559,9 @@ pub fn build_viewport_2d_panel(world: &mut World, parent: Entity) {
 /// The despawn observer on `parent` (via [`Viewport2dPanelHost`]) cleans
 /// the camera up when the reconciler tears the panel down.
 pub(crate) fn build_2d_presentation(world: &mut World, parent: Entity) -> Entity {
-    // A render-target image dedicated to this panel. The size is only a starting
-    // point: `size_targets_to_reference` holds it at the authored reference size
-    // while a UI scene is open.
-    let image_handle = {
-        let size = Extent3d {
-            width: DEFAULT_VIEWPORT_WIDTH,
-            height: DEFAULT_VIEWPORT_HEIGHT,
-            depth_or_array_layers: 1,
-        };
-        let mut image = Image::new_fill(
-            size,
-            TextureDimension::D2,
-            &[0, 0, 0, 255],
-            TextureFormat::Bgra8UnormSrgb,
-            default(),
-        );
-        image.texture_descriptor.usage = TextureUsages::TEXTURE_BINDING
-            | TextureUsages::COPY_DST
-            | TextureUsages::RENDER_ATTACHMENT;
-        image.sampler = ImageSampler::linear();
-        world.resource_mut::<Assets<Image>>().add(image)
-    };
+    let image_handle = world
+        .resource_mut::<Assets<Image>>()
+        .add(viewport_2d_target_image());
 
     // A private render layer per panel, so per-viewport overlays can be drawn to
     // this camera alone. Layer 0 stays in the mask so default-layer scene


### PR DESCRIPTION
The editor quit with a wgpu validation error about a minute into a project with a terrain detail layer. A rebuilt viewport's target image has no GPU copy for one frame, so its view key fell back to Rgba8 while the viewport asked for Bgra8, and detail tiles specialised in that frame stayed in a retained bin and were replayed into the later pass.

Every editor view now renders in Rgba8UnormSrgb, the format Bevy uses for windows and for that fallback. The detail queue remembers which bin each tile was placed in and removes it from that bin before re-adding it whenever its key changes.

LLM disclaimer: Claude Code was used to help plan and implement this change, but all code was human reviewed by myself!
