### PR TITLE
Reference assets by path

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -5391,6 +5391,7 @@ dependencies = [
  "noise",
  "path-slash",
  "rand 0.10.2",
+ "tempfile",
 ]
 
 [[package]]

--- a/book/src/developer-guide/bsn-format.md
+++ b/book/src/developer-guide/bsn-format.md
@@ -62,21 +62,30 @@ nesting, not of a flat entity list.
 
 ## Asset references
 
-Materials and other shared assets are referenced by name:
+A material or any other asset file is referenced by its path
+under `assets/`:
 
-- `#Name` for a scene-local asset, defined inline in the same
-  `.bsn` file.
-- `@Name` for a project-wide asset, resolved from the project
-  catalog.
+```
+my_game::Signpost { board: "materials/slate.material.bsn" }
+```
 
-Both prefixes resolve against the same name-to-handle table at
-load time, populated from the scene's own inline definitions and
-the project catalog. A name that resolves to nothing falls back
-to a default handle rather than failing the load, so a missing
-material shows up as untextured geometry, not an error.
+A scene-local asset, defined inline in the same `.bsn` file, is
+referenced as `#Name`. The `@Name` spelling of a project-wide
+asset is what files written before paths use; it still resolves
+while a project catches up, as long as one file answers to that
+name, and the next save writes the path.
 
-A component value that is a plain path string (no prefix) is
-loaded through the asset server as a file path instead.
+Every reference resolves against the same table at load time:
+the project's asset files under their paths, plus the scene's
+own inline definitions. A reference that resolves to nothing is
+left as the file spelled it and falls back to a default handle
+rather than failing the load, so a missing material shows up as
+untextured geometry, not an error, and a save does not quietly
+drop what could not be found.
+
+A reference no asset file answers to is loaded through the asset
+server as a file path, which is how an image, a mesh or any other
+file the engine loads for itself is named.
 
 ## Project file
 

--- a/book/src/user-guide/materials-textures.md
+++ b/book/src/user-guide/materials-textures.md
@@ -51,9 +51,9 @@ recognises common suffixes (`_albedo`, `_diffuse`, `_normal`,
 `_height`, `_displacement`).
 
 You can edit the resulting material in the inspector.
-Material values serialize into the scene's asset table
-(or the project-wide catalog) keyed by
-`bevy_pbr::StandardMaterial` and ride along with save.
+A material saved to a file of its own is referenced by that
+file's path; a material that belongs to one scene serializes
+into that scene's asset table and rides along with save.
 
 ### Applying
 
@@ -79,7 +79,10 @@ Two storage tiers:
   whatever folder you keep it in; the editor finds it by
   reading what the file holds. A save with no folder in mind
   puts it under `assets/materials/`. Any scene in the project
-  can reference it, and references use `@Name`.
+  can reference it, and references spell its path, such as
+  `materials/slate.material.bsn`. Scenes written before paths
+  spell `@Name` instead; they still load, and the next save
+  writes the path.
 
 The browser shows both, with the source labelled.
 
@@ -92,7 +95,8 @@ The browser shows both, with the source labelled.
   Filename heuristics are coarse. Rename the files or open
   the affected definition and split it manually.
 - **Material disappears in the standalone build.** Standalone
-  loads the scene file plus `assets/catalog.bsn`. Scene-local
-  materials still ship inline; project references resolve
-  from the catalog at load time, so a missing catalog file
-  causes `@Name` references to fall back to defaults.
+  loads the scene file plus every material file under
+  `assets/materials/`. Scene-local materials still ship inline;
+  a reference resolves to the file at that path, so a material
+  file left out of the build, or kept in another folder, falls
+  back to a default.

--- a/book/src/user-guide/terrain.md
+++ b/book/src/user-guide/terrain.md
@@ -109,6 +109,12 @@ the scene in versioned `.jdterrain` files, along with the terrain's
 texture-set reference. Save and move those sidecars with the `.bsn`
 scene that references them.
 
+Each material slot holds the path of the material file it draws,
+such as `materials/slate.material.bsn`. A sidecar written before
+slots held paths spells a bare name; opening the scene points each
+name at `materials/<name>.material.bsn` where that file is there,
+and leaves it a name where it is not, saying which slot it left.
+
 A sidecar in an older format migrates when the scene opens and is
 rewritten in the current format on the next save. A sidecar this
 build cannot read, such as one written by a newer jackdaw or one

--- a/crates/jackdaw_bsn/src/apply.rs
+++ b/crates/jackdaw_bsn/src/apply.rs
@@ -28,21 +28,60 @@ use crate::{
 #[derive(Component)]
 pub struct AstDirty;
 
-/// Assets available while applying document values: the asset server for
-/// path-string handles, plus the scene's local named assets so `#Name` and
-/// `@Name` reference strings resolve to their loaded handles.
+/// Assets available while applying document values: a map of the references
+/// already loaded, consulted first for any string a handle field spells, and
+/// the asset server for everything else.
 pub struct BsnApplyAssets<'a> {
     pub server: &'a AssetServer,
     pub local: Option<&'a bevy::platform::collections::HashMap<String, bevy::asset::UntypedHandle>>,
 }
 
-/// The scene's named local assets (`#Name` inline entries and `@Name`
-/// catalog entries), kept as a resource so document applies after load can
-/// resolve reference strings.
+/// The references the open scene resolves: the paths of the project's asset
+/// files, the `#Name` entries the document embeds, and the `@Name` spelling
+/// older files use. Kept as a resource so document applies after load resolve
+/// what a handle field names.
 #[derive(Resource, Default)]
 pub struct BsnSceneAssets(
     pub bevy::platform::collections::HashMap<String, bevy::asset::UntypedHandle>,
 );
+
+/// The references the project holds outside any one scene: an asset file under
+/// the path that names it, and the bare name older files spell it by.
+///
+/// A scene load folds this into [`BsnSceneAssets`], so a scene resolves the
+/// project's asset files as well as the ones it embeds.
+#[derive(Resource, Default)]
+pub struct BsnProjectAssets(
+    pub bevy::platform::collections::HashMap<String, bevy::asset::UntypedHandle>,
+);
+
+/// The reference each loaded asset is emitted under: the path of the file it
+/// came from, for the handles the asset server cannot name.
+#[derive(Resource, Default)]
+pub struct BsnAssetPaths(
+    pub bevy::platform::collections::HashMap<bevy::asset::UntypedAssetId, String>,
+);
+
+/// Every reference a value can be resolved against: the project's asset files,
+/// with the open scene's own entries over them.
+///
+/// A scene load folds the project's references into [`BsnSceneAssets`], so an
+/// apply reads that one map; this is for the callers that resolve a reference
+/// outside a scene, such as an operator setting a field by path.
+pub fn apply_reference_map(
+    world: &World,
+) -> bevy::platform::collections::HashMap<String, bevy::asset::UntypedHandle> {
+    let mut map = world
+        .get_resource::<BsnProjectAssets>()
+        .map(|assets| assets.0.clone())
+        .unwrap_or_default();
+    if let Some(scene) = world.get_resource::<BsnSceneAssets>() {
+        for (reference, handle) in &scene.0 {
+            map.insert(reference.clone(), handle.clone());
+        }
+    }
+    map
+}
 
 /// Type paths the open project's schema reports and the editor has no ECS
 /// registration for, so apply skips a patch naming one without the "not in the
@@ -450,7 +489,9 @@ fn dynamic_struct_from_patch(
 
 fn apply_struct_patch(world: &mut World, entity: Entity, data: &BsnStructData) {
     let server = world.get_resource::<AssetServer>().cloned();
-    let local = world.get_resource::<BsnSceneAssets>().map(|r| r.0.clone());
+    let local = world
+        .get_resource::<BsnSceneAssets>()
+        .map(|assets| assets.0.clone());
     let assets_ctx = server.as_ref().map(|s| BsnApplyAssets {
         server: s,
         local: local.as_ref(),
@@ -713,7 +754,9 @@ fn apply_tuple_variant_patch(
 
 fn apply_tuple_struct_patch(world: &mut World, entity: Entity, data: &BsnTupleStructData) {
     let server = world.get_resource::<AssetServer>().cloned();
-    let local = world.get_resource::<BsnSceneAssets>().map(|r| r.0.clone());
+    let local = world
+        .get_resource::<BsnSceneAssets>()
+        .map(|assets| assets.0.clone());
     let assets_ctx = server.as_ref().map(|s| BsnApplyAssets {
         server: s,
         local: local.as_ref(),
@@ -915,13 +958,14 @@ pub fn bsn_value_to_reflect(
             && !path.is_empty()
             && let Some(assets) = assets
         {
+            if let Some(local) = assets.local
+                && let Some(handle) = local.get(path)
+                && handle.type_id() == reflect_handle.asset_type_id()
+            {
+                let typed = reflect_handle.typed(handle.clone());
+                return Some(typed.into_partial_reflect());
+            }
             if path.starts_with('#') || path.starts_with('@') {
-                if let Some(local) = assets.local
-                    && let Some(handle) = local.get(path)
-                {
-                    let typed = reflect_handle.typed(handle.clone());
-                    return Some(typed.into_partial_reflect());
-                }
                 log::warn!(
                     "asset reference '{path}' did not resolve in the project catalog or \
                      embedded assets; using the default handle"

--- a/crates/jackdaw_bsn/src/catalog.rs
+++ b/crates/jackdaw_bsn/src/catalog.rs
@@ -160,8 +160,12 @@ pub fn load_bsn_scene(world: &mut World, text: &str) -> Result<LoadedBsnScene, B
         }
     }
 
-    // Record both reference spellings: scene-inline (`#`) and catalog (`@`).
-    let mut names = bevy::platform::collections::HashMap::default();
+    // The project's asset files by path, then the document's own entries in
+    // both spellings: scene-inline (`#`) and catalog (`@`).
+    let mut names = world
+        .get_resource::<crate::BsnProjectAssets>()
+        .map(|project| project.0.clone())
+        .unwrap_or_default();
     for entry in &assets {
         names.insert(format!("#{}", entry.name), entry.handle.clone());
         names.insert(format!("@{}", entry.name), entry.handle.clone());
@@ -356,6 +360,7 @@ pub fn append_assets_to_ast(
     let registry = world.resource::<AppTypeRegistry>().clone();
     let reg = registry.read();
     let asset_server = world.get_resource::<AssetServer>();
+    let paths = world.get_resource::<crate::BsnAssetPaths>();
 
     let mut sorted: Vec<&CatalogAssetRef> = assets.iter().collect();
     sorted.sort_by(|a, b| a.name.cmp(&b.name));
@@ -387,7 +392,7 @@ pub fn append_assets_to_ast(
             let ctx = BsnAssetContext {
                 asset_server: server,
                 parent_path: Path::new(""),
-                asset_names: None,
+                asset_names: paths.as_ref().map(|paths| &paths.0),
             };
             component_to_bsn_patch_with_assets(asset_value.as_partial_reflect(), &reg, &ctx)
         } else {

--- a/crates/jackdaw_bsn/src/lib.rs
+++ b/crates/jackdaw_bsn/src/lib.rs
@@ -41,9 +41,10 @@ pub use loader::{BsnLoadError, parse_bsn_text};
 pub use retired::{RETIRED_UI_PREFIX, RetiredUiComponents, reject_retired_ui_components};
 
 pub use apply::{
-    AstDirty, BsnApplyAssets, BsnSceneAssets, DocumentOnlyTypes, UnresolvedTypes, apply_ast_to_ecs,
-    apply_component_patch, apply_dirty_ast_patches, bsn_value_to_reflect, get_bsn_field,
-    remove_bsn_field, set_bsn_field, spawn_ast_node, spawn_from_ast,
+    AstDirty, BsnApplyAssets, BsnAssetPaths, BsnProjectAssets, BsnSceneAssets, DocumentOnlyTypes,
+    UnresolvedTypes, apply_ast_to_ecs, apply_component_patch, apply_dirty_ast_patches,
+    apply_reference_map, bsn_value_to_reflect, get_bsn_field, remove_bsn_field, set_bsn_field,
+    spawn_ast_node, spawn_from_ast,
 };
 
 pub use sync::{

--- a/crates/jackdaw_runtime/src/lib.rs
+++ b/crates/jackdaw_runtime/src/lib.rs
@@ -236,8 +236,9 @@ impl Plugin for JackdawPlugin {
     }
 }
 
-/// Project-wide asset catalog. Maps `@Name` references found in
-/// scene files to loaded `UntypedHandle`s.
+/// Project-wide asset catalog. Maps the references found in scene files to
+/// loaded `UntypedHandle`s: the assets-relative path of a material file, and
+/// the `@Name` the same material was spelled by before references were paths.
 ///
 /// Populated at startup from `assets/catalog.bsn` under the Bevy
 /// asset root (mirrors `FileAssetReader::get_base_path()`). To
@@ -246,12 +247,14 @@ impl Plugin for JackdawPlugin {
 #[derive(Resource, Default)]
 pub struct JackdawCatalog {
     handles: HashMap<String, UntypedHandle>,
+    files: HashMap<String, UntypedHandle>,
 }
 
 impl JackdawCatalog {
-    /// Look up a catalog handle by its `@Name` reference.
+    /// Look up a catalog handle by the reference a document spells it as: the
+    /// path of the file holding it, or its `@Name`.
     pub fn get(&self, name: &str) -> Option<&UntypedHandle> {
-        self.handles.get(name)
+        self.handles.get(name).or_else(|| self.files.get(name))
     }
 
     /// Number of catalog entries (each `@Name`).
@@ -261,7 +264,7 @@ impl JackdawCatalog {
 
     /// True when no catalog has been loaded.
     pub fn is_empty(&self) -> bool {
-        self.handles.is_empty()
+        self.handles.is_empty() && self.files.is_empty()
     }
 }
 
@@ -703,11 +706,21 @@ fn spawn_scene_entities(
     let _preloaded_textures = preload_linear_textures(world, ast);
 
     // Embedded assets keyed as both `#Name` (scene-inline) and `@Name`
-    // (catalog spelling), merged with the project catalog. Kept in
-    // `BsnSceneAssets` so `apply_component_patch` resolves reference strings.
+    // (catalog spelling), merged with the project catalog under every
+    // reference it answers to. Kept in `BsnSceneAssets` so
+    // `apply_component_patch` resolves reference strings.
     let mut local_assets = load_embedded_assets(world, ast, &registry);
-    for (name, handle) in world.resource::<JackdawCatalog>().handles.clone() {
-        local_assets.entry(name).or_insert(handle);
+    {
+        let catalog = world.resource::<JackdawCatalog>();
+        let entries: Vec<(String, UntypedHandle)> = catalog
+            .handles
+            .iter()
+            .chain(catalog.files.iter())
+            .map(|(name, handle)| (name.clone(), handle.clone()))
+            .collect();
+        for (name, handle) in entries {
+            local_assets.entry(name).or_insert(handle);
+        }
     }
     let mut scene_assets = bevy::platform::collections::HashMap::default();
     for (name, handle) in &local_assets {
@@ -1276,6 +1289,9 @@ fn promote_material_texture_formats(
 /// it is the material's `@Name`.
 const MATERIAL_FILE_SUFFIX: &str = ".material.bsn";
 
+/// Where a saved material file sits, relative to the project's assets.
+const MATERIALS_DIR: &str = "materials";
+
 /// Startup system: discover the project catalog and populate
 /// [`JackdawCatalog`]. Honours [`JackdawCatalogPath`] if present;
 /// otherwise mirrors Bevy's `FileAssetReader::get_base_path()` to
@@ -1297,7 +1313,7 @@ fn load_project_catalog(world: &mut World) {
     // right color space and a saved material wins its name over any inline
     // entry in the catalog file.
     if let Some(root) = &root {
-        load_material_files(world, &root.join("materials"));
+        load_material_files(world, root);
     }
 
     if !catalog_path.is_file() {
@@ -1347,10 +1363,11 @@ fn load_project_catalog(world: &mut World) {
 }
 
 /// Load every `assets/materials/*.material.bsn` into [`JackdawCatalog`] under
-/// its file stem. A file that fails to read or parse is reported and skipped
-/// so one bad material never costs the rest.
-fn load_material_files(world: &mut World, dir: &Path) {
-    let Ok(read_dir) = std::fs::read_dir(dir) else {
+/// the path that names it and under its file stem. A file that fails to read
+/// or parse is reported and skipped so one bad material never costs the rest.
+fn load_material_files(world: &mut World, root: &Path) {
+    let dir = root.join(MATERIALS_DIR);
+    let Ok(read_dir) = std::fs::read_dir(&dir) else {
         return;
     };
     let mut files: Vec<PathBuf> = read_dir
@@ -1408,10 +1425,12 @@ fn load_material_files(world: &mut World, dir: &Path) {
                     warn!("{} is not a StandardMaterial", path.display());
                     continue;
                 }
-                world
-                    .resource_mut::<JackdawCatalog>()
-                    .handles
-                    .insert(format!("@{name}"), entry.handle);
+                let mut catalog = world.resource_mut::<JackdawCatalog>();
+                catalog.files.insert(
+                    format!("{MATERIALS_DIR}/{name}{MATERIAL_FILE_SUFFIX}"),
+                    entry.handle.clone(),
+                );
+                catalog.handles.insert(format!("@{name}"), entry.handle);
                 count += 1;
             }
             Err(err) => warn!("Failed to parse material {}: {err}", path.display()),
@@ -1495,7 +1514,7 @@ mod material_file_tests {
     fn a_missing_materials_directory_is_not_an_error() {
         let mut app = runtime_app();
         let tmp = tempfile::tempdir().expect("tempdir");
-        load_material_files(app.world_mut(), &tmp.path().join("materials"));
+        load_material_files(app.world_mut(), tmp.path());
         assert!(app.world().resource::<JackdawCatalog>().is_empty());
     }
 
@@ -1513,7 +1532,7 @@ mod material_file_tests {
         )
         .expect("write");
 
-        load_material_files(app.world_mut(), &dir);
+        load_material_files(app.world_mut(), tmp.path());
 
         assert_eq!(
             app.world().resource::<Assets<Image>>().len(),
@@ -1527,6 +1546,26 @@ mod material_file_tests {
     }
 
     #[test]
+    fn a_material_file_answers_to_the_path_that_names_it() {
+        let mut app = runtime_app();
+        let tmp = tempfile::tempdir().expect("tempdir");
+        let dir = tmp.path().join("materials");
+        std::fs::create_dir_all(&dir).expect("dir");
+        std::fs::write(dir.join("grass.material.bsn"), GRASS).expect("write");
+
+        load_material_files(app.world_mut(), tmp.path());
+
+        let catalog = app.world().resource::<JackdawCatalog>();
+        assert_eq!(
+            catalog
+                .get("materials/grass.material.bsn")
+                .map(UntypedHandle::id),
+            catalog.get("@grass").map(UntypedHandle::id),
+            "a scene saved with the path reaches the same material the name did"
+        );
+    }
+
+    #[test]
     fn a_material_file_outranks_an_inline_catalog_entry_of_the_same_name() {
         let mut app = runtime_app();
         let tmp = tempfile::tempdir().expect("tempdir");
@@ -1534,7 +1573,7 @@ mod material_file_tests {
         std::fs::create_dir_all(&dir).expect("dir");
         std::fs::write(dir.join("grass.material.bsn"), GRASS).expect("write");
 
-        load_material_files(app.world_mut(), &dir);
+        load_material_files(app.world_mut(), tmp.path());
         let from_file = app
             .world()
             .resource::<JackdawCatalog>()

--- a/crates/jackdaw_runtime/src/terrain.rs
+++ b/crates/jackdaw_runtime/src/terrain.rs
@@ -187,12 +187,20 @@ fn load_sidecars(
         (Entity, &Terrain, Option<&TerrainSidecar>),
         (Without<TerrainDocument>, Without<TerrainUnreadable>),
     >,
+    catalog_path: Option<Res<crate::JackdawCatalogPath>>,
+    asset_folder: Option<Res<crate::AssetFolder>>,
 ) {
+    let assets = crate::resolve_assets_root(catalog_path.as_deref(), asset_folder.as_deref());
     for (entity, terrain, sidecar_path) in &terrains {
         let data = match sidecar_path {
             Some(TerrainSidecar(path)) => match std::fs::read(path) {
-                Ok(bytes) => match sidecar::load(&bytes) {
-                    Ok(data) => data,
+                Ok(bytes) => match sidecar::load_from(&bytes, assets.as_deref()) {
+                    Ok(loaded) => {
+                        for message in loaded.warnings() {
+                            warn!("{message}");
+                        }
+                        loaded.data
+                    }
                     Err(err) => {
                         error!(
                             "terrain data {} is unreadable ({err}); this terrain draws nothing \
@@ -243,16 +251,29 @@ fn document_of(data: RegionTerrainData, terrain: &Terrain) -> TerrainDocument {
     }
 }
 
-/// The `StandardMaterial` a slot's name addresses, through the project catalog
-/// that `materials/<name>.material.bsn` and `catalog.bsn` both feed.
+/// The `StandardMaterial` a slot's reference addresses, through the project
+/// catalog that `materials/<name>.material.bsn` and `catalog.bsn` both feed.
+///
+/// A slot spells the path of its material file; the catalog is keyed by the
+/// name that path's file carries, so a path is looked up by its own last
+/// segment when nothing answers to the path itself.
 ///
 /// [`resolve_with`] decides what a resolved material means: which of its slots
-/// is albedo, and that a vacated or unfound name keeps its texture id.
-fn catalog_material(catalog: &JackdawCatalog, name: &str) -> Option<Handle<StandardMaterial>> {
+/// is albedo, and that a vacated or unfound reference keeps its texture id.
+fn catalog_material(catalog: &JackdawCatalog, reference: &str) -> Option<Handle<StandardMaterial>> {
+    let name = material_name_of(reference);
     catalog
-        .get(&format!("@{name}"))
+        .get(reference)
+        .or_else(|| catalog.get(&format!("@{name}")))
         .cloned()
         .and_then(|handle| handle.try_typed::<StandardMaterial>().ok())
+}
+
+/// The name a material reference carries: the part of its last path segment
+/// before the first dot, which is what a bare name already is.
+fn material_name_of(reference: &str) -> &str {
+    let file = reference.rsplit('/').next().unwrap_or(reference);
+    file.split_once('.').map_or(file, |(stem, _)| stem)
 }
 
 /// Keep every terrain's resolved set following its material list.
@@ -778,7 +799,7 @@ mod tests {
         app.register_asset_reflect::<Image>();
         app.register_asset_reflect::<StandardMaterial>();
         app.init_resource::<JackdawCatalog>();
-        crate::load_material_files(app.world_mut(), &assets_root.join("materials"));
+        crate::load_material_files(app.world_mut(), assets_root);
         app
     }
 

--- a/crates/jackdaw_runtime/tests/catalog_loading.rs
+++ b/crates/jackdaw_runtime/tests/catalog_loading.rs
@@ -86,3 +86,70 @@ fn unique_temp_dir(label: &str) -> PathBuf {
         std::process::id()
     ))
 }
+
+/// A component holding one material, so a scene can spell a reference without
+/// a mesh in the way.
+#[derive(Component, Reflect, Clone, Default)]
+#[reflect(Component, Default)]
+struct Painted {
+    material: Handle<StandardMaterial>,
+}
+
+#[test]
+fn a_scene_reaches_a_material_by_the_path_of_its_file() {
+    let dir = unique_temp_dir("catalog-loading-path");
+    std::fs::create_dir_all(dir.join("materials")).unwrap();
+    std::fs::write(
+        dir.join("materials/grass.material.bsn"),
+        "#grass\nbevy_pbr::pbr_material::StandardMaterial {\n    perceptual_roughness: 0.25,\n}\n",
+    )
+    .unwrap();
+    std::fs::write(
+        dir.join("scene.bsn"),
+        format!(
+            "{} {{ material: \"materials/grass.material.bsn\" }}\n",
+            <Painted as TypePath>::type_path()
+        ),
+    )
+    .unwrap();
+
+    let mut app = App::new();
+    app.add_plugins(MinimalPlugins);
+    app.add_plugins(bevy::transform::TransformPlugin);
+    app.add_plugins(bevy::asset::AssetPlugin {
+        file_path: dir.to_string_lossy().into_owned(),
+        ..Default::default()
+    });
+    app.add_plugins(bevy::world_serialization::WorldSerializationPlugin);
+    app.add_plugins(bevy::image::ImagePlugin::default());
+    app.init_asset::<StandardMaterial>();
+    app.register_asset_reflect::<StandardMaterial>();
+    app.register_type::<Painted>();
+    app.add_plugins(JackdawPlugin);
+
+    let handle: Handle<jackdaw_runtime::JackdawScene> =
+        app.world().resource::<AssetServer>().load("scene.bsn");
+    app.world_mut()
+        .spawn(jackdaw_runtime::JackdawSceneRoot(handle));
+
+    let mut painted = None;
+    for _ in 0..200 {
+        app.update();
+        let mut query = app.world_mut().query::<&Painted>();
+        if let Some(found) = query.iter(app.world()).next() {
+            painted = Some(found.material.clone());
+            break;
+        }
+        std::thread::sleep(std::time::Duration::from_millis(5));
+    }
+    let painted = painted.expect("the scene spawned its painted entity");
+
+    let catalog = app.world().resource::<JackdawCatalog>();
+    assert_eq!(
+        Some(painted.id().untyped()),
+        catalog
+            .get("materials/grass.material.bsn")
+            .map(bevy::asset::UntypedHandle::id),
+        "the path names the material the catalog loaded, not a fresh load of the document"
+    );
+}

--- a/crates/jackdaw_terrain/Cargo.toml
+++ b/crates/jackdaw_terrain/Cargo.toml
@@ -44,5 +44,8 @@ render = [
     "bevy/bevy_log",
 ]
 
+[dev-dependencies]
+tempfile = "3"
+
 [lints]
 workspace = true

--- a/crates/jackdaw_terrain/src/sidecar.rs
+++ b/crates/jackdaw_terrain/src/sidecar.rs
@@ -219,8 +219,22 @@ pub const VERSION_6: u16 = 6;
 /// What [`save`] writes.
 pub const VERSION_7: u16 = 7;
 
+/// Region documents whose material slots hold the path of a material file
+/// under the project's assets rather than a bare name. A version-7 or older
+/// file's name becomes `materials/<name>.material.bsn` where that file is
+/// there, and stays a name where it is not. What [`save`] writes.
+pub const VERSION_8: u16 = 8;
+
 /// Conventional file extension for a terrain sidecar.
 pub const EXTENSION: &str = "jdterrain";
+
+/// Where a material file written before references were paths sits, relative
+/// to the project's assets.
+pub const MATERIALS_DIR: &str = "materials";
+
+/// What a material file written before references were paths is called after
+/// its stem.
+pub const MATERIAL_FILE_SUFFIX: &str = ".material.bsn";
 
 /// Region flags bit: this region has a color layer, written right after
 /// its control words.
@@ -322,8 +336,8 @@ pub fn validate_asset_ref(path: &str) -> Result<(), SidecarPathError> {
 /// Why a material name could not be stored on a terrain slot.
 #[derive(Clone, Copy, Debug, PartialEq, Eq)]
 pub enum MaterialNameError {
-    /// A character that cannot appear in a file stem, so the name could
-    /// never address one material file.
+    /// A character that cannot appear in a path under the project's assets,
+    /// so the reference could never address one material file.
     InvalidCharacter,
     /// `.` or `..`, which name a directory rather than a material.
     Reserved,
@@ -334,9 +348,10 @@ impl core::fmt::Display for MaterialNameError {
         match self {
             Self::InvalidCharacter => write!(
                 f,
-                "material name may hold only letters, digits, '.', '_' and '-'"
+                "a material reference may hold only letters, digits, '.', '_', '-' \
+                 and the '/' between path segments"
             ),
-            Self::Reserved => write!(f, "'.' and '..' are not material names"),
+            Self::Reserved => write!(f, "'.' and '..' are not material references"),
         }
     }
 }
@@ -345,24 +360,35 @@ impl core::error::Error for MaterialNameError {}
 
 /// Validate a terrain slot's material reference.
 ///
-/// A material's name, its `@Name` identity and its file stem are one string, so
-/// a name that could not be a file stem could never resolve. Checked at the
-/// format boundary, because an unchecked name fails every subsequent save.
+/// A reference is the path of a material file under the project's assets, and
+/// the files written before version 8 spell a bare name, which is that path's
+/// last segment without its extensions. Either way every segment must be able
+/// to name a directory or a file, so a reference that could not address one is
+/// refused at the format boundary, where an unchecked one would fail every
+/// subsequent save.
 ///
-/// The empty name is valid and means a tombstone; see
+/// The empty reference is valid and means a tombstone; see
 /// [`TerrainMaterialSlot::tombstone`].
 pub fn validate_material_name(name: &str) -> Result<(), MaterialNameError> {
     if name.is_empty() {
         return Ok(());
     }
-    if name == "." || name == ".." {
-        return Err(MaterialNameError::Reserved);
-    }
-    if !name
-        .chars()
-        .all(|c| c.is_ascii_alphanumeric() || matches!(c, '_' | '-' | '.'))
-    {
+    if name.starts_with('/') || name.ends_with('/') {
         return Err(MaterialNameError::InvalidCharacter);
+    }
+    for segment in name.split('/') {
+        if segment.is_empty() {
+            return Err(MaterialNameError::InvalidCharacter);
+        }
+        if segment == "." || segment == ".." {
+            return Err(MaterialNameError::Reserved);
+        }
+        if !segment
+            .chars()
+            .all(|c| c.is_ascii_alphanumeric() || matches!(c, '_' | '-' | '.'))
+        {
+            return Err(MaterialNameError::InvalidCharacter);
+        }
     }
     Ok(())
 }
@@ -379,8 +405,9 @@ pub fn validate_material_name(name: &str) -> Result<(), MaterialNameError> {
 /// painted with them.
 #[derive(Clone, Debug, PartialEq)]
 pub struct TerrainMaterialSlot {
-    /// Name of a saved material: the `@Name` identity, which is also the
-    /// `.material.bsn` file stem. Empty for a tombstone.
+    /// The material this id draws: the path of its file under the project's
+    /// assets, or the bare name a file written before version 8 spells. Empty
+    /// for a tombstone.
     pub material: String,
     /// Texture repeats per world unit. Unused by a tombstone, which draws
     /// nothing.
@@ -1544,7 +1571,7 @@ pub fn encode_regions(data: &RegionTerrainData) -> Result<Vec<u8>, SidecarError>
     let mut out = Vec::with_capacity(data.encoded_len().ok_or(SidecarError::TooLarge)?);
 
     out.extend_from_slice(&MAGIC);
-    out.extend_from_slice(&VERSION_7.to_le_bytes());
+    out.extend_from_slice(&VERSION_8.to_le_bytes());
     out.extend_from_slice(&0u16.to_le_bytes());
     out.extend_from_slice(&(data.channels.len() as u32).to_le_bytes());
     encode_channel_directory(&mut out, &data.channels);
@@ -1668,7 +1695,7 @@ pub fn decode_regions(bytes: &[u8]) -> Result<RegionTerrainData, SidecarError> {
         return Err(SidecarError::BadMagic);
     }
     let version = r.u16()?;
-    if !(VERSION_2..=VERSION_7).contains(&version) {
+    if !(VERSION_2..=VERSION_8).contains(&version) {
         return Err(SidecarError::UnsupportedVersion(version));
     }
     if r.u16()? != 0 {
@@ -1955,11 +1982,40 @@ pub fn decode_regions(bytes: &[u8]) -> Result<RegionTerrainData, SidecarError> {
     })
 }
 
-/// Load a sidecar of either format version, upgrading version 1 to a
-/// region document and normalizing it before returning. Refuses a file
-/// written by a newer build, and a version-1 file whose resolution cannot
-/// become a region.
+/// A sidecar as it was read, with whatever its material references could not
+/// be given a path.
+pub struct LoadedSidecar {
+    pub data: RegionTerrainData,
+    /// Slots of a file older than version 8 whose material name has no file
+    /// under `materials/`, left as the names they were.
+    pub kept_names: Vec<(usize, String)>,
+}
+
+impl LoadedSidecar {
+    /// What to say about each name that stayed a name.
+    pub fn warnings(&self) -> impl Iterator<Item = String> + '_ {
+        self.kept_names.iter().map(|(slot, name)| {
+            format!(
+                "terrain slot {slot} keeps the material name '{name}': \
+                 there is no materials/{name}{MATERIAL_FILE_SUFFIX} to point it at"
+            )
+        })
+    }
+}
+
+/// Load a sidecar of any format version, upgrading version 1 to a region
+/// document and normalizing it before returning. Refuses a file written by a
+/// newer build, and a version-1 file whose resolution cannot become a region.
 pub fn load(bytes: &[u8]) -> Result<RegionTerrainData, SidecarError> {
+    Ok(load_from(bytes, None)?.data)
+}
+
+/// Load a sidecar and give the material slots of a file older than version 8
+/// the path of the file each name stands for under `assets`.
+///
+/// A name with no file of its own keeps the name, so a project whose materials
+/// live somewhere else still draws what it drew.
+pub fn load_from(bytes: &[u8], assets: Option<&Path>) -> Result<LoadedSidecar, SidecarError> {
     let mut r = Reader { bytes, at: 0 };
     if r.take(MAGIC.len())? != MAGIC {
         return Err(SidecarError::BadMagic);
@@ -1969,11 +2025,38 @@ pub fn load(bytes: &[u8]) -> Result<RegionTerrainData, SidecarError> {
     let mut data = match version {
         0 => Err(SidecarError::UnsupportedVersion(0)),
         VERSION => decode(bytes).and_then(|legacy| RegionTerrainData::from_legacy_v1(&legacy)),
-        VERSION_2..=VERSION_7 => decode_regions(bytes),
+        VERSION_2..=VERSION_8 => decode_regions(bytes),
         other => Err(SidecarError::UnsupportedVersion(other)),
     }?;
     data.normalize();
-    Ok(data)
+    let kept_names = if version < VERSION_8 {
+        name_slots_as_paths(&mut data.materials, assets)
+    } else {
+        Vec::new()
+    };
+    Ok(LoadedSidecar { data, kept_names })
+}
+
+/// Point every bare material name at the file it stands for, and report the
+/// slots whose name has no file.
+fn name_slots_as_paths(
+    materials: &mut [TerrainMaterialSlot],
+    assets: Option<&Path>,
+) -> Vec<(usize, String)> {
+    let mut kept = Vec::new();
+    for (index, slot) in materials.iter_mut().enumerate() {
+        if slot.is_tombstone() || slot.material.contains('/') {
+            continue;
+        }
+        let path = format!("{MATERIALS_DIR}/{}{MATERIAL_FILE_SUFFIX}", slot.material);
+        let exists = assets.is_some_and(|assets| assets.join(&path).is_file());
+        if exists {
+            slot.material = path;
+        } else {
+            kept.push((index, slot.material.clone()));
+        }
+    }
+    kept
 }
 
 /// Serialize a terrain document as the current format version. The inverse
@@ -2538,7 +2621,7 @@ mod tests {
         migrated.grid = Some(GridGeometry::DEFAULT);
 
         let v2_bytes = save(&migrated).expect("encodes");
-        assert_eq!(u16::from_le_bytes([v2_bytes[8], v2_bytes[9]]), VERSION_7);
+        assert_eq!(u16::from_le_bytes([v2_bytes[8], v2_bytes[9]]), VERSION_8);
         assert_ne!(v2_bytes[8..10], v1_bytes[8..10]);
 
         let reloaded = load(&v2_bytes).expect("loads");
@@ -2645,15 +2728,88 @@ mod tests {
     fn rejects_a_v2_file_written_by_a_newer_build() {
         let bytes = encode_regions(&sample_regions()).expect("encodes");
         let mut newer = bytes.clone();
-        newer[8..10].copy_from_slice(&(VERSION_7 + 1).to_le_bytes());
+        newer[8..10].copy_from_slice(&(VERSION_8 + 1).to_le_bytes());
         assert_eq!(
             decode_regions(&newer),
-            Err(SidecarError::UnsupportedVersion(VERSION_7 + 1))
+            Err(SidecarError::UnsupportedVersion(VERSION_8 + 1))
         );
         assert_eq!(
             load(&newer),
-            Err(SidecarError::UnsupportedVersion(VERSION_7 + 1))
+            Err(SidecarError::UnsupportedVersion(VERSION_8 + 1))
         );
+    }
+
+    /// Version 7 and version 8 lay the same bytes out; only what a slot's
+    /// string means changed, so a version-7 file is this build's bytes under
+    /// the older version word.
+    fn version_7_bytes(data: &RegionTerrainData) -> Vec<u8> {
+        let mut bytes = encode_regions(data).expect("encodes");
+        bytes[8..10].copy_from_slice(&VERSION_7.to_le_bytes());
+        bytes
+    }
+
+    fn assets_holding_material(name: &str) -> tempfile::TempDir {
+        let assets = tempfile::tempdir().expect("tempdir");
+        let dir = assets.path().join(MATERIALS_DIR);
+        std::fs::create_dir_all(&dir).expect("materials dir");
+        std::fs::write(dir.join(format!("{name}{MATERIAL_FILE_SUFFIX}")), "").expect("write");
+        assets
+    }
+
+    #[test]
+    fn a_version_7_slot_reads_as_the_path_of_the_material_file_it_names() {
+        let assets = assets_holding_material("grass");
+        let bytes = version_7_bytes(&RegionTerrainData {
+            materials: vec![TerrainMaterialSlot::new("grass")],
+            ..RegionTerrainData::default()
+        });
+
+        let loaded = load_from(&bytes, Some(assets.path())).expect("loads");
+
+        assert_eq!(
+            loaded.data.materials[0].material,
+            "materials/grass.material.bsn"
+        );
+        assert!(loaded.kept_names.is_empty());
+    }
+
+    #[test]
+    fn a_version_7_file_saves_forward_as_version_8() {
+        let assets = assets_holding_material("grass");
+        let bytes = version_7_bytes(&RegionTerrainData {
+            materials: vec![TerrainMaterialSlot::new("grass")],
+            ..RegionTerrainData::default()
+        });
+
+        let loaded = load_from(&bytes, Some(assets.path())).expect("loads");
+        let forward = save(&loaded.data).expect("encodes");
+
+        assert_eq!(u16::from_le_bytes([forward[8], forward[9]]), VERSION_8);
+        assert_eq!(
+            load(&forward).expect("reloads").materials[0].material,
+            "materials/grass.material.bsn",
+            "a file already holding paths is read back as it stands"
+        );
+    }
+
+    #[test]
+    fn a_version_7_name_with_no_file_keeps_the_name_and_says_so() {
+        let assets = tempfile::tempdir().expect("tempdir");
+        let bytes = version_7_bytes(&RegionTerrainData {
+            materials: vec![
+                TerrainMaterialSlot::tombstone(),
+                TerrainMaterialSlot::new("grass"),
+            ],
+            ..RegionTerrainData::default()
+        });
+
+        let loaded = load_from(&bytes, Some(assets.path())).expect("loads");
+
+        assert_eq!(loaded.data.materials[1].material, "grass");
+        assert_eq!(loaded.kept_names, vec![(1, "grass".to_string())]);
+        let said: Vec<String> = loaded.warnings().collect();
+        assert!(said[0].contains("slot 1"), "{said:?}");
+        assert!(said[0].contains("grass"), "{said:?}");
     }
 
     #[test]
@@ -2666,7 +2822,7 @@ mod tests {
         );
         assert_eq!(
             decode(&regions_bytes),
-            Err(SidecarError::UnsupportedVersion(VERSION_7))
+            Err(SidecarError::UnsupportedVersion(VERSION_8))
         );
     }
 
@@ -2912,14 +3068,32 @@ mod tests {
     }
 
     #[test]
-    fn material_names_accept_a_file_stem_and_reject_anything_that_is_not_one() {
-        for good in ["grass", "rock_05", "moss-2", "a.b"] {
+    fn material_references_accept_a_path_under_the_assets_and_reject_anything_else() {
+        for good in [
+            "grass",
+            "rock_05",
+            "moss-2",
+            "a.b",
+            "materials/grass.material.bsn",
+            "content/ground/a.b",
+        ] {
             assert!(
                 validate_material_name(good).is_ok(),
                 "{good:?} must validate"
             );
         }
-        for bad in [".", "..", "../x", "a/b", r"a\b", "C:x", "my material"] {
+        for bad in [
+            ".",
+            "..",
+            "../x",
+            "a//b",
+            "/a",
+            "a/",
+            "a/../b",
+            r"a\b",
+            "C:x",
+            "my material",
+        ] {
             assert!(
                 validate_material_name(bad).is_err(),
                 "{bad:?} must not validate"
@@ -3063,7 +3237,7 @@ mod tests {
         assert_eq!(decoded.materials[0].detile, 0.5);
 
         let forward = save(&decoded).expect("encodes");
-        assert_eq!(u16::from_le_bytes([forward[8], forward[9]]), VERSION_7);
+        assert_eq!(u16::from_le_bytes([forward[8], forward[9]]), VERSION_8);
         assert_eq!(
             load(&forward).expect("reloads").autoterrain,
             decoded.autoterrain
@@ -3152,7 +3326,7 @@ mod tests {
         });
 
         let bytes = encode_regions(&data).expect("encodes");
-        assert_eq!(u16::from_le_bytes([bytes[8], bytes[9]]), VERSION_7);
+        assert_eq!(u16::from_le_bytes([bytes[8], bytes[9]]), VERSION_8);
         assert_eq!(decode_regions(&bytes).expect("decodes"), data);
         assert_eq!(load(&bytes).expect("loads"), data);
     }
@@ -3243,7 +3417,7 @@ mod tests {
     fn a_scatter_palette_and_its_placements_round_trip() {
         let data = scattered_document();
         let bytes = save(&data).expect("encodes");
-        assert_eq!(u16::from_le_bytes([bytes[8], bytes[9]]), VERSION_7);
+        assert_eq!(u16::from_le_bytes([bytes[8], bytes[9]]), VERSION_8);
         assert_eq!(bytes.len(), data.encoded_len().expect("fits"));
         assert_eq!(load(&bytes).expect("loads"), data);
     }
@@ -3258,7 +3432,7 @@ mod tests {
         // Saving it forward writes the empty palette and one zero
         // placement count per region, and reads back the same document.
         let forward = save(&data).expect("encodes");
-        assert_eq!(u16::from_le_bytes([forward[8], forward[9]]), VERSION_7);
+        assert_eq!(u16::from_le_bytes([forward[8], forward[9]]), VERSION_8);
         assert_eq!(load(&forward).expect("loads"), data);
     }
 
@@ -3436,11 +3610,11 @@ mod tests {
     /// Loading a version-5 file and saving it back writes version 6 with
     /// the defaults spelled out, and reloading that changes nothing.
     #[test]
-    fn a_version_5_file_saves_forward_as_version_6() {
+    fn a_version_5_file_saves_forward_as_the_current_version() {
         let data = load(VERSION_5_FILE).expect("loads");
         let forward = save(&data).expect("encodes");
 
-        assert_eq!(u16::from_le_bytes([forward[8], forward[9]]), VERSION_7);
+        assert_eq!(u16::from_le_bytes([forward[8], forward[9]]), VERSION_8);
         assert_eq!(load(&forward).expect("reloads"), data);
     }
 
@@ -3455,7 +3629,7 @@ mod tests {
         };
 
         let bytes = save(&data).expect("encodes");
-        assert_eq!(u16::from_le_bytes([bytes[8], bytes[9]]), VERSION_7);
+        assert_eq!(u16::from_le_bytes([bytes[8], bytes[9]]), VERSION_8);
         let back = load(&bytes).expect("decodes");
         assert_eq!(back.surface, data.surface);
         assert_eq!(back, data);

--- a/src/asset_index.rs
+++ b/src/asset_index.rs
@@ -434,6 +434,7 @@ pub fn rescan_asset_index(world: &mut World) -> AssetRescan {
             mtime,
         });
     }
+    publish_reference_map(world);
     scan
 }
 
@@ -450,6 +451,52 @@ fn publish_name(world: &mut World, path: &Path, kind: &AssetKind, value: &AssetV
     world
         .resource_mut::<crate::asset_catalog::AssetCatalog>()
         .insert(format!("@{name}"), handle.clone());
+}
+
+/// Publish what the index holds as the references a document reads and writes:
+/// every loaded file under the path that names it, under the bare name it was
+/// spelled by before paths when no other file shares that stem, and every
+/// loaded handle under the path it is emitted as.
+///
+/// The open scene resolves those as well as what it embeds, and what it embeds
+/// wins the spellings they share. Only its `#` entries are the document's own,
+/// so a name published for a file that has since gone is not carried over.
+pub fn publish_reference_map(world: &mut World) {
+    let mut references: bevy::platform::collections::HashMap<String, UntypedHandle> =
+        bevy::platform::collections::HashMap::default();
+    let mut paths: bevy::platform::collections::HashMap<UntypedAssetId, String> =
+        bevy::platform::collections::HashMap::default();
+    let mut stems: HashMap<String, usize> = HashMap::new();
+    let index = world.resource::<AssetIndex>();
+    for entry in index.iter() {
+        *stems.entry(entry.name()).or_default() += 1;
+    }
+    for entry in index.iter() {
+        let Some(handle) = entry.value.handle() else {
+            continue;
+        };
+        let path = entry.path.to_slash_lossy().into_owned();
+        paths.insert(handle.id(), path.clone());
+        references.insert(path, handle.clone());
+        let name = entry.name();
+        if stems.get(&name) == Some(&1) {
+            references.insert(format!("@{name}"), handle.clone());
+            references.entry(name).or_insert_with(|| handle.clone());
+        }
+    }
+    let mut scene = references.clone();
+    if let Some(embedded) = world.get_resource::<jackdaw_bsn::BsnSceneAssets>() {
+        for (reference, handle) in &embedded.0 {
+            let Some(name) = reference.strip_prefix('#') else {
+                continue;
+            };
+            scene.insert(reference.clone(), handle.clone());
+            scene.insert(format!("@{name}"), handle.clone());
+        }
+    }
+    world.insert_resource(jackdaw_bsn::BsnProjectAssets(references));
+    world.insert_resource(jackdaw_bsn::BsnSceneAssets(scene));
+    world.insert_resource(jackdaw_bsn::BsnAssetPaths(paths));
 }
 
 /// Record a file the editor itself wrote, holding the value it wrote, and
@@ -475,6 +522,7 @@ pub fn index_written(
         value,
         mtime,
     });
+    publish_reference_map(world);
     Some(indexed)
 }
 

--- a/src/definition_assets.rs
+++ b/src/definition_assets.rs
@@ -463,7 +463,8 @@ fn asset_field_json(
         value.reflect_path(field_path).ok()?
     };
     let server = world.get_resource::<AssetServer>();
-    if let Some(path) = crate::typed_values::asset_path_json(&registry, server, field) {
+    let index = world.get_resource::<crate::asset_index::AssetIndex>();
+    if let Some(path) = crate::typed_values::asset_path_json(&registry, server, index, field) {
         return Some(path);
     }
     crate::inspector::reflect_fields::reflect_to_json(field, &registry)
@@ -553,11 +554,12 @@ fn text_value_for_asset_field(
         value.reflect_path(field_path).ok()?
     };
     let type_id = field.get_represented_type_info()?.type_id();
-    if crate::typed_values::takes_asset_path(&registry, type_id) {
+    let references = jackdaw_bsn::apply_reference_map(world);
+    if crate::typed_values::takes_asset_path(&registry, type_id) && !references.contains_key(text) {
         report_missing_asset(text);
     }
     let server = world.get_resource::<AssetServer>();
-    crate::typed_values::text_value_for_field(&registry, server, type_id, text)
+    crate::typed_values::text_value_for_field(&registry, server, Some(&references), type_id, text)
 }
 
 /// Say when a path names nothing under the project's assets, without refusing

--- a/src/inspector/schema_fields.rs
+++ b/src/inspector/schema_fields.rs
@@ -106,7 +106,7 @@ fn spawn_one_field(
     }
     let value = {
         let registry = ctx.registry.read();
-        native_value_for_json(&registry, ctx.server, &field.type_path, held)
+        native_value_for_json(&registry, ctx.server, None, &field.type_path, held)
     };
     let Some(value) = value else {
         spawn_read_only(commands, parent, &field.name, held, depth);
@@ -199,7 +199,7 @@ fn spawn_item_value(
 ) {
     let value = {
         let registry = ctx.registry.read();
-        native_value_for_json(&registry, ctx.server, item_type, item)
+        native_value_for_json(&registry, ctx.server, None, item_type, item)
     };
     let Some(value) = value else {
         spawn_read_only(commands, parent, "", item, depth);

--- a/src/material_assets.rs
+++ b/src/material_assets.rs
@@ -140,6 +140,52 @@ impl MaterialRegistry {
     }
 }
 
+/// The name a material reference carries: the part of its last path segment
+/// before the first dot, which is what a bare name already is.
+pub fn material_name_of(reference: &str) -> &str {
+    let file = reference.rsplit('/').next().unwrap_or(reference);
+    file.split_once('.').map_or(file, |(stem, _)| stem)
+}
+
+/// The file a material reference names, if one holds it: the file at that
+/// path, or, for the references written before paths, the file whose stem is
+/// that bare name.
+pub fn material_file_of<'a>(
+    index: &'a crate::asset_index::AssetIndex,
+    reference: &str,
+) -> Option<&'a crate::asset_index::AssetEntry> {
+    if reference.is_empty() {
+        return None;
+    }
+    let path = <PathBuf as path_slash::PathBufExt>::from_slash(reference);
+    index
+        .get(&path)
+        .filter(|entry| entry.kind == crate::definition_assets::MATERIAL_KIND)
+        .or_else(|| index.material_named(material_name_of(reference)))
+}
+
+/// The material a reference names: the file it spells the path of, or, for the
+/// references written before paths, the bare name a file's stem gives it.
+pub fn material_of_reference(
+    index: Option<&crate::asset_index::AssetIndex>,
+    registry: &MaterialRegistry,
+    reference: &str,
+) -> Option<Handle<StandardMaterial>> {
+    if reference.is_empty() {
+        return None;
+    }
+    if let Some(handle) = index
+        .and_then(|index| material_file_of(index, reference))
+        .and_then(|entry| entry.value.handle())
+        && let Ok(typed) = handle.clone().try_typed::<StandardMaterial>()
+    {
+        return Some(typed);
+    }
+    registry
+        .get_by_name(material_name_of(reference))
+        .map(|entry| entry.handle.clone())
+}
+
 /// Strip path separators and other characters that cannot appear in a file
 /// stem, so a material name always maps to exactly one file.
 pub fn sanitize_material_name(name: &str) -> String {

--- a/src/material_browser.rs
+++ b/src/material_browser.rs
@@ -1157,17 +1157,22 @@ pub(crate) fn material_select(
     allows_undo = false,
     params(material(
         String,
-        doc = "Name of the material to apply. Defaults to the previewed one."
+        doc = "Path of the material file to apply, such as \
+               materials/slate.material.bsn. A bare name still resolves for \
+               one release. Defaults to the previewed one."
     ))
 )]
 pub(crate) fn material_apply(
     params: In<OperatorParameters>,
     registry: Res<MaterialRegistry>,
+    index: Option<Res<crate::asset_index::AssetIndex>>,
     preview_state: Res<MaterialPreviewState>,
     mut commands: Commands,
 ) -> OperatorResult {
     let handle = match params.as_str("material") {
-        Some(name) => registry.get_by_name(name).map(|e| e.handle.clone()),
+        Some(reference) => {
+            crate::material_assets::material_of_reference(index.as_deref(), &registry, reference)
+        }
         None => preview_state.active_material.clone(),
     };
     let Some(material) = handle.filter(|h| *h != Handle::default()) else {

--- a/src/scene_io/load.rs
+++ b/src/scene_io/load.rs
@@ -531,6 +531,7 @@ pub(crate) fn import_terrain_sidecars(
             });
         }
     }
+    let assets = crate::asset_index::assets_dir(world);
     let mut imported: std::collections::HashSet<String> = std::collections::HashSet::new();
     for (data_path, no_inline_heights) in wanted {
         let full = match sidecar::resolve_path(&scene_dir, &data_path) {
@@ -541,10 +542,14 @@ pub(crate) fn import_terrain_sidecars(
             }
         };
         match std::fs::read(&full) {
-            // `load` takes either format version: a sidecar written before
-            // regions existed migrates on the way in.
-            Ok(bytes) => match sidecar::load(&bytes) {
-                Ok(data) => {
+            // A sidecar written before regions existed, or before slots held
+            // paths, migrates on the way in.
+            Ok(bytes) => match sidecar::load_from(&bytes, assets.as_deref()) {
+                Ok(loaded) => {
+                    for message in loaded.warnings() {
+                        warn!("{message}");
+                    }
+                    let data = loaded.data;
                     let mtime = std::fs::metadata(&full)
                         .and_then(|meta| meta.modified())
                         .ok();

--- a/src/scene_io/save.rs
+++ b/src/scene_io/save.rs
@@ -2,7 +2,7 @@ use std::collections::HashMap;
 use std::path::{Path, PathBuf};
 
 use bevy::asset::{ReflectAsset, ReflectHandle, UntypedAssetId};
-use bevy::reflect::TypeRegistry;
+use bevy::reflect::{TypeInfo, TypeRegistry};
 use bevy::{ecs::reflect::AppTypeRegistry, prelude::*, tasks::AsyncComputeTaskPool};
 
 use super::load::SceneDialogTask;
@@ -525,6 +525,41 @@ pub fn save_layout_to_project(world: &mut World) {
     }
 }
 
+/// What each loaded asset is referenced by when a document emits a handle to
+/// it: the path of the file the index holds it under, else the `#Name` the
+/// open document embeds it as, else the name the catalog resolves.
+///
+/// An unsaved material is left out so it embeds inline: a name for it would
+/// resolve nowhere outside this editor run.
+fn asset_reference_seed(
+    world: &World,
+) -> bevy::platform::collections::HashMap<UntypedAssetId, String> {
+    let mut seed: bevy::platform::collections::HashMap<UntypedAssetId, String> =
+        bevy::platform::collections::HashMap::default();
+    if let Some(paths) = world.get_resource::<jackdaw_bsn::BsnAssetPaths>() {
+        for (id, path) in &paths.0 {
+            seed.insert(*id, path.clone());
+        }
+    }
+    if let Some(scene_assets) = world.get_resource::<jackdaw_bsn::BsnSceneAssets>() {
+        for (reference, handle) in &scene_assets.0 {
+            if reference.starts_with('#') {
+                seed.entry(handle.id()).or_insert_with(|| reference.clone());
+            }
+        }
+    }
+    let ephemeral = crate::material_assets::ephemeral_material_ids(world);
+    if let Some(catalog) = world.get_resource::<crate::asset_catalog::AssetCatalog>() {
+        for (id, name) in &catalog.id_to_name {
+            if ephemeral.contains(id) {
+                continue;
+            }
+            seed.entry(*id).or_insert_with(|| name.clone());
+        }
+    }
+    seed
+}
+
 /// The runtime inline assets referenced by a BSN document's kept components,
 /// collected at emit time so they can be embedded and resolved.
 struct BsnInlineAssetPass {
@@ -933,28 +968,7 @@ fn emit_bsn_scene_authored(
     let registry = world.resource::<AppTypeRegistry>().clone();
     normalize_derived_button_styles(world, &mut ast, &registry);
 
-    // Seed the reference map with assets that already resolve: catalog entries
-    // and scene-inline entries already embedded as document roots.
-    // An unsaved material is left unseeded so it embeds inline: an `@Name`
-    // for it would resolve nowhere outside this editor run.
-    let mut seed: bevy::platform::collections::HashMap<UntypedAssetId, String> =
-        bevy::platform::collections::HashMap::default();
-    let ephemeral = crate::material_assets::ephemeral_material_ids(world);
-    if let Some(catalog) = world.get_resource::<crate::asset_catalog::AssetCatalog>() {
-        for (id, name) in &catalog.id_to_name {
-            if ephemeral.contains(id) {
-                continue;
-            }
-            seed.entry(*id).or_insert_with(|| name.clone());
-        }
-    }
-    if let Some(scene_assets) = world.get_resource::<jackdaw_bsn::BsnSceneAssets>() {
-        for (ref_name, handle) in &scene_assets.0 {
-            if ref_name.starts_with('#') {
-                seed.insert(handle.id(), ref_name.clone());
-            }
-        }
-    }
+    let seed = asset_reference_seed(world);
 
     let entities = doc_entities_in_order(&ast);
     let pass = {
@@ -1017,6 +1031,7 @@ fn rederive_handle_patches(
         parent_path,
         asset_names: Some(&pass.names),
     };
+    let mut kept: Vec<String> = Vec::new();
     for (entity, type_path) in &pass.touched {
         let Some(patches_entity) = ast.ast_for(*entity) else {
             continue;
@@ -1036,12 +1051,183 @@ fn rederive_handle_patches(
         let Some(component) = reflect_component.reflect(entity_ref) else {
             continue;
         };
-        let new_patch = jackdaw_bsn::component_to_bsn_patch_with_assets(
+        let mut new_patch = jackdaw_bsn::component_to_bsn_patch_with_assets(
             component.as_partial_reflect(),
             &reg,
             &ctx,
         );
+        if let Some(authored) = ast.get_patch(patch_entity) {
+            keep_unresolved_references(
+                &reg,
+                registration.type_id(),
+                authored,
+                &mut new_patch,
+                &mut kept,
+            );
+        }
         ast.set_patch(patch_entity, new_patch);
+    }
+    for reference in kept {
+        warn!("keeping the asset reference '{reference}', which this project does not resolve");
+    }
+}
+
+/// Keep a reference the editor could not resolve.
+///
+/// A handle field whose reference resolved to nothing holds the default handle,
+/// which re-derives as an empty string. What the file said is better than
+/// nothing: another project, or this one once the file is there, resolves it,
+/// so the authored string stays and is reported. The emitter elides a field
+/// left at its default, so a kept reference brings its field back with it, and
+/// a component whose every field elided comes back as a struct patch.
+fn keep_unresolved_references(
+    reg: &TypeRegistry,
+    type_id: std::any::TypeId,
+    authored: &jackdaw_bsn::BsnPatch,
+    fresh: &mut jackdaw_bsn::BsnPatch,
+    kept: &mut Vec<String>,
+) {
+    use jackdaw_bsn::BsnPatch;
+    match (authored, &mut *fresh) {
+        (BsnPatch::Struct(authored), BsnPatch::Struct(fresh)) => {
+            keep_in_fields(reg, type_id, &authored.fields, &mut fresh.fields, kept);
+        }
+        (BsnPatch::TupleStruct(authored), BsnPatch::TupleStruct(fresh)) => {
+            keep_in_values(reg, type_id, &authored.values, &mut fresh.values, kept);
+        }
+        (BsnPatch::Struct(authored), BsnPatch::Type(type_path)) => {
+            let type_path = type_path.clone();
+            let mut fields = jackdaw_bsn::BsnStructFields::default();
+            keep_in_fields(reg, type_id, &authored.fields, &mut fields, kept);
+            if !fields.0.is_empty() {
+                *fresh = BsnPatch::Struct(jackdaw_bsn::BsnStructData { type_path, fields });
+            }
+        }
+        _ => {}
+    }
+}
+
+fn keep_in_fields(
+    reg: &TypeRegistry,
+    type_id: std::any::TypeId,
+    authored: &jackdaw_bsn::BsnStructFields,
+    fresh: &mut jackdaw_bsn::BsnStructFields,
+    kept: &mut Vec<String>,
+) {
+    let Some(TypeInfo::Struct(info)) = reg
+        .get(type_id)
+        .map(bevy::reflect::TypeRegistration::type_info)
+    else {
+        return;
+    };
+    for field in &mut fresh.0 {
+        let Some(field_type) = info
+            .field(&field.name)
+            .map(bevy::reflect::NamedField::type_id)
+        else {
+            continue;
+        };
+        let Some(was) = authored.0.iter().find(|other| other.name == field.name) else {
+            continue;
+        };
+        keep_in_value(reg, field_type, &was.value, &mut field.value, kept);
+    }
+    for was in &authored.0 {
+        if fresh.0.iter().any(|field| field.name == was.name) {
+            continue;
+        }
+        let Some(field_type) = info
+            .field(&was.name)
+            .map(bevy::reflect::NamedField::type_id)
+        else {
+            continue;
+        };
+        let jackdaw_bsn::BsnValue::String(reference) = &was.value else {
+            continue;
+        };
+        if reference.is_empty() || !crate::typed_values::takes_asset_path(reg, field_type) {
+            continue;
+        }
+        if !kept.contains(reference) {
+            kept.push(reference.clone());
+        }
+        fresh.0.push(jackdaw_bsn::BsnField {
+            name: was.name.clone(),
+            value: was.value.clone(),
+        });
+    }
+}
+
+fn keep_in_values(
+    reg: &TypeRegistry,
+    type_id: std::any::TypeId,
+    authored: &[jackdaw_bsn::BsnValue],
+    fresh: &mut [jackdaw_bsn::BsnValue],
+    kept: &mut Vec<String>,
+) {
+    let Some(TypeInfo::TupleStruct(info)) = reg
+        .get(type_id)
+        .map(bevy::reflect::TypeRegistration::type_info)
+    else {
+        return;
+    };
+    for (index, value) in fresh.iter_mut().enumerate() {
+        let Some(field_type) = info
+            .field_at(index)
+            .map(bevy::reflect::UnnamedField::type_id)
+        else {
+            continue;
+        };
+        let Some(was) = authored.get(index) else {
+            continue;
+        };
+        keep_in_value(reg, field_type, was, value, kept);
+    }
+}
+
+fn keep_in_value(
+    reg: &TypeRegistry,
+    type_id: std::any::TypeId,
+    authored: &jackdaw_bsn::BsnValue,
+    fresh: &mut jackdaw_bsn::BsnValue,
+    kept: &mut Vec<String>,
+) {
+    use jackdaw_bsn::BsnValue;
+    if crate::typed_values::takes_asset_path(reg, type_id) {
+        if let (BsnValue::String(was), BsnValue::String(now)) = (authored, &mut *fresh)
+            && now.is_empty()
+            && !was.is_empty()
+        {
+            now.clone_from(was);
+            if !kept.contains(was) {
+                kept.push(was.clone());
+            }
+        }
+        return;
+    }
+    match (authored, fresh) {
+        (BsnValue::Struct(authored), BsnValue::Struct(fresh)) => {
+            keep_in_fields(reg, type_id, &authored.fields, &mut fresh.fields, kept);
+        }
+        (BsnValue::TupleStruct(authored), BsnValue::TupleStruct(fresh)) => {
+            keep_in_values(reg, type_id, &authored.values, &mut fresh.values, kept);
+        }
+        (BsnValue::List(authored), BsnValue::List(fresh)) => {
+            let Some(TypeInfo::List(info)) = reg
+                .get(type_id)
+                .map(bevy::reflect::TypeRegistration::type_info)
+            else {
+                return;
+            };
+            let item = info.item_ty().id();
+            for (index, value) in fresh.iter_mut().enumerate() {
+                let Some(was) = authored.get(index) else {
+                    continue;
+                };
+                keep_in_value(reg, item, was, value, kept);
+            }
+        }
+        _ => {}
     }
 }
 
@@ -1081,27 +1267,7 @@ fn emit_bsn_entities_authored(world: &mut World, parent_path: &Path, nodes: &[En
     let registry = world.resource::<AppTypeRegistry>().clone();
     normalize_derived_button_styles(world, &mut ast, &registry);
 
-    // Seed catalog and live scene-inline names so same-scene copy keeps the
-    // existing `#Name` refs. Unsaved materials are left unseeded so the clip
-    // carries them inline.
-    let mut seed: bevy::platform::collections::HashMap<UntypedAssetId, String> =
-        bevy::platform::collections::HashMap::default();
-    let ephemeral = crate::material_assets::ephemeral_material_ids(world);
-    if let Some(catalog) = world.get_resource::<crate::asset_catalog::AssetCatalog>() {
-        for (id, name) in &catalog.id_to_name {
-            if ephemeral.contains(id) {
-                continue;
-            }
-            seed.entry(*id).or_insert_with(|| name.clone());
-        }
-    }
-    if let Some(scene_assets) = world.get_resource::<jackdaw_bsn::BsnSceneAssets>() {
-        for (ref_name, handle) in &scene_assets.0 {
-            if ref_name.starts_with('#') {
-                seed.insert(handle.id(), ref_name.clone());
-            }
-        }
-    }
+    let seed = asset_reference_seed(world);
 
     // The copied subtrees' document nodes and their live ECS entities.
     let mut subtree_nodes: Vec<Entity> = Vec::new();
@@ -1698,7 +1864,7 @@ mod terrain_sidecar_tests {
         let sidecar_path = tmp.join("zone.terrain-0.jdterrain");
 
         let mut original = sidecar::save(&document(&sculpted())).expect("encodes");
-        original[8..10].copy_from_slice(&(sidecar::VERSION_7 + 1).to_le_bytes());
+        original[8..10].copy_from_slice(&(sidecar::VERSION_8 + 1).to_le_bytes());
         std::fs::write(&sidecar_path, &original).expect("write sidecar");
 
         let mut world = World::new();
@@ -1930,7 +2096,7 @@ mod terrain_sidecar_tests {
         let rewritten = std::fs::read(&sidecar_path).expect("read back");
         assert_eq!(
             u16::from_le_bytes([rewritten[8], rewritten[9]]),
-            sidecar::VERSION_7,
+            sidecar::VERSION_8,
         );
         // The load settled this terrain onto the geometry its declared rectangle drew with
         // (four vertices across the default 100 metres, cornered at -size/2) and the rewrite

--- a/src/schema_values.rs
+++ b/src/schema_values.rs
@@ -494,6 +494,7 @@ fn enum_bsn_for_json(
 pub fn native_value_for_json(
     registry: &bevy::reflect::TypeRegistry,
     server: Option<&AssetServer>,
+    references: Option<&crate::typed_values::References>,
     type_path: &str,
     json: &Value,
 ) -> Option<Box<dyn PartialReflect>> {
@@ -502,6 +503,7 @@ pub fn native_value_for_json(
         && let Some(value) = crate::typed_values::text_value_for_field(
             registry,
             server,
+            references,
             registration.type_id(),
             text,
         )
@@ -521,7 +523,8 @@ fn native_bsn_for_json(world: &World, type_path: &str, json: &Value) -> Option<B
         ));
     }
     let server = world.get_resource::<AssetServer>();
-    let reflected = native_value_for_json(&registry, server, type_path, json)?;
+    let references = jackdaw_bsn::apply_reference_map(world);
+    let reflected = native_value_for_json(&registry, server, Some(&references), type_path, json)?;
     Some(match server {
         Some(server) => BsnValue::from_reflect_with_assets(
             reflected.as_ref(),

--- a/src/terrain/panel.rs
+++ b/src/terrain/panel.rs
@@ -265,6 +265,7 @@ struct TexturesTabRefs<'w> {
     paint: Res<'w, TerrainPaintState>,
     picker: Res<'w, TerrainMaterialPicker>,
     registry: Res<'w, MaterialRegistry>,
+    index: Option<Res<'w, crate::asset_index::AssetIndex>>,
     materials: Res<'w, Assets<StandardMaterial>>,
     italic_font: Res<'w, EditorFontItalic>,
     icon_font: Res<'w, IconFont>,
@@ -1407,14 +1408,21 @@ fn spawn_slot_editor(
     refs: &TexturesTabRefs,
 ) {
     let icon_font = refs.icon_font.0.clone();
-    let entry = refs.registry.get_by_name(&slot.material);
-    let saved = entry.is_some_and(|entry| entry.saved);
+    let name = crate::material_assets::material_name_of(&slot.material);
+    let handle = crate::material_assets::material_of_reference(
+        refs.index.as_deref(),
+        &refs.registry,
+        &slot.material,
+    );
+    let saved = refs.index.as_deref().is_some_and(|index| {
+        crate::material_assets::material_file_of(index, &slot.material).is_some()
+    }) || refs.registry.is_saved(name);
 
     spawn_action_header(
         commands,
         parent,
         ActionHeaderProps {
-            name: format!("Slot {index}: {}", slot.material),
+            name: format!("Slot {index}: {name}"),
             saved,
             italic_font: &refs.italic_font.0,
             icon_font: &icon_font,
@@ -1422,7 +1430,7 @@ fn spawn_slot_editor(
         },
     );
 
-    let Some(handle) = entry.map(|entry| entry.handle.clone()) else {
+    let Some(handle) = handle else {
         spawn_error_hint(
             commands,
             parent,

--- a/src/terrain/splat.rs
+++ b/src/terrain/splat.rs
@@ -4,10 +4,10 @@
 //! least one material slot and everything those materials name has loaded.
 //! Otherwise it draws with the plain editor material.
 //!
-//! The editor contributes the name store: it hands [`resolve_with`] a closure
-//! that looks a slot's name up in [`MaterialRegistry`]. The id space and the
-//! array stacking live in the shared crate, so the editor and a built game
-//! turn the same names into the same pixels.
+//! The editor contributes the lookup: it hands [`resolve_with`] a closure that
+//! finds the file a slot's path names, or the material a bare name stands for.
+//! The id space and the array stacking live in the shared crate, so the editor
+//! and a built game turn the same references into the same pixels.
 
 use std::sync::Arc;
 
@@ -194,8 +194,8 @@ impl TerrainSplatMaterials {
 
 /// Resolve every terrain's material list into the array builder's input.
 ///
-/// Runs every frame rather than on a change signal: resolution is a registry
-/// lookup per slot and the result is compared before it is stored, so an
+/// Runs every frame rather than on a change signal: resolution is one lookup
+/// per slot and the result is compared before it is stored, so an
 /// unchanged terrain writes nothing and a material that loaded late is picked
 /// up without invalidation bookkeeping.
 fn resolve_terrain_materials(
@@ -203,6 +203,7 @@ fn resolve_terrain_materials(
     mut paint_state: ResMut<super::TerrainPaintState>,
     store: Res<TerrainDataStore>,
     registry: Res<MaterialRegistry>,
+    index: Option<Res<crate::asset_index::AssetIndex>>,
     standard: Res<Assets<StandardMaterial>>,
     assets: Res<AssetServer>,
     terrains: Query<&jackdaw_scene_types::Terrain>,
@@ -222,10 +223,13 @@ fn resolve_terrain_materials(
         let slots = store.materials(&data_path).to_vec();
         let resolved = resolve_with(
             &slots,
-            |name| {
-                registry
-                    .get_by_name(name)
-                    .and_then(|entry| standard.get(&entry.handle))
+            |reference| {
+                crate::material_assets::material_of_reference(
+                    index.as_deref(),
+                    &registry,
+                    reference,
+                )
+                .and_then(|handle| standard.get(&handle))
             },
             &assets,
         );

--- a/src/terrain/texture_ops.rs
+++ b/src/terrain/texture_ops.rs
@@ -17,6 +17,7 @@ use bevy::prelude::*;
 use jackdaw_api::prelude::*;
 use jackdaw_terrain::sidecar::{AutoTerrainSettings, TerrainMaterialSlot};
 use jackdaw_terrain::texture_set::{DEFAULT_UV_SCALE, MAX_DETILE, MAX_UV_SCALE, MIN_UV_SCALE};
+use path_slash::PathExt as _;
 
 use super::TerrainDataStore;
 use super::ops::has_selected_terrain;
@@ -119,34 +120,38 @@ fn commit(
     description = "Give the selected terrain another texture id, drawn by a saved material.",
     is_available = has_selected_terrain,
     allows_undo = false,
-    params(material(String, doc = "Name of a saved material.")),
+    params(material(
+        String,
+        doc = "Path of a saved material file, such as \
+               materials/slate.material.bsn. A bare name still resolves for \
+               one release."
+    )),
 )]
 pub(crate) fn terrain_material_add(
     params: In<OperatorParameters>,
     selection: Res<Selection>,
     terrains: Query<&jackdaw_scene_types::Terrain>,
     registry: Res<MaterialRegistry>,
+    index: Option<Res<crate::asset_index::AssetIndex>>,
     mut store: ResMut<TerrainDataStore>,
     mut picker: ResMut<TerrainMaterialPicker>,
     mut history: ResMut<CommandHistory>,
 ) -> OperatorResult {
     let data_path = selected_data_path(&selection, &terrains)?;
-    let name = params.as_str("material").unwrap_or("").trim().to_string();
+    let named = params.as_str("material").unwrap_or("").trim();
 
-    let refusal = match registry.get_by_name(&name) {
-        None => Some(TerrainMaterialError::Unknown(name.clone())),
-        Some(entry) if !entry.saved => Some(TerrainMaterialError::Unsaved(name.clone())),
-        Some(_) => None,
+    let reference = match slot_reference(index.as_deref(), &registry, named) {
+        Ok(reference) => reference,
+        Err(refusal) => {
+            picker.error = Some(refusal.to_string());
+            return OperatorResult::Cancelled;
+        }
     };
-    if let Some(refusal) = refusal {
-        picker.error = Some(refusal.to_string());
-        return OperatorResult::Cancelled;
-    }
 
     let mut materials = store.materials(&data_path).to_vec();
     match materials.iter().position(TerrainMaterialSlot::is_tombstone) {
-        Some(vacant) => materials[vacant] = TerrainMaterialSlot::new(name),
-        None => materials.push(TerrainMaterialSlot::new(name)),
+        Some(vacant) => materials[vacant] = TerrainMaterialSlot::new(reference),
+        None => materials.push(TerrainMaterialSlot::new(reference)),
     }
     let result = commit(
         &mut store,
@@ -161,6 +166,27 @@ pub(crate) fn terrain_material_add(
         picker.open = false;
     }
     result
+}
+
+/// What a slot stores for the material a caller named: the path of the file
+/// holding it, or the bare name of a material no file has claimed, which is
+/// what the slots written before paths spell.
+fn slot_reference(
+    index: Option<&crate::asset_index::AssetIndex>,
+    registry: &MaterialRegistry,
+    named: &str,
+) -> Result<String, TerrainMaterialError> {
+    let name = crate::material_assets::material_name_of(named);
+    if let Some(entry) =
+        index.and_then(|index| crate::material_assets::material_file_of(index, named))
+    {
+        return Ok(entry.path.to_slash_lossy().into_owned());
+    }
+    match registry.get_by_name(name) {
+        None => Err(TerrainMaterialError::Unknown(named.to_string())),
+        Some(entry) if !entry.saved => Err(TerrainMaterialError::Unsaved(named.to_string())),
+        Some(entry) => Ok(entry.name.clone()),
+    }
 }
 
 /// Take the material off one of the selected terrain's texture ids.

--- a/src/typed_values.rs
+++ b/src/typed_values.rs
@@ -5,14 +5,19 @@
 //! and a `Color`, which a person writes as channels, hex or a name. Both are
 //! resolved here, against the field's own type, and everything else is left to
 //! the JSON paths.
+//!
+//! A handle field is resolved against the references the project already
+//! holds before the asset server is asked, so a path names the file the editor
+//! loaded rather than a second copy of it.
 
 use std::any::TypeId;
 
-use bevy::asset::{AssetServer, ReflectHandle};
+use bevy::asset::{AssetServer, ReflectHandle, UntypedHandle};
 use bevy::color::palettes::css;
 use bevy::prelude::*;
 use bevy::reflect::{PartialReflect, TypeInfo, TypeRegistry, enums::VariantInfo};
 use jackdaw_bsn::{BsnApplyAssets, BsnValue, bsn_value_to_reflect};
+use path_slash::PathExt as _;
 
 /// Whether a field of this type names its value by asset path.
 pub fn takes_asset_path(registry: &TypeRegistry, type_id: TypeId) -> bool {
@@ -73,18 +78,23 @@ fn named_color(name: &str) -> Option<Color> {
     Some(Color::Srgba(srgba))
 }
 
+/// The references a field's text is resolved against: what the project holds
+/// under that spelling, keyed by path and by the bare name older files use.
+pub type References = bevy::platform::collections::HashMap<String, UntypedHandle>;
+
 /// The value `text` stands for in a field of `type_id`, or `None` when the
 /// field's type takes its value some other way.
 pub fn text_value_for_field(
     registry: &TypeRegistry,
     server: Option<&AssetServer>,
+    references: Option<&References>,
     type_id: TypeId,
     text: &str,
 ) -> Option<Box<dyn PartialReflect>> {
     if takes_asset_path(registry, type_id) {
         let assets = BsnApplyAssets {
             server: server?,
-            local: None,
+            local: references,
         };
         return bsn_value_to_reflect(
             &BsnValue::String(text.to_string()),
@@ -104,14 +114,24 @@ pub fn text_value_for_field(
 pub fn asset_path_json(
     registry: &TypeRegistry,
     server: Option<&AssetServer>,
+    index: Option<&crate::asset_index::AssetIndex>,
     field: &dyn PartialReflect,
 ) -> Option<serde_json::Value> {
     if !takes_asset_path(registry, field.get_represented_type_info()?.type_id()) {
         return None;
     }
-    let path = handle_of(registry, field)
-        .and_then(|handle| server.and_then(|server| server.get_path(handle.id())))
-        .map(|path| path.to_string())
+    let handle = handle_of(registry, field);
+    let indexed = handle.as_ref().and_then(|handle| {
+        index
+            .and_then(|index| index.path_of_id(handle.id()))
+            .map(|path| path.to_slash_lossy().into_owned())
+    });
+    let path = indexed
+        .or_else(|| {
+            handle
+                .and_then(|handle| server.and_then(|server| server.get_path(handle.id())))
+                .map(|path| path.to_string())
+        })
         .unwrap_or_default();
     Some(serde_json::Value::String(path))
 }

--- a/tests/stage/asset_references.rs
+++ b/tests/stage/asset_references.rs
@@ -1,0 +1,361 @@
+//! References between assets are paths.
+//!
+//! A scene, a prefab or an asset that points at another asset spells the path
+//! of the file it points at. The bare names written before paths still resolve
+//! while projects catch up, and a reference the editor cannot resolve at all is
+//! kept rather than blanked.
+
+use crate::util;
+
+use std::path::{Path, PathBuf};
+
+use bevy::asset::{Asset, Assets};
+use bevy::prelude::*;
+use jackdaw::asset_index::{AssetIndex, AssetValue};
+use jackdaw_api::prelude::*;
+use jackdaw_api_internal::operator::{CallOperatorSettings, ExecutionContext};
+use jackdaw_scene_types::PropertyValue;
+
+/// An asset of the project's own with a handle field, which is what a game's
+/// outfits, mobs and items look like.
+#[derive(Asset, Reflect, Clone, Default)]
+#[reflect(Default)]
+struct OutfitDef {
+    material: Handle<StandardMaterial>,
+}
+
+/// A component holding one material, so a scene can spell a reference without
+/// a brush's geometry in the way.
+#[derive(Component, Reflect, Clone, Default)]
+#[reflect(Component, Default)]
+struct Painted {
+    material: Handle<StandardMaterial>,
+}
+
+fn editor_with_outfits() -> (App, tempfile::TempDir) {
+    let tmp = tempfile::tempdir().expect("tempdir");
+    let mut app = util::editor_test_app();
+    app.init_asset::<OutfitDef>();
+    app.register_asset_reflect::<OutfitDef>();
+    app.register_type::<OutfitDef>();
+    app.register_type::<Painted>();
+    app.world_mut()
+        .insert_resource(jackdaw::project::ProjectRoot {
+            root: tmp.path().to_path_buf(),
+            config: default(),
+        });
+    app.world_mut()
+        .resource_mut::<AssetKinds>()
+        .register(AssetKind::extension(
+            "outfit",
+            "Outfit",
+            OutfitDef::type_path(),
+        ));
+    app.world_mut()
+        .resource_mut::<NextState<jackdaw::AppState>>()
+        .set(jackdaw::AppState::Editor);
+    app.update();
+    (app, tmp)
+}
+
+#[track_caller]
+fn call(app: &mut App, id: &'static str, params: &[(&'static str, PropertyValue)]) {
+    let mut call = app.world_mut().operator(id).settings(CallOperatorSettings {
+        execution_context: ExecutionContext::Invoke,
+        creates_history_entry: true,
+    });
+    for (key, value) in params {
+        call = call.param(*key, value.clone());
+    }
+    let result = call.call().expect("the operator dispatched");
+    assert_eq!(result, OperatorResult::Finished, "{id} did not finish");
+    app.update();
+}
+
+/// A material of the project's own, filed where the caller asks for it, as the
+/// index holds it once the walk has read the file back.
+fn file_material(app: &mut App, relative: &str) -> Handle<StandardMaterial> {
+    let handle = app
+        .world_mut()
+        .resource_mut::<Assets<StandardMaterial>>()
+        .add(StandardMaterial {
+            metallic: 0.5,
+            ..default()
+        });
+    let root = app
+        .world()
+        .resource::<jackdaw::project::ProjectRoot>()
+        .root
+        .clone();
+    let path = root.join("assets").join(relative);
+    std::fs::create_dir_all(path.parent().expect("a parent")).expect("the directory is made");
+    let name = path
+        .file_name()
+        .and_then(|name| name.to_str())
+        .and_then(|name| name.split('.').next())
+        .expect("a name");
+    jackdaw::definition_assets::write_asset_file(
+        app.world(),
+        name,
+        &AssetValue::Handle(handle.clone().untyped()),
+        &path,
+    )
+    .expect("the material file is written");
+    jackdaw::asset_index::rescan_asset_index(app.world_mut());
+    app.update();
+    app.world()
+        .resource::<AssetIndex>()
+        .get(Path::new(relative))
+        .and_then(|entry| entry.value.handle())
+        .expect("the walk indexed the material")
+        .clone()
+        .typed::<StandardMaterial>()
+}
+
+/// Write a scene naming one material, open it, and emit it again.
+fn round_trip_scene(app: &mut App, tmp: &tempfile::TempDir, reference: &str) -> String {
+    let scene = tmp.path().join("assets/zone.bsn");
+    std::fs::create_dir_all(scene.parent().expect("a parent")).expect("the directory is made");
+    std::fs::write(
+        &scene,
+        format!("{} {{ material: \"{reference}\" }}\n", Painted::type_path()),
+    )
+    .expect("the scene is written");
+
+    jackdaw::scene_io::load_scene_from_file(app.world_mut(), &scene);
+    app.update();
+    jackdaw::scene_io::emit_bsn_scene_with_inline_assets(
+        app.world_mut(),
+        scene.parent().expect("a parent"),
+    )
+}
+
+fn painted_material(app: &mut App) -> Handle<StandardMaterial> {
+    let world = app.world_mut();
+    let mut query = world.query::<&Painted>();
+    query
+        .iter(world)
+        .next()
+        .expect("the scene spawned its painted entity")
+        .material
+        .clone()
+}
+
+#[test]
+fn a_scene_naming_a_material_by_name_saves_it_as_a_path() {
+    let (mut app, tmp) = editor_with_outfits();
+    let filed = file_material(&mut app, "materials/slate.material.bsn");
+
+    let text = round_trip_scene(&mut app, &tmp, "@slate");
+
+    assert_eq!(
+        painted_material(&mut app),
+        filed,
+        "the name resolves to the file the index holds"
+    );
+    assert!(
+        text.contains("materials/slate.material.bsn"),
+        "the save spells the path:\n{text}"
+    );
+    assert!(!text.contains("@slate"), "got:\n{text}");
+}
+
+#[test]
+fn a_scene_referencing_an_asset_outside_the_materials_folder_round_trips() {
+    let (mut app, tmp) = editor_with_outfits();
+    let filed = file_material(&mut app, "content/ground/slate.bsn");
+
+    let text = round_trip_scene(&mut app, &tmp, "content/ground/slate.bsn");
+
+    assert_eq!(
+        painted_material(&mut app),
+        filed,
+        "a path outside the materials folder names the file it points at"
+    );
+    assert!(
+        text.contains("content/ground/slate.bsn"),
+        "the save spells the same path:\n{text}"
+    );
+}
+
+#[test]
+fn a_name_two_files_share_is_kept_rather_than_pointed_at_either() {
+    let (mut app, tmp) = editor_with_outfits();
+    let filed = file_material(&mut app, "materials/slate.material.bsn");
+    let other = file_material(&mut app, "content/slate.material.bsn");
+    assert_ne!(filed, other, "two files, two materials");
+
+    let text = round_trip_scene(&mut app, &tmp, "@slate");
+
+    let painted = painted_material(&mut app);
+    assert!(
+        painted != filed && painted != other,
+        "an ambiguous name names neither file"
+    );
+    assert!(
+        text.contains("@slate"),
+        "and the save keeps what the file said:\n{text}"
+    );
+}
+
+#[test]
+fn a_reference_the_editor_cannot_resolve_survives_the_save() {
+    let (mut app, tmp) = editor_with_outfits();
+
+    let text = round_trip_scene(&mut app, &tmp, "@ghost");
+
+    assert!(
+        text.contains("@ghost"),
+        "what the file said is kept rather than blanked:\n{text}"
+    );
+}
+
+#[test]
+fn asset_set_takes_a_material_path_and_still_takes_a_bare_name() {
+    let (mut app, _tmp) = editor_with_outfits();
+    let filed = file_material(&mut app, "materials/slate.material.bsn");
+
+    call(
+        &mut app,
+        "asset.new",
+        &[("type", "outfit".into()), ("name", "ranger".into())],
+    );
+    call(
+        &mut app,
+        "asset.set",
+        &[
+            ("field", "material".into()),
+            ("value", "materials/slate.material.bsn".into()),
+        ],
+    );
+    assert_eq!(
+        open_outfit(&app).material,
+        filed,
+        "a path assigns the handle the index loaded"
+    );
+
+    call(
+        &mut app,
+        "asset.set",
+        &[
+            ("field", "material".into()),
+            ("value", String::new().into()),
+        ],
+    );
+    call(
+        &mut app,
+        "asset.set",
+        &[("field", "material".into()), ("value", "slate".into())],
+    );
+    assert_eq!(
+        open_outfit(&app).material,
+        filed,
+        "and a bare name still resolves to the same file"
+    );
+
+    call(&mut app, "asset.save", &[]);
+    let written = std::fs::read_to_string(outfit_path(&app, "ranger.bsn")).expect("the file reads");
+    assert!(
+        written.contains("materials/slate.material.bsn"),
+        "the asset file spells the path:\n{written}"
+    );
+}
+
+#[test]
+fn undo_takes_a_material_field_back_to_the_path_it_held() {
+    let (mut app, _tmp) = editor_with_outfits();
+    let slate = file_material(&mut app, "materials/slate.material.bsn");
+    let moss = file_material(&mut app, "materials/moss.material.bsn");
+
+    call(
+        &mut app,
+        "asset.new",
+        &[("type", "outfit".into()), ("name", "ranger".into())],
+    );
+    call(
+        &mut app,
+        "asset.set",
+        &[
+            ("field", "material".into()),
+            ("value", "materials/slate.material.bsn".into()),
+        ],
+    );
+    call(
+        &mut app,
+        "asset.set",
+        &[
+            ("field", "material".into()),
+            ("value", "materials/moss.material.bsn".into()),
+        ],
+    );
+    assert_eq!(open_outfit(&app).material, moss);
+
+    app.world_mut().resource_scope(
+        |world, mut history: Mut<jackdaw_commands::CommandHistory>| {
+            history.undo(world);
+        },
+    );
+
+    assert_eq!(
+        open_outfit(&app).material,
+        slate,
+        "undo takes the field back to the path it held before"
+    );
+}
+
+#[test]
+fn material_apply_takes_the_path_of_a_material_file() {
+    use jackdaw::brush::{BrushEditMode, BrushSelection, EditMode};
+    use jackdaw::selection::Selection;
+    use jackdaw_scene_types::Brush;
+
+    let (mut app, _tmp) = editor_with_outfits();
+    let filed = file_material(&mut app, "materials/slate.material.bsn");
+    let brush = app
+        .world_mut()
+        .spawn((
+            Name::new("Wall"),
+            Brush::cuboid(0.5, 0.5, 0.5),
+            Transform::default(),
+            Visibility::default(),
+        ))
+        .id();
+    app.world_mut().resource_mut::<Selection>().entities = vec![brush];
+    *app.world_mut().resource_mut::<EditMode>() = EditMode::BrushEdit(BrushEditMode::Face);
+    {
+        let mut selection = app.world_mut().resource_mut::<BrushSelection>();
+        selection.active_brush = Some(brush);
+        selection.sub_mut(brush).faces = vec![0];
+    }
+    app.update();
+
+    call(
+        &mut app,
+        "material.apply",
+        &[("material", "materials/slate.material.bsn".into())],
+    );
+
+    assert_eq!(
+        app.world().get::<Brush>(brush).expect("the brush").faces[0]
+            .material
+            .clone(),
+        filed,
+        "the face draws the file the path names"
+    );
+}
+
+fn open_outfit(app: &App) -> OutfitDef {
+    let value =
+        jackdaw::definition_assets::open_definition_value(app.world()).expect("an asset is open");
+    let handle = value.handle().expect("a compiled asset").clone();
+    app.world()
+        .resource::<Assets<OutfitDef>>()
+        .get(&handle.typed::<OutfitDef>())
+        .expect("the asset is in its store")
+        .clone()
+}
+
+fn outfit_path(app: &App, relative: &str) -> PathBuf {
+    let root = &app.world().resource::<jackdaw::project::ProjectRoot>().root;
+    root.join("assets").join(Path::new(relative))
+}

--- a/tests/stage/main.rs
+++ b/tests/stage/main.rs
@@ -11,6 +11,7 @@ mod animation_graph;
 mod animation_library;
 mod animation_markers;
 mod animation_timeline;
+mod asset_references;
 mod brush_ops;
 mod canvas_guides;
 mod canvas_snap;


### PR DESCRIPTION
Scenes, prefabs, terrain slots and asset fields referenced materials and other assets by name, so two files could not share a stem and an unresolved reference was saved back as an empty string.

References are now the path of the file under assets. Old names still load for one release and come out as paths on the next save, an unresolved reference is kept as written, and terrain sidecars move to version 8 with paths in their slots.

LLM disclaimer: Claude Code was used to help plan and implement this change, but all code was human reviewed by myself!
