### PR TITLE
Load asset files by path in the runtime

### DIFF
--- a/book/src/developer-guide/bsn-format.md
+++ b/book/src/developer-guide/bsn-format.md
@@ -122,6 +122,44 @@ catalogs at `.jsn/catalog.jsn` or `assets/catalog.jsn` are read
 for migration and rewritten to `assets/catalog.bsn` on the
 next save.
 
+## Asset files in a game
+
+The runtime reads the project's asset files itself: at startup it walks
+every `.bsn` under the asset folder, takes the type each file holds
+from its header or its first root, and loads the ones whose type the
+game registered as a reflected asset into that type's store. A file is
+reachable by the path it sits at, and, while a project still spells
+references by name, by its stem where only one file carries that stem.
+A file naming a type the game has not registered is skipped with a
+warning; scenes and prefabs are left to the loaders that own them.
+
+This is a walk rather than a Bevy `AssetLoader` for `.bsn`, because a
+typed handle needs one loader per concrete asset type the game
+registers, while the walk is generic over reflection and matches the
+index the editor builds for the same folder. Loading a type
+asynchronously through the asset server can come later without changing
+how a file is written or referenced.
+
+A game that keeps its definitions as rows rather than as assets reads
+the same files directly:
+
+```rust,ignore
+use jackdaw_bsn::{read_asset_file, walk_asset_files};
+
+for (path, type_path) in walk_asset_files(Path::new("assets")) {
+    if type_path == ItemDef::type_path() {
+        let item: ItemDef = read_asset_file(&path)?;
+        items.insert(item.id.clone(), item);
+    }
+}
+```
+
+`walk_asset_files` yields one entry per asset file with the type it
+holds, leaving scenes and prefabs out. `read_asset_file` reads the
+value the file's first root holds, refusing a file whose root is
+another type; fields naming other assets by path stay at their
+defaults, since resolving those takes an asset server.
+
 ## What is not in BSN
 
 - Mesh data. Brushes serialize as their face planes; the mesh

--- a/crates/jackdaw_bsn/src/catalog.rs
+++ b/crates/jackdaw_bsn/src/catalog.rs
@@ -273,6 +273,18 @@ pub fn adopt_asset_roots(world: &mut World, source: &SceneBsnAst) -> Vec<String>
     dropped
 }
 
+/// Load the asset one document root holds into its `Assets<T>` store.
+pub fn load_asset_root(
+    world: &mut World,
+    ast: &SceneBsnAst,
+    root: bevy::ecs::entity::Entity,
+) -> Option<UntypedHandle> {
+    let (type_path, asset_value) = asset_value_from_root(ast, root)?;
+    let registry = world.resource::<AppTypeRegistry>().clone();
+    let reg = registry.read();
+    load_asset_value(world, &reg, &type_path, &asset_value)
+}
+
 /// Build one named asset from its document value and insert it into its
 /// `Assets<T>` store.
 fn load_asset_entry(
@@ -282,6 +294,20 @@ fn load_asset_entry(
     type_path: &str,
     asset_value: &BsnValue,
 ) -> Option<CatalogEntry> {
+    load_asset_value(world, reg, type_path, asset_value).map(|handle| CatalogEntry {
+        name: name.to_owned(),
+        handle,
+    })
+}
+
+/// Build one asset from its document value and insert it into its `Assets<T>`
+/// store.
+fn load_asset_value(
+    world: &mut World,
+    reg: &bevy::reflect::TypeRegistry,
+    type_path: &str,
+    asset_value: &BsnValue,
+) -> Option<UntypedHandle> {
     let registration = reg.get_with_type_path(type_path)?;
     let reflect_asset = registration.data::<ReflectAsset>()?;
     let type_id = registration.type_id();
@@ -292,11 +318,7 @@ fn load_asset_entry(
         local: None,
     });
     let value = bsn_value_to_reflect(asset_value, type_id, reg, assets_ctx.as_ref())?;
-    let handle = reflect_asset.add(world, &*value);
-    Some(CatalogEntry {
-        name: name.to_owned(),
-        handle,
-    })
+    Some(reflect_asset.add(world, &*value))
 }
 
 /// The type path and value a document root's first non-name patch names.

--- a/crates/jackdaw_bsn/src/header.rs
+++ b/crates/jackdaw_bsn/src/header.rs
@@ -1,17 +1,28 @@
-//! The header line an asset `.bsn` file carries, naming the reflect type it
-//! holds.
+//! What an asset `.bsn` file holds: the header line naming its reflect type,
+//! the walk that finds those files, and a reader for a game that wants the
+//! value rather than an asset.
 //!
 //! The header sits in the leading comment block, on the line after the
 //! version stamp when one is present. It is a hint for anything reading the
 //! file before it parses; the first document root's type is the truth.
 
-use bevy::ecs::entity::Entity;
+use std::any::TypeId;
+use std::path::{Path, PathBuf};
 
-use crate::SceneBsnAst;
+use bevy::ecs::entity::Entity;
+use bevy::reflect::{FromReflect, GetTypeRegistration, TypePath, TypeRegistry};
+
 use crate::catalog::asset_value_from_root;
+use crate::{BsnLoadError, SceneBsnAst, bsn_value_to_reflect, parse_bsn_text};
 
 /// The comment marker that introduces an asset file's type header.
 pub const ASSET_HEADER: &str = "// jackdaw asset ";
+
+/// The type path of the marker a prefab document's roots carry.
+pub const PREFAB_TYPE: &str = "jackdaw::prefab::components::Prefab";
+
+/// How deep under the assets directory a walk looks.
+const MAX_ASSET_DEPTH: usize = 12;
 
 /// Prepend the header naming the type an asset file holds.
 pub fn with_asset_header(type_path: &str, body: &str) -> String {
@@ -39,6 +50,171 @@ pub fn read_asset_header(text: &str) -> Option<String> {
 /// The type path a document root names, or `None` when the root names none.
 pub fn root_type_path(ast: &SceneBsnAst, root: Entity) -> Option<String> {
     asset_value_from_root(ast, root).map(|(type_path, _)| type_path)
+}
+
+/// The type a document names as the one it holds: [`PREFAB_TYPE`] for a
+/// document whose roots carry the prefab marker, else its first root's type.
+/// `None` for a document that spawns a hierarchy rather than holding one value.
+pub fn document_type_path(text: &str) -> Option<String> {
+    let ast = parse_bsn_text(text).ok()?;
+    if text.contains(PREFAB_TYPE)
+        && ast
+            .roots
+            .iter()
+            .any(|&root| ast.find_patch_by_type_path(root, PREFAB_TYPE).is_some())
+    {
+        return Some(PREFAB_TYPE.to_string());
+    }
+    let root = *ast.roots.first()?;
+    if !ast.get_children_ast(root).is_empty() {
+        return None;
+    }
+    root_type_path(&ast, root)
+}
+
+/// The type the `.bsn` file at `path` holds, taken from its first root and
+/// from its header only where the document names no type of its own.
+pub fn asset_file_type(path: &Path) -> Option<String> {
+    if !path
+        .extension()
+        .and_then(|extension| extension.to_str())
+        .is_some_and(|extension| extension.eq_ignore_ascii_case("bsn"))
+    {
+        return None;
+    }
+    let text = std::fs::read_to_string(path).ok()?;
+    asset_text_type(&text, path)
+}
+
+/// [`asset_file_type`] over text already in hand, `path` naming it in the
+/// warning a header that disagrees with the document earns.
+pub fn asset_text_type(text: &str, path: &Path) -> Option<String> {
+    let header = read_asset_header(text);
+    let Some(found) = document_type_path(text) else {
+        return header;
+    };
+    if let Some(header) = header.filter(|header| *header != found) {
+        log::warn!(
+            "{} says it holds a {header} but its first root is a {found}; going by the root",
+            path.display()
+        );
+    }
+    Some(found)
+}
+
+/// Every `.bsn` and `.jsn` file under `dir`, as absolute paths, skipping
+/// hidden directories and following no symlink out of the tree.
+pub fn walk_document_files(dir: &Path) -> Vec<PathBuf> {
+    let mut found = Vec::new();
+    collect_document_files(dir, 0, &mut found);
+    found.sort();
+    found
+}
+
+fn collect_document_files(dir: &Path, depth: usize, found: &mut Vec<PathBuf>) {
+    if depth > MAX_ASSET_DEPTH {
+        return;
+    }
+    let Ok(entries) = std::fs::read_dir(dir) else {
+        return;
+    };
+    for entry in entries.flatten() {
+        let path = entry.path();
+        let name = entry.file_name();
+        let name = name.to_string_lossy();
+        if name.starts_with('.') {
+            continue;
+        }
+        let Ok(file_type) = entry.file_type() else {
+            continue;
+        };
+        if file_type.is_symlink() {
+            continue;
+        }
+        if file_type.is_dir() {
+            collect_document_files(&path, depth + 1, found);
+        } else if path
+            .extension()
+            .and_then(|extension| extension.to_str())
+            .is_some_and(|extension| {
+                extension.eq_ignore_ascii_case("bsn") || extension.eq_ignore_ascii_case("jsn")
+            })
+        {
+            found.push(path);
+        }
+    }
+}
+
+/// Every asset file under `assets_root`, as the path it sits at and the type
+/// it holds. Scenes and prefabs are not asset files and are left out.
+pub fn walk_asset_files(assets_root: &Path) -> impl Iterator<Item = (PathBuf, String)> {
+    walk_document_files(assets_root)
+        .into_iter()
+        .filter_map(|path| {
+            let type_path = asset_file_type(&path)?;
+            (type_path != PREFAB_TYPE).then_some((path, type_path))
+        })
+}
+
+/// Why an asset file did not read as the value it was asked for.
+#[derive(Debug, thiserror::Error)]
+pub enum AssetFileError {
+    #[error("failed to read {}: {}", .0.display(), .1)]
+    Read(PathBuf, std::io::Error),
+    #[error("failed to parse {}: {}", .0.display(), .1)]
+    Parse(PathBuf, BsnLoadError),
+    #[error("{} holds no value", .0.display())]
+    Empty(PathBuf),
+    #[error("{} holds a {found}, not a {expected}", .path.display())]
+    WrongType {
+        path: PathBuf,
+        expected: String,
+        found: String,
+    },
+    #[error("{} does not read as a {}", .0.display(), .1)]
+    Unreadable(PathBuf, String),
+}
+
+/// Read the one value an asset file holds, for a game that keeps its
+/// definitions as rows rather than in an `Assets<T>` store.
+///
+/// The header is checked when the file carries one, the document's first root
+/// is the value, and fields naming other assets by path are left at their
+/// defaults, since resolving those takes an asset server.
+pub fn read_asset_file<T>(path: &Path) -> Result<T, AssetFileError>
+where
+    T: FromReflect + TypePath + GetTypeRegistration,
+{
+    let expected = T::type_path();
+    let text = std::fs::read_to_string(path)
+        .map_err(|err| AssetFileError::Read(path.to_path_buf(), err))?;
+    if let Some(header) = read_asset_header(&text).filter(|header| header != expected) {
+        return Err(AssetFileError::WrongType {
+            path: path.to_path_buf(),
+            expected: expected.to_string(),
+            found: header,
+        });
+    }
+    let ast =
+        parse_bsn_text(&text).map_err(|err| AssetFileError::Parse(path.to_path_buf(), err))?;
+    let root = *ast
+        .roots
+        .first()
+        .ok_or_else(|| AssetFileError::Empty(path.to_path_buf()))?;
+    let (found, value) = asset_value_from_root(&ast, root)
+        .ok_or_else(|| AssetFileError::Empty(path.to_path_buf()))?;
+    if found != expected {
+        return Err(AssetFileError::WrongType {
+            path: path.to_path_buf(),
+            expected: expected.to_string(),
+            found,
+        });
+    }
+    let mut registry = TypeRegistry::default();
+    registry.register::<T>();
+    bsn_value_to_reflect(&value, TypeId::of::<T>(), &registry, None)
+        .and_then(|reflected| T::from_reflect(&*reflected))
+        .ok_or_else(|| AssetFileError::Unreadable(path.to_path_buf(), expected.to_string()))
 }
 
 #[cfg(test)]
@@ -91,5 +267,103 @@ mod tests {
             root_type_path(&ast, root).as_deref(),
             Some("my_game::content::ItemDef")
         );
+    }
+
+    /// A game's own definition type, of the shape a game keeps as rows.
+    #[derive(bevy::reflect::Reflect, Default, Debug, PartialEq)]
+    #[type_path = "my_game::content"]
+    struct ItemDef {
+        damage: f32,
+        name: String,
+    }
+
+    fn write(dir: &Path, relative: &str, text: &str) -> PathBuf {
+        let path = dir.join(relative);
+        std::fs::create_dir_all(path.parent().expect("a parent directory")).expect("dir");
+        std::fs::write(&path, text).expect("the file is written");
+        path
+    }
+
+    #[test]
+    fn an_asset_file_reads_back_as_the_value_it_holds() {
+        let dir = tempfile::tempdir().expect("tempdir");
+        let path = write(
+            dir.path(),
+            "content/items/torch.bsn",
+            &with_asset_header(
+                "my_game::content::ItemDef",
+                "#torch\nmy_game::content::ItemDef { damage: 3.0, name: \"Torch\" }\n",
+            ),
+        );
+
+        let item = read_asset_file::<ItemDef>(&path).expect("the file reads as an item");
+
+        assert_eq!(
+            item,
+            ItemDef {
+                damage: 3.0,
+                name: "Torch".to_string(),
+            }
+        );
+    }
+
+    #[test]
+    fn an_asset_file_whose_root_carries_no_name_still_reads() {
+        let dir = tempfile::tempdir().expect("tempdir");
+        let path = write(
+            dir.path(),
+            "content/items/lamp.bsn",
+            &with_asset_header(
+                "my_game::content::ItemDef",
+                "my_game::content::ItemDef { damage: 1.0, name: \"Lamp\" }\n",
+            ),
+        );
+
+        let item = read_asset_file::<ItemDef>(&path).expect("the file reads as an item");
+
+        assert_eq!(item.name, "Lamp");
+    }
+
+    #[test]
+    fn a_file_holding_another_type_is_refused() {
+        let dir = tempfile::tempdir().expect("tempdir");
+        let path = write(
+            dir.path(),
+            "content/mobs/rat.bsn",
+            "#rat\nmy_game::content::MobDef { health: 12.0 }\n",
+        );
+
+        let refused = read_asset_file::<ItemDef>(&path);
+
+        assert!(
+            matches!(refused, Err(AssetFileError::WrongType { .. })),
+            "got {refused:?}"
+        );
+    }
+
+    #[test]
+    fn a_walk_lists_asset_files_with_their_types_and_leaves_scenes_and_prefabs_out() {
+        let dir = tempfile::tempdir().expect("tempdir");
+        write(
+            dir.path(),
+            "content/items/torch.bsn",
+            "#torch\nmy_game::content::ItemDef { damage: 3.0 }\n",
+        );
+        write(
+            dir.path(),
+            "zones/starter.bsn",
+            "#Root\nbevy_transform::components::transform::Transform\nbevy_ecs::hierarchy::Children [\n    bevy_transform::components::transform::Transform\n]\n",
+        );
+        write(
+            dir.path(),
+            "prefabs/tree.bsn",
+            "#tree\njackdaw::prefab::components::Prefab\nbevy_ecs::hierarchy::Children [\n    bevy_transform::components::transform::Transform\n]\n",
+        );
+
+        let found: Vec<(PathBuf, String)> = walk_asset_files(dir.path()).collect();
+
+        assert_eq!(found.len(), 1, "got {found:?}");
+        assert!(found[0].0.ends_with("content/items/torch.bsn"));
+        assert_eq!(found[0].1, "my_game::content::ItemDef");
     }
 }

--- a/crates/jackdaw_bsn/src/lib.rs
+++ b/crates/jackdaw_bsn/src/lib.rs
@@ -20,11 +20,15 @@ pub mod writer;
 
 pub use catalog::{
     CatalogAssetRef, CatalogEntry, LoadedBsnScene, adopt_asset_roots, append_assets_to_ast,
-    asset_roots, asset_value_from_root, entity_roots, is_asset_root, load_bsn_assets,
-    load_bsn_scene, serialize_assets_to_bsn, serialize_assets_to_bsn_reporting,
+    asset_roots, asset_value_from_root, entity_roots, is_asset_root, load_asset_root,
+    load_bsn_assets, load_bsn_scene, serialize_assets_to_bsn, serialize_assets_to_bsn_reporting,
 };
 
-pub use header::{ASSET_HEADER, read_asset_header, root_type_path, with_asset_header};
+pub use header::{
+    ASSET_HEADER, AssetFileError, PREFAB_TYPE, asset_file_type, asset_text_type,
+    document_type_path, read_asset_file, read_asset_header, root_type_path, walk_asset_files,
+    walk_document_files, with_asset_header,
+};
 
 pub use parse::{ParseError, parse_bsn};
 

--- a/crates/jackdaw_prefab/src/components.rs
+++ b/crates/jackdaw_prefab/src/components.rs
@@ -39,7 +39,7 @@ pub struct IsA {
 }
 
 /// Reflect type path of [`Prefab`], as scene documents spell it.
-pub const PREFAB_TYPE: &str = "jackdaw::prefab::components::Prefab";
+pub use jackdaw_bsn::PREFAB_TYPE;
 /// Reflect type path of [`PrefabEntityId`], as scene documents spell it.
 pub const PREFAB_ENTITY_ID_TYPE: &str = "jackdaw::prefab::components::PrefabEntityId";
 /// Reflect type path of [`IsA`], as scene documents spell it.

--- a/crates/jackdaw_runtime/src/lib.rs
+++ b/crates/jackdaw_runtime/src/lib.rs
@@ -34,9 +34,10 @@
 //!
 //! - `<scene>.bsn`: the scene, its entities and their components, plus inline
 //!   `#Name` assets.
-//! - `catalog.bsn` and `materials/<name>.material.bsn`: the project's named
-//!   assets, loaded at startup into [`JackdawCatalog`], which an `@Name`
-//!   reference in a scene resolves against.
+//! - Every `.bsn` under the asset folder that holds a registered asset type,
+//!   loaded at startup into [`JackdawCatalog`] under the path it sits at, and
+//!   under the `@Name` a reference written before paths spells. `catalog.bsn`
+//!   is read after them for the entries that have no file of their own.
 //! - `<scene>.terrain-<n>.jdterrain`: one terrain's heights, control map,
 //!   colors and material slots, named by the `Terrain` component's `data_path`
 //!   relative to the scene. Read under the `terrain` feature.
@@ -187,7 +188,7 @@ impl Plugin for JackdawPlugin {
             .init_asset_loader::<JackdawSceneLoader>()
             .init_resource::<JackdawCatalog>();
 
-        app.add_systems(Startup, load_project_catalog);
+        app.add_systems(Startup, load_asset_files);
         app.add_systems(
             Update,
             (
@@ -237,13 +238,13 @@ impl Plugin for JackdawPlugin {
 }
 
 /// Project-wide asset catalog. Maps the references found in scene files to
-/// loaded `UntypedHandle`s: the assets-relative path of a material file, and
-/// the `@Name` the same material was spelled by before references were paths.
+/// loaded `UntypedHandle`s: the assets-relative path of an asset file, and the
+/// `@Name` the same asset was spelled by before references were paths.
 ///
-/// Populated at startup from `assets/catalog.bsn` under the Bevy
-/// asset root (mirrors `FileAssetReader::get_base_path()`). To
-/// load from a different location, insert a [`JackdawCatalogPath`]
-/// resource before [`JackdawPlugin`] is built.
+/// Populated at startup by a walk of the asset root (mirrors
+/// `FileAssetReader::get_base_path()`) and then of `catalog.bsn`. To read from
+/// a different location, insert a [`JackdawCatalogPath`] resource before
+/// [`JackdawPlugin`] is built.
 #[derive(Resource, Default)]
 pub struct JackdawCatalog {
     handles: HashMap<String, UntypedHandle>,
@@ -257,9 +258,9 @@ impl JackdawCatalog {
         self.handles.get(name).or_else(|| self.files.get(name))
     }
 
-    /// Number of catalog entries (each `@Name`).
+    /// Number of references the catalog answers to.
     pub fn len(&self) -> usize {
-        self.handles.len()
+        self.handles.len() + self.files.len()
     }
 
     /// True when no catalog has been loaded.
@@ -268,9 +269,9 @@ impl JackdawCatalog {
     }
 }
 
-/// Optional override for catalog discovery. Insert this resource
-/// before [`JackdawPlugin`] to point the loader at an explicit
-/// `catalog.bsn` path instead of running the default discovery.
+/// Optional override for where the project's assets are read from. Insert this
+/// resource before [`JackdawPlugin`] to name an explicit `catalog.bsn`; its
+/// directory is the root the walk covers.
 #[derive(Resource, Clone, Debug)]
 pub struct JackdawCatalogPath(pub PathBuf);
 
@@ -1285,37 +1286,34 @@ fn promote_material_texture_formats(
     }
 }
 
-/// Suffix of a saved material file under `assets/materials`. The stem before
-/// it is the material's `@Name`.
-const MATERIAL_FILE_SUFFIX: &str = ".material.bsn";
+/// The file the project's remaining named assets are read from, under the
+/// asset root.
+const CATALOG_FILE: &str = "catalog.bsn";
 
-/// Where a saved material file sits, relative to the project's assets.
-const MATERIALS_DIR: &str = "materials";
-
-/// Startup system: discover the project catalog and populate
-/// [`JackdawCatalog`]. Honours [`JackdawCatalogPath`] if present;
-/// otherwise mirrors Bevy's `FileAssetReader::get_base_path()` to
-/// look for `assets/catalog.bsn` under the asset root.
+/// Startup system: read the project's asset files into [`JackdawCatalog`].
 ///
-/// Materials are one file each under `assets/materials`; the catalog file
-/// holds the remaining named assets. Both feed the same `@Name` map.
-fn load_project_catalog(world: &mut World) {
+/// Every `.bsn` under the asset root is sniffed for the type it holds, and one
+/// that holds a registered asset is loaded under the path it sits at and,
+/// while a project still spells references by name, under its stem. The
+/// entries `catalog.bsn` holds are read after the files, so a file wins the
+/// name it shares with one.
+///
+/// Honours [`JackdawCatalogPath`] if present; otherwise mirrors Bevy's
+/// `FileAssetReader::get_base_path()` to find the asset root.
+fn load_asset_files(world: &mut World) {
     let root = assets_root(world);
-    let Some(catalog_path) = world
+    let catalog_path = world
         .get_resource::<JackdawCatalogPath>()
-        .map(|p| p.0.clone())
-        .or_else(|| root.as_ref().map(|root| root.join("catalog.bsn")))
-    else {
-        return;
-    };
+        .map(|path| path.0.clone())
+        .or_else(|| root.as_ref().map(|root| root.join(CATALOG_FILE)));
 
-    // Materials first, so their linear-space textures claim their paths at the
-    // right color space and a saved material wins its name over any inline
-    // entry in the catalog file.
-    if let Some(root) = &root {
-        load_material_files(world, root);
+    if let Some(root) = root.clone() {
+        load_walked_assets(world, &root, catalog_path.as_deref());
     }
 
+    let Some(catalog_path) = catalog_path else {
+        return;
+    };
     if !catalog_path.is_file() {
         info!(
             "No catalog at {}, skipping catalog load",
@@ -1346,8 +1344,7 @@ fn load_project_catalog(world: &mut World) {
             let count = entries.len();
             let mut catalog = world.resource_mut::<JackdawCatalog>();
             for entry in entries {
-                // A material file already holding the name wins over the
-                // inline entry.
+                // A file already holding the name wins over the inline entry.
                 catalog
                     .handles
                     .entry(format!("@{}", entry.name))
@@ -1362,83 +1359,149 @@ fn load_project_catalog(world: &mut World) {
     }
 }
 
-/// Load every `assets/materials/*.material.bsn` into [`JackdawCatalog`] under
-/// the path that names it and under its file stem. A file that fails to read
-/// or parse is reported and skipped so one bad material never costs the rest.
-fn load_material_files(world: &mut World, root: &Path) {
-    let dir = root.join(MATERIALS_DIR);
-    let Ok(read_dir) = std::fs::read_dir(&dir) else {
-        return;
-    };
-    let mut files: Vec<PathBuf> = read_dir
-        .flatten()
-        .map(|entry| entry.path())
-        .filter(|path| {
-            path.file_name()
-                .and_then(|n| n.to_str())
-                .is_some_and(|n| n.ends_with(MATERIAL_FILE_SUFFIX))
-        })
-        .collect();
-    files.sort();
-
+/// Walk the asset files under `root` into [`JackdawCatalog`], skipping the
+/// catalog file, which is read as a document of its own.
+///
+/// The walk costs one parse per `.bsn`, which is what telling a file that
+/// holds an asset from one that spawns a scene takes.
+fn load_walked_assets(world: &mut World, root: &Path, catalog_path: Option<&Path>) {
+    let mut stems: HashMap<String, Vec<(String, UntypedHandle)>> = HashMap::new();
     let mut count = 0usize;
-    for path in files {
-        let Some(name) = path
-            .file_name()
-            .and_then(|n| n.to_str())
-            .and_then(|n| n.strip_suffix(MATERIAL_FILE_SUFFIX))
-            .map(str::to_owned)
-        else {
+
+    for path in jackdaw_bsn::walk_document_files(root) {
+        let is_bsn = path
+            .extension()
+            .and_then(|extension| extension.to_str())
+            .is_some_and(|extension| extension.eq_ignore_ascii_case("bsn"));
+        if !is_bsn || Some(path.as_path()) == catalog_path {
+            continue;
+        }
+        let Some(key) = assets_relative_key(root, &path) else {
             continue;
         };
-        let text = match std::fs::read_to_string(&path) {
-            Ok(text) => text,
-            Err(err) => {
-                warn!("Failed to read material {}: {err}", path.display());
-                continue;
-            }
+        let Some(handle) = load_asset_file(world, &path) else {
+            continue;
         };
+        let stem = file_stem_name(&path);
+        world
+            .resource_mut::<JackdawCatalog>()
+            .files
+            .insert(key.clone(), handle.clone());
+        stems.entry(stem).or_default().push((key, handle));
+        count += 1;
+    }
 
-        #[cfg(feature = "render")]
-        let _preloaded_textures = parse_bsn_text(&text)
-            .ok()
-            .map(|ast| preload_linear_textures(world, &ast))
-            .unwrap_or_default();
-
-        match load_bsn_assets(world, &text) {
-            Ok(entries) => {
-                if entries.len() > 1 {
-                    warn!(
-                        "{} holds {} assets; only the first is used",
-                        path.display(),
-                        entries.len()
-                    );
-                }
-                let Some(entry) = entries.into_iter().next() else {
-                    continue;
-                };
-                // `StandardMaterial` exists only in a rendering build; without
-                // one the type is unregistered and the document fails its own
-                // load rather than reaching this far.
-                #[cfg(feature = "render")]
-                if entry.handle.type_id() != TypeId::of::<StandardMaterial>() {
-                    warn!("{} is not a StandardMaterial", path.display());
-                    continue;
-                }
-                let mut catalog = world.resource_mut::<JackdawCatalog>();
-                catalog.files.insert(
-                    format!("{MATERIALS_DIR}/{name}{MATERIAL_FILE_SUFFIX}"),
-                    entry.handle.clone(),
-                );
-                catalog.handles.insert(format!("@{name}"), entry.handle);
-                count += 1;
+    let mut catalog = world.resource_mut::<JackdawCatalog>();
+    for (stem, found) in stems {
+        match found.as_slice() {
+            [(_, handle)] => {
+                catalog.handles.insert(format!("@{stem}"), handle.clone());
             }
-            Err(err) => warn!("Failed to parse material {}: {err}", path.display()),
+            [(first, _), (second, _), ..] => {
+                warn!("'{stem}' names both {first} and {second}; spell the one you mean as a path");
+            }
+            [] => {}
         }
     }
+
     if count > 0 {
-        info!("Loaded {count} saved materials from {}", dir.display());
+        info!("Loaded {count} asset files from {}", root.display());
     }
+}
+
+/// Load the asset the file at `path` holds, or nothing when it holds a scene,
+/// a prefab, or a type this app has not registered as an asset.
+fn load_asset_file(world: &mut World, path: &Path) -> Option<UntypedHandle> {
+    let text = match std::fs::read_to_string(path) {
+        Ok(text) => text,
+        Err(err) => {
+            warn!("Failed to read {}: {err}", path.display());
+            return None;
+        }
+    };
+    let ast = match parse_bsn_text(&text) {
+        Ok(ast) => ast,
+        Err(err) => {
+            warn!("Failed to parse {}: {err}", path.display());
+            return None;
+        }
+    };
+    let root = *ast.roots.first()?;
+    if !ast.get_children_ast(root).is_empty()
+        || ast
+            .find_patch_by_type_path(root, jackdaw_bsn::PREFAB_TYPE)
+            .is_some()
+    {
+        return None;
+    }
+    let type_path = jackdaw_bsn::root_type_path(&ast, root)
+        .or_else(|| jackdaw_bsn::read_asset_header(&text))?;
+
+    let registered = {
+        let registry = world.resource::<AppTypeRegistry>().read();
+        registry
+            .get_with_type_path(&type_path)
+            .map(|registration| registration.data::<ReflectAsset>().is_some())
+    };
+    match registered {
+        None => {
+            warn!(
+                "{} holds a {type_path}, which this app has not registered; skipping it",
+                path.display()
+            );
+            return None;
+        }
+        Some(false) => {
+            if jackdaw_bsn::read_asset_header(&text).is_some() {
+                warn!(
+                    "{} holds a {type_path}, which this app registered without register_asset_reflect; skipping it",
+                    path.display()
+                );
+            }
+            return None;
+        }
+        Some(true) => {}
+    }
+    if ast.roots.len() > 1 {
+        warn!(
+            "{} holds {} values; only the first answers to its path",
+            path.display(),
+            ast.roots.len()
+        );
+    }
+
+    // Held until the asset below takes its own strong references, so the
+    // textures it names are decoded in linear space.
+    #[cfg(feature = "render")]
+    let _preloaded_textures = preload_linear_textures(world, &ast);
+
+    jackdaw_bsn::load_asset_root(world, &ast, root)
+}
+
+/// Where a file sits under the asset root, as the reference a document spells
+/// it by: forward slashes, whatever the platform's separator is.
+fn assets_relative_key(root: &Path, path: &Path) -> Option<String> {
+    let relative = path.strip_prefix(root).ok()?;
+    let mut key = String::new();
+    for component in relative.components() {
+        if !key.is_empty() {
+            key.push('/');
+        }
+        key.push_str(component.as_os_str().to_str()?);
+    }
+    (!key.is_empty()).then_some(key)
+}
+
+/// The bare name a file's stem gives it: everything before the first dot of its
+/// file name, so `grass.material.bsn` is `grass`.
+fn file_stem_name(path: &Path) -> String {
+    path.file_name()
+        .and_then(|name| name.to_str())
+        .map_or_else(String::new, |name| {
+            name.split_once('.')
+                .map_or(name, |(stem, _)| stem)
+                .to_owned()
+        })
 }
 
 /// The folder Bevy reads assets from, as this app's [`AssetPlugin`] was
@@ -1491,10 +1554,18 @@ fn asset_folder(app: &App) -> Option<PathBuf> {
 }
 
 #[cfg(test)]
-mod material_file_tests {
+mod asset_file_tests {
     use super::*;
     use bevy::app::App;
     use bevy::asset::{AssetApp, AssetPlugin};
+
+    /// A game's own asset type, registered by the app rather than compiled
+    /// into the runtime.
+    #[derive(Asset, Reflect, Default)]
+    #[reflect(Default)]
+    struct Recipe {
+        steps: u32,
+    }
 
     fn runtime_app() -> App {
         let mut app = App::new();
@@ -1510,50 +1581,43 @@ mod material_file_tests {
     const GRASS: &str =
         "#grass\nbevy_pbr::pbr_material::StandardMaterial {\n    perceptual_roughness: 0.25,\n}\n";
 
+    fn write(root: &Path, relative: &str, text: &str) {
+        let path = root.join(relative);
+        std::fs::create_dir_all(path.parent().expect("a parent directory")).expect("dir");
+        std::fs::write(path, text).expect("write");
+    }
+
     #[test]
-    fn a_missing_materials_directory_is_not_an_error() {
+    fn a_missing_assets_directory_is_not_an_error() {
         let mut app = runtime_app();
         let tmp = tempfile::tempdir().expect("tempdir");
-        load_material_files(app.world_mut(), tmp.path());
+        load_walked_assets(app.world_mut(), &tmp.path().join("gone"), None);
         assert!(app.world().resource::<JackdawCatalog>().is_empty());
     }
 
     #[test]
-    fn material_files_populate_the_catalog_under_their_stem() {
+    fn an_asset_file_in_any_folder_answers_to_its_path() {
         let mut app = runtime_app();
         let tmp = tempfile::tempdir().expect("tempdir");
-        let dir = tmp.path().join("materials");
-        std::fs::create_dir_all(&dir).expect("dir");
-        std::fs::write(dir.join("grass.material.bsn"), GRASS).expect("write");
-        std::fs::write(dir.join("notes.txt"), "ignored").expect("write");
-        std::fs::write(
-            dir.join("wrong.material.bsn"),
-            "#wrong\nbevy_image::image::Image\n",
-        )
-        .expect("write");
+        write(tmp.path(), "content/props/grass.material.bsn", GRASS);
+        write(tmp.path(), "content/props/notes.txt", "ignored");
 
-        load_material_files(app.world_mut(), tmp.path());
+        load_walked_assets(app.world_mut(), tmp.path(), None);
 
-        assert_eq!(
-            app.world().resource::<Assets<Image>>().len(),
-            1,
-            "the non-material file must have parsed, so the rejection is the type check"
-        );
         let catalog = app.world().resource::<JackdawCatalog>();
-        assert_eq!(catalog.len(), 1);
-        assert!(catalog.get("@grass").is_some());
-        assert!(catalog.get("@wrong").is_none());
+        assert!(
+            catalog.get("content/props/grass.material.bsn").is_some(),
+            "a material outside the materials folder is still the project's"
+        );
     }
 
     #[test]
-    fn a_material_file_answers_to_the_path_that_names_it() {
+    fn an_asset_file_answers_to_the_name_its_stem_gives_it() {
         let mut app = runtime_app();
         let tmp = tempfile::tempdir().expect("tempdir");
-        let dir = tmp.path().join("materials");
-        std::fs::create_dir_all(&dir).expect("dir");
-        std::fs::write(dir.join("grass.material.bsn"), GRASS).expect("write");
+        write(tmp.path(), "materials/grass.material.bsn", GRASS);
 
-        load_material_files(app.world_mut(), tmp.path());
+        load_walked_assets(app.world_mut(), tmp.path(), None);
 
         let catalog = app.world().resource::<JackdawCatalog>();
         assert_eq!(
@@ -1566,14 +1630,110 @@ mod material_file_tests {
     }
 
     #[test]
-    fn a_material_file_outranks_an_inline_catalog_entry_of_the_same_name() {
+    fn two_files_of_one_stem_answer_by_path_and_neither_by_name() {
         let mut app = runtime_app();
         let tmp = tempfile::tempdir().expect("tempdir");
-        let dir = tmp.path().join("materials");
-        std::fs::create_dir_all(&dir).expect("dir");
-        std::fs::write(dir.join("grass.material.bsn"), GRASS).expect("write");
+        write(tmp.path(), "materials/grass.material.bsn", GRASS);
+        write(tmp.path(), "content/props/grass.bsn", GRASS);
 
-        load_material_files(app.world_mut(), tmp.path());
+        load_walked_assets(app.world_mut(), tmp.path(), None);
+
+        let catalog = app.world().resource::<JackdawCatalog>();
+        assert!(catalog.get("materials/grass.material.bsn").is_some());
+        assert!(catalog.get("content/props/grass.bsn").is_some());
+        assert!(
+            catalog.get("@grass").is_none(),
+            "an ambiguous name stands for neither file"
+        );
+    }
+
+    #[test]
+    fn an_asset_type_the_game_registered_is_loaded_into_its_store() {
+        let mut app = runtime_app();
+        app.init_asset::<Recipe>();
+        app.register_asset_reflect::<Recipe>();
+        let tmp = tempfile::tempdir().expect("tempdir");
+        let type_path = <Recipe as TypePath>::type_path();
+        write(
+            tmp.path(),
+            "content/recipes/stew.bsn",
+            &jackdaw_bsn::with_asset_header(type_path, &format!("{type_path} {{ steps: 4 }}\n")),
+        );
+
+        load_walked_assets(app.world_mut(), tmp.path(), None);
+
+        let handle = app
+            .world()
+            .resource::<JackdawCatalog>()
+            .get("content/recipes/stew.bsn")
+            .cloned()
+            .expect("the file is in the catalog");
+        let handle = handle.try_typed::<Recipe>().expect("a recipe handle");
+        assert_eq!(
+            app.world()
+                .resource::<Assets<Recipe>>()
+                .get(&handle)
+                .map(|recipe| recipe.steps),
+            Some(4)
+        );
+    }
+
+    #[test]
+    fn a_file_naming_a_type_the_game_did_not_register_is_skipped() {
+        let mut app = runtime_app();
+        let tmp = tempfile::tempdir().expect("tempdir");
+        write(
+            tmp.path(),
+            "content/items/torch.bsn",
+            "#torch\nmy_game::content::ItemDef { damage: 3.0 }\n",
+        );
+
+        load_walked_assets(app.world_mut(), tmp.path(), None);
+
+        assert!(app.world().resource::<JackdawCatalog>().is_empty());
+    }
+
+    #[test]
+    fn an_asset_type_registered_without_its_reflection_is_skipped() {
+        let mut app = runtime_app();
+        app.init_asset::<Recipe>();
+        app.register_type::<Recipe>();
+        let tmp = tempfile::tempdir().expect("tempdir");
+        let type_path = <Recipe as TypePath>::type_path();
+        write(
+            tmp.path(),
+            "content/recipes/stew.bsn",
+            &jackdaw_bsn::with_asset_header(type_path, &format!("{type_path} {{ steps: 4 }}\n")),
+        );
+
+        load_walked_assets(app.world_mut(), tmp.path(), None);
+
+        assert!(app.world().resource::<JackdawCatalog>().is_empty());
+        assert!(app.world().resource::<Assets<Recipe>>().is_empty());
+    }
+
+    #[test]
+    fn a_scene_file_is_not_taken_for_an_asset() {
+        let mut app = runtime_app();
+        let tmp = tempfile::tempdir().expect("tempdir");
+        write(
+            tmp.path(),
+            "zones/starter.bsn",
+            "#Root\nbevy_transform::components::transform::Transform\nbevy_ecs::hierarchy::Children [\n    bevy_transform::components::transform::Transform\n]\n",
+        );
+
+        load_walked_assets(app.world_mut(), tmp.path(), None);
+
+        assert!(app.world().resource::<JackdawCatalog>().is_empty());
+    }
+
+    #[test]
+    fn an_asset_file_outranks_an_inline_catalog_entry_of_the_same_name() {
+        let mut app = runtime_app();
+        let tmp = tempfile::tempdir().expect("tempdir");
+        write(tmp.path(), "materials/grass.material.bsn", GRASS);
+
+        load_walked_assets(app.world_mut(), tmp.path(), None);
         let from_file = app
             .world()
             .resource::<JackdawCatalog>()

--- a/crates/jackdaw_runtime/src/terrain.rs
+++ b/crates/jackdaw_runtime/src/terrain.rs
@@ -799,7 +799,7 @@ mod tests {
         app.register_asset_reflect::<Image>();
         app.register_asset_reflect::<StandardMaterial>();
         app.init_resource::<JackdawCatalog>();
-        crate::load_material_files(app.world_mut(), assets_root);
+        crate::load_walked_assets(app.world_mut(), assets_root, None);
         app
     }
 

--- a/crates/jackdaw_runtime/tests/catalog_loading.rs
+++ b/crates/jackdaw_runtime/tests/catalog_loading.rs
@@ -1,7 +1,7 @@
-//! `JackdawPlugin` loads `catalog.bsn` at `Startup` and exposes its named
-//! entries via the `JackdawCatalog` resource, keyed as `@Name`. Without this,
-//! scene fields like `material: "@bricks"` silently fall back to defaults at
-//! runtime.
+//! `JackdawPlugin` reads the project's asset files at `Startup` and exposes
+//! them through the `JackdawCatalog` resource, keyed by the path each file sits
+//! at and by the `@Name` the references written before paths spell. Without it,
+//! a scene field naming a material silently falls back to a default at runtime.
 
 use std::path::PathBuf;
 
@@ -96,18 +96,18 @@ struct Painted {
 }
 
 #[test]
-fn a_scene_reaches_a_material_by_the_path_of_its_file() {
+fn a_scene_reaches_a_material_in_any_folder_by_the_path_of_its_file() {
     let dir = unique_temp_dir("catalog-loading-path");
-    std::fs::create_dir_all(dir.join("materials")).unwrap();
+    std::fs::create_dir_all(dir.join("content/props")).unwrap();
     std::fs::write(
-        dir.join("materials/grass.material.bsn"),
+        dir.join("content/props/grass.bsn"),
         "#grass\nbevy_pbr::pbr_material::StandardMaterial {\n    perceptual_roughness: 0.25,\n}\n",
     )
     .unwrap();
     std::fs::write(
         dir.join("scene.bsn"),
         format!(
-            "{} {{ material: \"materials/grass.material.bsn\" }}\n",
+            "{} {{ material: \"content/props/grass.bsn\" }}\n",
             <Painted as TypePath>::type_path()
         ),
     )
@@ -148,8 +148,15 @@ fn a_scene_reaches_a_material_by_the_path_of_its_file() {
     assert_eq!(
         Some(painted.id().untyped()),
         catalog
-            .get("materials/grass.material.bsn")
+            .get("content/props/grass.bsn")
             .map(bevy::asset::UntypedHandle::id),
         "the path names the material the catalog loaded, not a fresh load of the document"
     );
+    assert_eq!(
+        Some(painted.id().untyped()),
+        catalog.get("@grass").map(bevy::asset::UntypedHandle::id),
+        "the name the file was spelled by before paths reaches the same material"
+    );
+
+    let _ = std::fs::remove_dir_all(&dir);
 }

--- a/src/asset_files.rs
+++ b/src/asset_files.rs
@@ -48,47 +48,14 @@ pub fn read_asset_kind(path: &Path, kinds: &AssetKinds) -> AssetFileKind {
 /// naming the marker its roots carry, and its header for a document that names
 /// nothing. `None` when neither names a type.
 pub fn read_file_type(path: &Path) -> Option<String> {
-    let extension = path
+    if path
         .extension()
         .and_then(|extension| extension.to_str())
-        .unwrap_or_default();
-    if extension.eq_ignore_ascii_case("jsn") {
+        .is_some_and(|extension| extension.eq_ignore_ascii_case("jsn"))
+    {
         return jsn_type(path);
     }
-    if !extension.eq_ignore_ascii_case("bsn") {
-        return None;
-    }
-    let text = std::fs::read_to_string(path).ok()?;
-    let header = jackdaw_bsn::read_asset_header(&text);
-    let Some(found) = document_type(&text) else {
-        return header;
-    };
-    if let Some(header) = header.filter(|header| *header != found) {
-        warn!(
-            "{} says it holds a {header} but its first root is a {found}; going by the root",
-            path.display()
-        );
-    }
-    Some(found)
-}
-
-/// The type a document's own first root names, or `None` for a document that
-/// spawns a hierarchy rather than holding one value.
-fn document_type(text: &str) -> Option<String> {
-    let ast = jackdaw_bsn::parse_bsn_text(text).ok()?;
-    if text.contains(PREFAB_TYPE)
-        && ast
-            .roots
-            .iter()
-            .any(|&root| ast.find_patch_by_type_path(root, PREFAB_TYPE).is_some())
-    {
-        return Some(PREFAB_TYPE.to_string());
-    }
-    let root = *ast.roots.first()?;
-    if !ast.get_children_ast(root).is_empty() {
-        return None;
-    }
-    jackdaw_bsn::root_type_path(&ast, root)
+    jackdaw_bsn::asset_file_type(path)
 }
 
 /// What a type path means to the editor: the marker a prefab carries, a kind
@@ -158,50 +125,7 @@ impl AssetKindCache {
     }
 }
 
-/// Every `.bsn` and `.jsn` file under `dir`, as absolute paths, skipping
-/// hidden directories and following no symlink out of the tree.
-pub fn walk_document_files(dir: &Path) -> Vec<PathBuf> {
-    let mut found = Vec::new();
-    collect_document_files(dir, 0, &mut found);
-    found.sort();
-    found
-}
-
-const MAX_ASSET_DEPTH: usize = 12;
-
-fn collect_document_files(dir: &Path, depth: usize, found: &mut Vec<PathBuf>) {
-    if depth > MAX_ASSET_DEPTH {
-        return;
-    }
-    let Ok(entries) = std::fs::read_dir(dir) else {
-        return;
-    };
-    for entry in entries.flatten() {
-        let path = entry.path();
-        let name = entry.file_name();
-        let name = name.to_string_lossy();
-        if name.starts_with('.') {
-            continue;
-        }
-        let Ok(file_type) = entry.file_type() else {
-            continue;
-        };
-        if file_type.is_symlink() {
-            continue;
-        }
-        if file_type.is_dir() {
-            collect_document_files(&path, depth + 1, found);
-        } else if path
-            .extension()
-            .and_then(|extension| extension.to_str())
-            .is_some_and(|extension| {
-                extension.eq_ignore_ascii_case("bsn") || extension.eq_ignore_ascii_case("jsn")
-            })
-        {
-            found.push(path);
-        }
-    }
-}
+pub use jackdaw_bsn::walk_document_files;
 
 #[cfg(test)]
 mod tests {


### PR DESCRIPTION
A built game found materials only in the materials folder under one suffix, and everything else only through catalog.bsn, so an asset the editor had filed elsewhere or of any other type was invisible in play.

At startup the runtime now walks every asset file under assets, loads the ones whose type the game registered as an asset, and keys them by path with the stem kept as an old spelling for one release. Games that read definition files as rows get read_asset_file and walk_asset_files.

LLM disclaimer: Claude Code was used to help plan and implement this change, but all code was human reviewed by myself!
