### PR TITLE
Many brush tweaks/fixes 

### DIFF
--- a/crates/jackdaw_avian_integration/src/lib.rs
+++ b/crates/jackdaw_avian_integration/src/lib.rs
@@ -11,7 +11,7 @@ use std::marker::PhantomData;
 use avian3d::debug_render::{PhysicsGizmoExt, PhysicsGizmos};
 use avian3d::prelude::*;
 use bevy::prelude::*;
-use jackdaw_geometry::{ModifierStack, is_convex_topology};
+use jackdaw_geometry::{ModifierStack, is_convex_topology, triangulate_polygons};
 use jackdaw_scene_types::{Brush, evaluate_brush_geometry};
 
 pub mod simulation;
@@ -98,7 +98,7 @@ pub fn brush_collider(
         return Collider::try_from_constructor(cfg.0.clone(), None);
     }
 
-    let (vertices, face_polygons, _) = evaluate_brush_geometry(brush, stack);
+    let (vertices, face_polygons, faces) = evaluate_brush_geometry(brush, stack);
     if vertices.is_empty() {
         return None;
     }
@@ -107,12 +107,11 @@ pub fn brush_collider(
         return Collider::convex_hull(vertices);
     }
 
-    let mut indices: Vec<[u32; 3]> = Vec::new();
-    for polygon in &face_polygons {
-        for i in 1..polygon.len().saturating_sub(1) {
-            indices.push([polygon[0] as u32, polygon[i] as u32, polygon[i + 1] as u32]);
-        }
-    }
+    let indices = triangulate_polygons(
+        &vertices,
+        &face_polygons,
+        faces.iter().map(|f| f.plane.normal),
+    );
     if indices.is_empty() {
         return None;
     }

--- a/crates/jackdaw_avian_integration/src/lib.rs
+++ b/crates/jackdaw_avian_integration/src/lib.rs
@@ -139,7 +139,7 @@ pub struct PhysicsOverlayConfig {
 impl Default for PhysicsOverlayConfig {
     fn default() -> Self {
         Self {
-            show_colliders: true,
+            show_colliders: false,
             show_hierarchy_arrows: false,
         }
     }

--- a/crates/jackdaw_avian_integration/src/lib.rs
+++ b/crates/jackdaw_avian_integration/src/lib.rs
@@ -129,20 +129,10 @@ pub mod physics_colors {
 }
 
 #[cfg(feature = "overlays")]
-#[derive(Resource, Clone, PartialEq)]
+#[derive(Resource, Clone, PartialEq, Default)]
 pub struct PhysicsOverlayConfig {
     pub show_colliders: bool,
     pub show_hierarchy_arrows: bool,
-}
-
-#[cfg(feature = "overlays")]
-impl Default for PhysicsOverlayConfig {
-    fn default() -> Self {
-        Self {
-            show_colliders: false,
-            show_hierarchy_arrows: false,
-        }
-    }
 }
 
 /// Plugin that renders collider wireframes and hierarchy arrows.

--- a/crates/jackdaw_geometry/src/lib.rs
+++ b/crates/jackdaw_geometry/src/lib.rs
@@ -28,7 +28,7 @@ pub mod newell;
 pub use newell::newell_normal;
 
 pub mod ray;
-pub use ray::ray_plane_intersection;
+pub use ray::{ray_axis_param, ray_plane_intersection};
 
 pub mod triangulate;
 pub use triangulate::{

--- a/crates/jackdaw_geometry/src/lib.rs
+++ b/crates/jackdaw_geometry/src/lib.rs
@@ -33,6 +33,7 @@ pub use ray::ray_plane_intersection;
 pub mod triangulate;
 pub use triangulate::{
     triangulate_face_polygon, triangulate_polygon, triangulate_polygon_with_holes,
+    triangulate_polygons,
 };
 
 pub mod topology_convexity;

--- a/crates/jackdaw_geometry/src/ray.rs
+++ b/crates/jackdaw_geometry/src/ray.rs
@@ -23,6 +23,30 @@ pub fn ray_plane_intersection(
     Some(origin + dir * t)
 }
 
+/// Signed distance along `axis_dir` from `axis_origin` to where the ray meets
+/// a camera-facing plane that contains the axis. `cam_pos` orients that plane.
+/// `axis_dir` need not be normalized. Returns `None` when the axis points at
+/// the camera (the plane is edge-on) or the ray misses.
+pub fn ray_axis_param(
+    ray_origin: Vec3,
+    ray_dir: Vec3,
+    axis_origin: Vec3,
+    axis_dir: Vec3,
+    cam_pos: Vec3,
+) -> Option<f32> {
+    let axis = axis_dir.normalize_or_zero();
+    if axis.length_squared() < 1e-12 {
+        return None;
+    }
+    let view = axis_origin - cam_pos;
+    let plane_normal = axis.cross(view.cross(axis)).normalize_or_zero();
+    if plane_normal.length_squared() < 1e-12 {
+        return None;
+    }
+    let hit = ray_plane_intersection(ray_origin, ray_dir, axis_origin, plane_normal)?;
+    Some((hit - axis_origin).dot(axis))
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;
@@ -48,6 +72,24 @@ mod tests {
         // The z = +2 plane lies behind a ray pointing -Z.
         let hit =
             ray_plane_intersection(Vec3::ZERO, Vec3::NEG_Z, Vec3::new(0.0, 0.0, 2.0), Vec3::Z);
+        assert!(hit.is_none());
+    }
+
+    #[test]
+    fn axis_param_projects_onto_x() {
+        // Camera on +Z looking at the origin. A ray through (2, 3, 0) meets
+        // the XY plane and projects to 2 along X, even though it is off-axis.
+        let cam = Vec3::new(0.0, 0.0, 10.0);
+        let target = Vec3::new(2.0, 3.0, 0.0);
+        let t = ray_axis_param(cam, target - cam, Vec3::ZERO, Vec3::X, cam)
+            .expect("ray hits the axis plane");
+        assert!((t - 2.0).abs() < 1e-4);
+    }
+
+    #[test]
+    fn axis_param_none_when_axis_points_at_camera() {
+        let cam = Vec3::new(0.0, 0.0, 10.0);
+        let hit = ray_axis_param(cam, Vec3::NEG_Z, Vec3::ZERO, Vec3::Z, cam);
         assert!(hit.is_none());
     }
 }

--- a/crates/jackdaw_geometry/src/triangulate.rs
+++ b/crates/jackdaw_geometry/src/triangulate.rs
@@ -65,6 +65,23 @@ pub fn triangulate_face_polygon(positions: &[Vec3], normal: Vec3) -> Vec<[u32; 3
     triangulate_polygon(positions, &ring, normal)
 }
 
+/// Earcut every face ring using the matching face-plane normal.
+pub fn triangulate_polygons(
+    vertices: &[Vec3],
+    polygons: &[Vec<usize>],
+    normals: impl IntoIterator<Item = Vec3>,
+) -> Vec<[u32; 3]> {
+    let mut indices = Vec::new();
+    for (polygon, normal) in polygons.iter().zip(normals) {
+        if polygon.len() < 3 {
+            continue;
+        }
+        let ring: Vec<u32> = polygon.iter().map(|&i| i as u32).collect();
+        indices.extend(triangulate_polygon(vertices, &ring, normal));
+    }
+    indices
+}
+
 /// Triangulate a polygon with one or more interior holes.
 ///
 /// `outer` and each entry in `holes` reference vertices in `positions` by

--- a/crates/jackdaw_scene_types/src/mesh_rebuild.rs
+++ b/crates/jackdaw_scene_types/src/mesh_rebuild.rs
@@ -104,15 +104,12 @@ pub fn mark_brushes_changed_on_modifier_removal(
 /// Evaluate a brush's geometry: authored topology rings (or plane intersection
 /// for legacy plane-only brushes) with the in-game modifier stack folded in.
 ///
-/// Returns the vertex positions, the per-face vertex-index rings, and the
-/// evaluated-to-authored face map. The face map is empty when no modifiers ran;
-/// otherwise it maps each evaluated face index back to its authored face index
-/// so callers can recover face data. Used by both the brush mesh build and the
-/// runtime collider bridge so the collision shape matches the rendered geometry.
+/// Returns vertex positions, per-face rings, and face data (mirrored copies
+/// get their plane recomputed from the reflected ring).
 pub fn evaluate_brush_geometry(
     brush: &Brush,
     stack: Option<&jackdaw_geometry::ModifierStack>,
-) -> (Vec<Vec3>, Vec<Vec<usize>>, Vec<u32>) {
+) -> (Vec<Vec3>, Vec<Vec<usize>>, Vec<crate::types::BrushFaceData>) {
     // Plane-intersection fallback for brushes without authored topology
     // (plane-only legacy data).
     let (vertices, face_polygons) = if !brush.topology.polygons.is_empty() {
@@ -125,10 +122,6 @@ pub fn evaluate_brush_geometry(
         compute_brush_geometry_from_planes(&brush.faces)
     };
 
-    // Fold the game-enabled modifiers (the `in_game` entries) over the
-    // authored geometry: evaluated copies append after the authored elements.
-    // Authored indices are unchanged (identity prefix); face_source maps
-    // evaluated face indices back to authored face indices for face-data lookup.
     let game_mods: Vec<&jackdaw_geometry::Modifier> = stack
         .map(|s| {
             s.modifiers
@@ -139,7 +132,7 @@ pub fn evaluate_brush_geometry(
         })
         .unwrap_or_default();
     if game_mods.is_empty() {
-        (vertices, face_polygons, Vec::new())
+        (vertices, face_polygons, brush.faces.clone())
     } else {
         let eval = jackdaw_geometry::evaluate_modifier_stack(
             &vertices,
@@ -147,7 +140,13 @@ pub fn evaluate_brush_geometry(
             &brush.faces,
             &game_mods,
         );
-        (eval.vertices, eval.face_polygons, eval.face_source)
+        let faces = jackdaw_geometry::resolve_evaluated_faces(
+            &eval.face_source,
+            &eval.vertices,
+            &eval.face_polygons,
+            &brush.faces,
+        );
+        (eval.vertices, eval.face_polygons, faces)
     }
 }
 
@@ -160,21 +159,7 @@ fn build_brush_meshes(
     materials: &mut Assets<StandardMaterial>,
     assets: &AssetServer,
 ) {
-    let (vertices, face_polygons, face_source) = evaluate_brush_geometry(brush, stack);
-
-    // Resolve the evaluated face data (mirrored polygons get their plane
-    // recomputed from the reflected ring) and mesh it into per-material chunks.
-    // `build_brush_chunks` is the shared editor / runtime build.
-    let evaluated_faces = if face_source.is_empty() {
-        brush.faces.clone()
-    } else {
-        jackdaw_geometry::resolve_evaluated_faces(
-            &face_source,
-            &vertices,
-            &face_polygons,
-            &brush.faces,
-        )
-    };
+    let (vertices, face_polygons, evaluated_faces) = evaluate_brush_geometry(brush, stack);
     let chunks = crate::build_brush_chunks(&vertices, &face_polygons, &evaluated_faces);
 
     let mut fallback_material: Option<Handle<StandardMaterial>> = None;

--- a/src/brush/interaction.rs
+++ b/src/brush/interaction.rs
@@ -136,37 +136,28 @@ pub(crate) struct VertexDragState {
 
 /// Compute a local-space offset for brush vertex/edge drag based on mouse
 /// movement. `anchor_world` is the world position of the dragged element;
-/// the pixels-per-world calibration happens at its depth so the drag tracks
-/// the cursor exactly, even when the element is far from the brush origin.
+/// the cursor ray meets a plane through that point so the drag tracks the
+/// pointer under perspective.
 pub(crate) fn compute_brush_drag_offset(
     constraint: VertexDragConstraint,
-    mouse_delta: Vec2,
+    start_cursor: Vec2,
+    current_cursor: Vec2,
     cam_tf: &GlobalTransform,
     camera: &Camera,
     brush_global: &GlobalTransform,
     anchor_world: Vec3,
 ) -> Option<Vec3> {
-    // Calibrate cursor pixels to world units against the live projection by
-    // measuring how many screen pixels one world unit spans at the dragged
-    // element's depth. Keeps the drag cursor-locked at any zoom or scale.
-    let origin_screen = camera.world_to_viewport(cam_tf, anchor_world).ok()?;
-
+    let (_, brush_rot, _) = brush_global.to_scale_rotation_translation();
     let offset = match constraint {
         VertexDragConstraint::Free => {
-            let cam_right = cam_tf.right().as_vec3();
-            let cam_up = cam_tf.up().as_vec3();
-            let right_screen = camera
-                .world_to_viewport(cam_tf, anchor_world + cam_right)
-                .ok()?;
-            let up_screen = camera
-                .world_to_viewport(cam_tf, anchor_world + cam_up)
-                .ok()?;
-            let px_per_world_x = (right_screen - origin_screen).length().max(1e-4);
-            let px_per_world_y = (up_screen - origin_screen).length().max(1e-4);
-            // Screen Y grows downward, so a downward cursor move is -up.
-            let world_offset = cam_right * (mouse_delta.x / px_per_world_x)
-                + cam_up * (-mouse_delta.y / px_per_world_y);
-            let (_, brush_rot, _) = brush_global.to_scale_rotation_translation();
+            let world_offset = crate::viewport_util::drag_on_plane(
+                camera,
+                cam_tf,
+                start_cursor,
+                current_cursor,
+                anchor_world,
+                cam_tf.forward().as_vec3(),
+            )?;
             brush_rot.inverse() * world_offset
         }
         constraint => {
@@ -176,18 +167,16 @@ pub(crate) fn compute_brush_drag_offset(
                 VertexDragConstraint::AxisZ => Vec3::Z,
                 VertexDragConstraint::Free => unreachable!(),
             };
-            let (_, brush_rot, _) = brush_global.to_scale_rotation_translation();
             let world_axis = brush_rot * axis_dir;
-            let axis_screen = camera
-                .world_to_viewport(cam_tf, anchor_world + world_axis)
-                .ok()?;
-            let screen_axis = axis_screen - origin_screen;
-            let px_per_world = screen_axis.length();
-            if px_per_world < 1e-4 {
-                return Some(Vec3::ZERO);
-            }
-            let projected_px = mouse_delta.dot(screen_axis / px_per_world);
-            axis_dir * (projected_px / px_per_world)
+            let amount = crate::viewport_util::drag_along_axis(
+                camera,
+                cam_tf,
+                start_cursor,
+                current_cursor,
+                anchor_world,
+                world_axis,
+            )?;
+            axis_dir * amount
         }
     };
     Some(offset)

--- a/src/brush/interaction.rs
+++ b/src/brush/interaction.rs
@@ -68,6 +68,8 @@ pub(crate) struct BrushDragState {
     pub(crate) start_brush: Option<Brush>,
     pub(crate) start_cursor: Vec2,
     pub(crate) drag_face_normal: Vec3,
+    /// World-space centroid of the dragged face at gesture start.
+    pub(crate) drag_face_centroid: Vec3,
     /// World-space face polygon vertices for extend preview.
     pub extend_face_polygon: Vec<Vec3>,
     /// World-space face normal for extend preview.

--- a/src/brush/mesh.rs
+++ b/src/brush/mesh.rs
@@ -63,14 +63,14 @@ pub fn setup_default_materials(
     palette.default_material = materials.add(StandardMaterial {
         base_color: default_style::DEFAULT_MATERIAL_COLOR,
         base_color_texture: Some(grid_handle.clone()),
-        alpha_mode: AlphaMode::Blend,
+        alpha_mode: AlphaMode::Opaque,
         uv_transform: uv_tile,
         ..default()
     });
     palette.default_selected_material = materials.add(StandardMaterial {
         base_color: default_style::DEFAULT_MATERIAL_SELECTED_COLOR,
         base_color_texture: Some(grid_handle.clone()),
-        alpha_mode: AlphaMode::Blend,
+        alpha_mode: AlphaMode::Opaque,
         uv_transform: uv_tile,
         ..default()
     });

--- a/src/brush/mesh.rs
+++ b/src/brush/mesh.rs
@@ -418,6 +418,7 @@ pub fn regenerate_brush_meshes(
         commands.entity(entity).insert(BrushMeshCache {
             vertices,
             face_polygons,
+            face_normals: evaluated_faces.iter().map(|f| f.plane.normal).collect(),
             chunk_entities,
             face_source,
             vert_source,

--- a/src/brush/mirror_plane_ops.rs
+++ b/src/brush/mirror_plane_ops.rs
@@ -299,9 +299,20 @@ pub fn mirror_plane_drag(
     mut drag_state: ResMut<MirrorPlaneDragState>,
     modal: Option<Single<Entity, With<ActiveModalOperator>>>,
 ) -> OperatorResult {
+    let modal_running = modal.is_some();
+    if modal_running {
+        if mouse.just_pressed(MouseButton::Right) {
+            return OperatorResult::Cancelled;
+        }
+        if vp.cursor().is_none() || mouse.just_released(MouseButton::Left) {
+            clear_drag_state(&mut drag_state);
+            return OperatorResult::Finished;
+        }
+    }
+
     let cursor_pos = vp.cursor()?;
 
-    if modal.is_none() {
+    if !modal_running {
         // First invoke: grab the hovered handle and capture the baseline.
         let Some((entity, axis)) = hover.target else {
             return OperatorResult::Cancelled;
@@ -333,15 +344,6 @@ pub fn mirror_plane_drag(
         return OperatorResult::Running;
     }
 
-    // Subsequent invokes: RMB cancel, release commit, per-frame plane slide.
-    if mouse.just_pressed(MouseButton::Right) {
-        return OperatorResult::Cancelled;
-    }
-    if mouse.just_released(MouseButton::Left) {
-        clear_drag_state(&mut drag_state);
-        return OperatorResult::Finished;
-    }
-
     let (Some(entity), Some(camera_entity), Some(viewport_entity)) = (
         drag_state.entity,
         drag_state.camera_entity,
@@ -351,9 +353,7 @@ pub fn mirror_plane_drag(
     };
     let axis = drag_state.axis;
     let (camera, cam_tf) = vp.camera_for(camera_entity)?;
-    let Some(viewport_cursor) = vp.viewport_cursor_for(camera, viewport_entity, cursor_pos) else {
-        return OperatorResult::Running;
-    };
+    let viewport_cursor = vp.viewport_cursor_for(camera, viewport_entity, cursor_pos)?;
     let Ok((brush, brush_global, mut stack)) = brushes.get_mut(entity) else {
         return OperatorResult::Running;
     };

--- a/src/brush/mirror_plane_ops.rs
+++ b/src/brush/mirror_plane_ops.rs
@@ -189,10 +189,8 @@ fn axis_constraint(axis: usize) -> VertexDragConstraint {
 }
 
 /// World units that one cursor pixel spans along the brush-local `axis` at
-/// `anchor_world`, measured against the live projection the same way
-/// [`compute_brush_drag_offset`]'s axis branch calibrates the drag. Used to
-/// turn [`PLANE_SNAP_PIXELS`] into a world-space snap tolerance so the lock
-/// distance reads the same at any zoom or brush scale.
+/// `anchor_world`. Used to turn [`PLANE_SNAP_PIXELS`] into a world-space snap
+/// tolerance so the lock distance reads the same at any zoom or brush scale.
 fn world_per_pixel_along_axis(
     axis: usize,
     cam_tf: &GlobalTransform,
@@ -358,10 +356,10 @@ pub fn mirror_plane_drag(
         return OperatorResult::Running;
     };
 
-    let mouse_delta = viewport_cursor - drag_state.start_cursor;
     let Some(local_delta) = compute_brush_drag_offset(
         axis_constraint(axis),
-        mouse_delta,
+        drag_state.start_cursor,
+        viewport_cursor,
         cam_tf,
         camera,
         brush_global,

--- a/src/brush/mod.rs
+++ b/src/brush/mod.rs
@@ -49,6 +49,8 @@ pub struct BrushMeshCache {
     pub vertices: Vec<Vec3>,
     /// Per-face: ordered vertex indices into `vertices`.
     pub face_polygons: Vec<Vec<usize>>,
+    /// Plane normal for each evaluated face, parallel to `face_polygons`.
+    pub face_normals: Vec<Vec3>,
     /// Child entities rendering this brush, one per material chunk.
     pub chunk_entities: Vec<Entity>,
     /// Evaluated face index -> authored face index. Empty when no mirror is active (identity).

--- a/src/brush/topology_ops/loop_cut.rs
+++ b/src/brush/topology_ops/loop_cut.rs
@@ -88,9 +88,7 @@ pub(crate) fn brush_loop_cut(
 ) -> OperatorResult {
     // --- Cursor position ---
     // Use raw UI-space cursor so dragging outside the viewport panel
-    // doesn't cancel the modal (the bounds check in window_to_viewport_cursor
-    // returns None when the cursor leaves the UI node, cancelling the modal
-    // mid-drag).
+    // doesn't cancel the modal.
     let (camera, cam_tf) = camera_query.single()?;
     let cursor_pos = cursor.get()?;
 

--- a/src/brush_drag_ops.rs
+++ b/src/brush_drag_ops.rs
@@ -729,6 +729,8 @@ fn spawn_extruded_brush(
         let entity = world
             .spawn((Name::new("Brush"), brush, transform, Visibility::default()))
             .id();
+        crate::scene_io::register_entity_in_ast(world, entity);
+        crate::physics_brush_bridge::insert_default_brush_physics(world, entity);
 
         let selection = world.resource::<Selection>();
         let old_selected: Vec<Entity> = selection.entities.clone();

--- a/src/brush_drag_ops.rs
+++ b/src/brush_drag_ops.rs
@@ -484,32 +484,21 @@ pub fn brush_face_drag(
             .unwrap_or_default();
         match drag_state.extrude_mode {
             FaceExtrudeMode::Merge => {
-                // Calibrate pixels-per-world at the dragged face's start
-                // centroid, not the brush origin: perspective px-per-world is
-                // depth-dependent, and the local face normal must be rotated
-                // into world space so rotated brushes track the cursor too.
-                // Mirrors the Extend branch and `compute_brush_drag_offset`.
                 let (mut brush, brush_global) = params.brushes.get_mut(brush_entity)?;
                 let start = drag_state.start_brush.as_ref()?;
                 let (_, brush_rot, _) = brush_global.to_scale_rotation_translation();
                 let world_normal = (brush_rot * drag_state.drag_face_normal).normalize();
-                let Ok(origin_screen) =
-                    camera.world_to_viewport(cam_tf, drag_state.drag_face_centroid)
-                else {
+                let Some(drag_amount) = crate::viewport_util::drag_along_axis(
+                    camera,
+                    cam_tf,
+                    drag_state.start_cursor,
+                    viewport_cursor,
+                    drag_state.drag_face_centroid,
+                    world_normal,
+                )
+                .map(|amount| snap_translate(amount, &snap_settings, ctrl)) else {
                     return OperatorResult::Running;
                 };
-                let Ok(normal_screen) =
-                    camera.world_to_viewport(cam_tf, drag_state.drag_face_centroid + world_normal)
-                else {
-                    return OperatorResult::Running;
-                };
-                // Pixels per world unit along the face normal at this depth, so
-                // the push/pull tracks the cursor at any zoom or scale.
-                let screen_span = normal_screen - origin_screen;
-                let px_per_world = screen_span.length().max(1e-4);
-                let mouse_delta = viewport_cursor - drag_state.start_cursor;
-                let projected = mouse_delta.dot(screen_span / px_per_world);
-                let drag_amount = snap_translate(projected / px_per_world, &snap_settings, ctrl);
                 if let Ok(mut halfedge) = halfedge_q.get_mut(brush_entity) {
                     // HalfedgeMesh path: translate each selected face's ring vertices along the face normal.
                     let face_keys = halfedge.face_keys.clone();
@@ -592,20 +581,17 @@ pub fn brush_face_drag(
                 let face_centroid: Vec3 = drag_state.extend_face_polygon.iter().sum::<Vec3>()
                     / drag_state.extend_face_polygon.len() as f32;
                 let world_normal = drag_state.extend_face_normal;
-                let Ok(origin_screen) = camera.world_to_viewport(cam_tf, face_centroid) else {
+                let Some(depth) = crate::viewport_util::drag_along_axis(
+                    camera,
+                    cam_tf,
+                    drag_state.start_cursor,
+                    viewport_cursor,
+                    face_centroid,
+                    world_normal,
+                ) else {
                     return OperatorResult::Running;
                 };
-                let Ok(normal_screen) =
-                    camera.world_to_viewport(cam_tf, face_centroid + world_normal)
-                else {
-                    return OperatorResult::Running;
-                };
-                let screen_span = normal_screen - origin_screen;
-                let px_per_world = screen_span.length().max(1e-4);
-                let mouse_delta = viewport_cursor - drag_state.start_cursor;
-                let projected = mouse_delta.dot(screen_span / px_per_world);
-                drag_state.extend_depth =
-                    snap_translate(projected / px_per_world, &snap_settings, ctrl);
+                drag_state.extend_depth = snap_translate(depth, &snap_settings, ctrl);
             }
         }
     }
@@ -1064,7 +1050,6 @@ pub fn brush_vertex_drag(
     }
 
     if drag_state.active {
-        let mouse_delta = viewport_cursor - drag_state.start_cursor;
         let primary_start = drag_state
             .start_vertex_positions
             .first()
@@ -1072,7 +1057,8 @@ pub fn brush_vertex_drag(
             .unwrap_or(Vec3::ZERO);
         apply_shared_drag(
             drag_state.constraint,
-            mouse_delta,
+            drag_state.start_cursor,
+            viewport_cursor,
             primary_start,
             cam_tf,
             camera,
@@ -1380,7 +1366,6 @@ pub fn brush_edge_drag(
     }
 
     if drag_state.active {
-        let mouse_delta = viewport_cursor - drag_state.start_cursor;
         let primary_start = drag_state
             .start_edge_vertices
             .first()
@@ -1388,7 +1373,8 @@ pub fn brush_edge_drag(
             .unwrap_or(Vec3::ZERO);
         apply_shared_drag(
             drag_state.constraint,
-            mouse_delta,
+            drag_state.start_cursor,
+            viewport_cursor,
             primary_start,
             cam_tf,
             camera,
@@ -1483,7 +1469,7 @@ pub(crate) fn capture_edit_brushes(
     captures
 }
 
-/// Resolve the current mouse delta into a snapped world displacement and
+/// Resolve the current cursor into a snapped world displacement and
 /// broadcast it to every captured brush. Shared by the vertex and edge drag
 /// per-frame tails, which differ only in how `primary_start` (the local start
 /// position the free-drag snap rounds against) is sourced. Does nothing when
@@ -1491,7 +1477,8 @@ pub(crate) fn capture_edit_brushes(
 /// return.
 fn apply_shared_drag(
     constraint: VertexDragConstraint,
-    mouse_delta: Vec2,
+    start_cursor: Vec2,
+    current_cursor: Vec2,
     primary_start: Vec3,
     cam_tf: &GlobalTransform,
     camera: &Camera,
@@ -1503,11 +1490,11 @@ fn apply_shared_drag(
     halfedge_q: &mut Query<&mut crate::brush::BrushHalfedge>,
     mirrors: &Query<&jackdaw_geometry::ModifierStack>,
 ) {
-    // Calibrate the cursor-to-world scale at the dragged element's depth.
     let anchor_world = brush_global.transform_point(primary_start);
     let Some(local_offset) = compute_brush_drag_offset(
         constraint,
-        mouse_delta,
+        start_cursor,
+        current_cursor,
         cam_tf,
         camera,
         brush_global,

--- a/src/brush_drag_ops.rs
+++ b/src/brush_drag_ops.rs
@@ -212,10 +212,42 @@ pub fn brush_face_drag(
     mut halfedge_q: Query<&mut crate::brush::BrushHalfedge>,
     mut override_cursor: ResMut<OverrideCursor>,
 ) -> OperatorResult {
+    let modal_running = modal.is_some();
+    if modal_running {
+        if drag_state.active && mouse.just_pressed(MouseButton::Right) {
+            return OperatorResult::Cancelled;
+        }
+        if vp.cursor().is_none() || mouse.just_released(MouseButton::Left) {
+            if drag_state.active {
+                match drag_state.extrude_mode {
+                    FaceExtrudeMode::Merge => {}
+                    FaceExtrudeMode::Extend => {
+                        if drag_state.extend_depth.abs() > MIN_EXTRUDE_DEPTH {
+                            spawn_extruded_brush(
+                                &drag_state.extend_face_polygon,
+                                drag_state.extend_face_normal,
+                                drag_state.extend_depth,
+                                &mut commands,
+                            );
+                        }
+                    }
+                }
+            }
+            let was_quick = drag_state.quick_action;
+            clear_face_drag_state(&mut drag_state);
+            clear_grab_cursor(&mut override_cursor);
+            if was_quick {
+                *edit_mode = EditMode::Object;
+                brush_selection.clear();
+            }
+            return OperatorResult::Finished;
+        }
+    }
+
     let cursor_pos = vp.cursor()?;
     // First invoke uses the hovered viewport; subsequent invokes use
     // the captured one so the drag stays bound to its origin panel.
-    let (camera_entity, viewport_entity) = if modal.is_none() {
+    let (camera_entity, viewport_entity) = if !modal_running {
         let camera_entity = vp.camera_entity()?;
         let viewport_entity = vp.viewport_entity()?;
         (camera_entity, viewport_entity)
@@ -392,38 +424,7 @@ pub fn brush_face_drag(
         return OperatorResult::Running;
     }
 
-    // Subsequent invoke: handle right-click cancel, release commit,
-    // pending -> active promotion, and per-frame drag math.
-    if drag_state.active && mouse.just_pressed(MouseButton::Right) {
-        return OperatorResult::Cancelled;
-    }
-
-    if mouse.just_released(MouseButton::Left) {
-        if drag_state.active {
-            match drag_state.extrude_mode {
-                FaceExtrudeMode::Merge => {}
-                FaceExtrudeMode::Extend => {
-                    if drag_state.extend_depth.abs() > MIN_EXTRUDE_DEPTH {
-                        spawn_extruded_brush(
-                            &drag_state.extend_face_polygon,
-                            drag_state.extend_face_normal,
-                            drag_state.extend_depth,
-                            &mut commands,
-                        );
-                    }
-                }
-            }
-        }
-        let was_quick = drag_state.quick_action;
-        clear_face_drag_state(&mut drag_state);
-        clear_grab_cursor(&mut override_cursor);
-        if was_quick {
-            *edit_mode = EditMode::Object;
-            brush_selection.clear();
-        }
-        return OperatorResult::Finished;
-    }
-
+    // Subsequent invoke: pending -> active promotion, and per-frame drag math.
     if let Some(ref pending) = drag_state.pending
         && mouse.pressed(MouseButton::Left)
         && !drag_state.active
@@ -824,8 +825,20 @@ pub fn brush_vertex_drag(
     snap_settings: Res<SnapSettings>,
     mut override_cursor: ResMut<OverrideCursor>,
 ) -> OperatorResult {
+    let modal_running = modal.is_some();
+    if modal_running {
+        if drag_state.active && mouse.just_pressed(MouseButton::Right) {
+            return OperatorResult::Cancelled;
+        }
+        if vp.cursor().is_none() || mouse.just_released(MouseButton::Left) {
+            clear_vertex_drag_state(&mut drag_state);
+            clear_grab_cursor(&mut override_cursor);
+            return OperatorResult::Finished;
+        }
+    }
+
     let cursor_pos = vp.cursor()?;
-    let (camera_entity, viewport_entity) = if modal.is_none() {
+    let (camera_entity, viewport_entity) = if !modal_running {
         let camera_entity = vp.camera_entity()?;
         let viewport_entity = vp.viewport_entity()?;
         (camera_entity, viewport_entity)
@@ -977,7 +990,7 @@ pub fn brush_vertex_drag(
     let brush_entity = brush_selection.active_brush?;
     let brush_global = brush_transforms.get(brush_entity)?;
 
-    // Subsequent invokes: constraint cycling, RMB cancel, release commit, drag math.
+    // Subsequent invokes: constraint cycling and drag math.
     if drag_state.active {
         if modal_inputs.axis_x() {
             drag_state.constraint =
@@ -989,16 +1002,6 @@ pub fn brush_vertex_drag(
             drag_state.constraint =
                 toggle_constraint(drag_state.constraint, VertexDragConstraint::AxisZ);
         }
-    }
-
-    if drag_state.active && mouse.just_pressed(MouseButton::Right) {
-        return OperatorResult::Cancelled;
-    }
-
-    if mouse.just_released(MouseButton::Left) {
-        clear_vertex_drag_state(&mut drag_state);
-        clear_grab_cursor(&mut override_cursor);
-        return OperatorResult::Finished;
     }
 
     if let Some(ref pending) = drag_state.pending
@@ -1191,8 +1194,20 @@ pub fn brush_edge_drag(
     snap_settings: Res<SnapSettings>,
     mut override_cursor: ResMut<OverrideCursor>,
 ) -> OperatorResult {
+    let modal_running = modal.is_some();
+    if modal_running {
+        if drag_state.active && mouse.just_pressed(MouseButton::Right) {
+            return OperatorResult::Cancelled;
+        }
+        if vp.cursor().is_none() || mouse.just_released(MouseButton::Left) {
+            clear_edge_drag_state(&mut drag_state);
+            clear_grab_cursor(&mut override_cursor);
+            return OperatorResult::Finished;
+        }
+    }
+
     let cursor_pos = vp.cursor()?;
-    let (camera_entity, viewport_entity) = if modal.is_none() {
+    let (camera_entity, viewport_entity) = if !modal_running {
         let camera_entity = vp.camera_entity()?;
         let viewport_entity = vp.viewport_entity()?;
         (camera_entity, viewport_entity)
@@ -1305,16 +1320,6 @@ pub fn brush_edge_drag(
             drag_state.constraint =
                 toggle_constraint(drag_state.constraint, VertexDragConstraint::AxisZ);
         }
-    }
-
-    if drag_state.active && mouse.just_pressed(MouseButton::Right) {
-        return OperatorResult::Cancelled;
-    }
-
-    if mouse.just_released(MouseButton::Left) {
-        clear_edge_drag_state(&mut drag_state);
-        clear_grab_cursor(&mut override_cursor);
-        return OperatorResult::Finished;
     }
 
     if let Some(ref pending) = drag_state.pending

--- a/src/brush_drag_ops.rs
+++ b/src/brush_drag_ops.rs
@@ -446,6 +446,17 @@ pub fn brush_face_drag(
         match drag_state.extrude_mode {
             FaceExtrudeMode::Merge => {
                 drag_state.start_brush = Some(brush.clone());
+                if let Ok(cache) = params.brush_caches.get(brush_entity)
+                    && let Some(&face_idx) = active_faces.first()
+                    && let Some(polygon) = cache.face_polygons.get(face_idx)
+                    && !polygon.is_empty()
+                {
+                    drag_state.drag_face_centroid = polygon
+                        .iter()
+                        .map(|&vi| brush_global.transform_point(cache.vertices[vi]))
+                        .sum::<Vec3>()
+                        / polygon.len() as f32;
+                }
             }
             FaceExtrudeMode::Extend => {
                 let (_, brush_rot, _) = brush_global.to_scale_rotation_translation();
@@ -472,31 +483,22 @@ pub fn brush_face_drag(
             .unwrap_or_default();
         match drag_state.extrude_mode {
             FaceExtrudeMode::Merge => {
-                // Calibrate pixels-per-world at the dragged face in world space,
-                // not the brush origin: perspective px-per-world is depth-
-                // dependent, and the local face normal must be rotated into world
-                // space so rotated brushes track the cursor too. Mirrors the
-                // Extend branch and `compute_brush_drag_offset`.
-                let face_idx = drag_faces.first().copied()?;
-                let cache = params.brush_caches.get(brush_entity).ok()?;
-                let polygon = cache.face_polygons.get(face_idx)?;
-                if polygon.is_empty() {
-                    return OperatorResult::Running;
-                }
+                // Calibrate pixels-per-world at the dragged face's start
+                // centroid, not the brush origin: perspective px-per-world is
+                // depth-dependent, and the local face normal must be rotated
+                // into world space so rotated brushes track the cursor too.
+                // Mirrors the Extend branch and `compute_brush_drag_offset`.
                 let (mut brush, brush_global) = params.brushes.get_mut(brush_entity)?;
                 let start = drag_state.start_brush.as_ref()?;
                 let (_, brush_rot, _) = brush_global.to_scale_rotation_translation();
                 let world_normal = (brush_rot * drag_state.drag_face_normal).normalize();
-                let face_centroid: Vec3 = polygon
-                    .iter()
-                    .map(|&vi| brush_global.transform_point(cache.vertices[vi]))
-                    .sum::<Vec3>()
-                    / polygon.len() as f32;
-                let Ok(origin_screen) = camera.world_to_viewport(cam_tf, face_centroid) else {
+                let Ok(origin_screen) =
+                    camera.world_to_viewport(cam_tf, drag_state.drag_face_centroid)
+                else {
                     return OperatorResult::Running;
                 };
                 let Ok(normal_screen) =
-                    camera.world_to_viewport(cam_tf, face_centroid + world_normal)
+                    camera.world_to_viewport(cam_tf, drag_state.drag_face_centroid + world_normal)
                 else {
                     return OperatorResult::Running;
                 };
@@ -644,6 +646,7 @@ fn clear_face_drag_state(drag_state: &mut BrushDragState) {
     drag_state.extend_face_polygon.clear();
     drag_state.extend_depth = 0.0;
     drag_state.start_brush = None;
+    drag_state.drag_face_centroid = Vec3::ZERO;
     drag_state.quick_action = false;
     drag_state.drag_camera = None;
     drag_state.drag_viewport = None;

--- a/src/clip_ops.rs
+++ b/src/clip_ops.rs
@@ -11,12 +11,8 @@ use jackdaw_api::prelude::*;
 use jackdaw_api_internal::keymap::PresetInput;
 use jackdaw_scene_types::{Brush, BrushFaceData, BrushPlane};
 
-use crate::brush::{
-    BrushEditMode, BrushMeshCache, BrushSelection, ClipMode, ClipState, EditMode, SetBrush,
-};
-use crate::commands::{CommandGroup, CommandHistory};
+use crate::brush::{BrushEditMode, BrushMeshCache, BrushSelection, ClipMode, ClipState, EditMode};
 use crate::core_extension::CoreExtensionInputContext;
-use crate::draw_brush::{CreateBrushCommand, brush_data_from_entity};
 use crate::viewport::{ActiveViewport, MainViewportCamera, SceneViewport};
 use crate::viewport_util::window_to_viewport_cursor_for;
 use jackdaw_geometry::{
@@ -218,7 +214,6 @@ pub(crate) fn clip_clear(
                    (`can_apply_or_cycle`) requires clip mode and a computed \
                    preview plane.",
     is_available = can_apply_or_cycle,
-    allows_undo = false,
 )]
 pub(crate) fn clip_apply(
     _: In<OperatorParameters>,
@@ -226,7 +221,6 @@ pub(crate) fn clip_apply(
     mut brushes: Query<&mut Brush>,
     brush_transforms: Query<&GlobalTransform>,
     mut clip_state: ResMut<ClipState>,
-    mut history: ResMut<CommandHistory>,
     mut commands: Commands,
 ) -> OperatorResult {
     let brush_entity = brush_selection.active_brush?;
@@ -248,26 +242,14 @@ pub(crate) fn clip_apply(
                     warn!("Clip: bisect failed; aborting");
                     return OperatorResult::Cancelled;
                 };
-                push_brush_command(
-                    &mut history,
-                    brush_entity,
-                    &mut brush,
-                    new_brush,
-                    "Clip brush (keep front)",
-                );
+                apply_clip_geometry(&mut commands, brush_entity, &mut brush, new_brush);
             }
             ClipMode::KeepBack => {
                 let Some(new_brush) = bisect_brush(&brush, &plane, BisectKeep::Back) else {
                     warn!("Clip: bisect failed; aborting");
                     return OperatorResult::Cancelled;
                 };
-                push_brush_command(
-                    &mut history,
-                    brush_entity,
-                    &mut brush,
-                    new_brush,
-                    "Clip brush (keep back)",
-                );
+                apply_clip_geometry(&mut commands, brush_entity, &mut brush, new_brush);
             }
             ClipMode::Split => {
                 let Some(front) = bisect_brush(&brush, &plane, BisectKeep::Front) else {
@@ -278,15 +260,8 @@ pub(crate) fn clip_apply(
                     warn!("Clip: split bisect (back) failed; aborting");
                     return OperatorResult::Cancelled;
                 };
-                let old = brush.clone();
                 *brush = front.clone();
-                let set_cmd = SetBrush {
-                    entity: brush_entity,
-                    old,
-                    new: front,
-                    label: "Clip brush (split - front)".to_string(),
-                };
-                queue_split_spawn(&mut commands, brush_entity, brush_global, set_cmd, back);
+                queue_split_spawn(&mut commands, brush_entity, brush_global, front, back);
             }
         }
     } else {
@@ -299,22 +274,10 @@ pub(crate) fn clip_apply(
 
         match clip_state.mode {
             ClipMode::KeepFront => {
-                push_face_command(
-                    &mut history,
-                    brush_entity,
-                    &mut brush,
-                    clip_face,
-                    "Clip brush (keep front)",
-                );
+                apply_clip_face(&mut commands, brush_entity, &mut brush, clip_face);
             }
             ClipMode::KeepBack => {
-                push_face_command(
-                    &mut history,
-                    brush_entity,
-                    &mut brush,
-                    flipped_face,
-                    "Clip brush (keep back)",
-                );
+                apply_clip_face(&mut commands, brush_entity, &mut brush, flipped_face);
             }
             ClipMode::Split => {
                 let old = brush.clone();
@@ -323,14 +286,7 @@ pub(crate) fn clip_apply(
                 let mut back = old.clone();
                 back.faces.push(flipped_face);
                 *brush = front.clone();
-
-                let set_cmd = SetBrush {
-                    entity: brush_entity,
-                    old,
-                    new: front,
-                    label: "Clip brush (split - front)".to_string(),
-                };
-                queue_split_spawn(&mut commands, brush_entity, brush_global, set_cmd, back);
+                queue_split_spawn(&mut commands, brush_entity, brush_global, front, back);
             }
         }
     }
@@ -426,29 +382,23 @@ pub(crate) fn bisect_brush(brush: &Brush, plane: &BrushPlane, keep: BisectKeep) 
     })
 }
 
-fn push_brush_command(
-    history: &mut CommandHistory,
+fn apply_clip_geometry(
+    commands: &mut Commands,
     entity: Entity,
     brush: &mut Brush,
     new_brush: Brush,
-    label: &str,
 ) {
-    let old = brush.clone();
     *brush = new_brush.clone();
-    let cmd = SetBrush {
-        entity,
-        old,
-        new: new_brush,
-        label: label.to_string(),
-    };
-    history.push_executed(Box::new(cmd));
+    commands.queue(move |world: &mut World| {
+        crate::brush::sync_brush_to_ast(world, entity, &new_brush);
+    });
 }
 
 fn queue_split_spawn(
     commands: &mut Commands,
     brush_entity: Entity,
     brush_global: &GlobalTransform,
-    set_cmd: SetBrush,
+    front: Brush,
     back: Brush,
 ) {
     let (_, brush_rot, brush_trans) = brush_global.to_scale_rotation_translation();
@@ -467,30 +417,17 @@ fn queue_split_spawn(
         } else {
             spawn_transform
         };
-
-        let mut spawner = world.spawn((
-            Name::new("Brush"),
+        if crate::entity_ops::spawn_cloned_brush_with_geometry(
+            world,
+            brush_entity,
             back,
             actual_transform,
-            Visibility::default(),
-        ));
-        if let Some(parent) = parent {
-            spawner.insert(ChildOf(parent));
+        )
+        .is_none()
+        {
+            warn!("Clip split spawn failed: source {brush_entity:?} has no document node");
         }
-        let entity = spawner.id();
-        crate::scene_io::register_entity_in_ast(world, entity);
-        crate::physics_brush_bridge::insert_default_brush_physics(world, entity);
-
-        let create_cmd = CreateBrushCommand {
-            data: brush_data_from_entity(world, entity),
-        };
-        let group = CommandGroup {
-            commands: vec![Box::new(set_cmd), Box::new(create_cmd)],
-            label: "Split brush".to_string(),
-        };
-        world
-            .resource_mut::<CommandHistory>()
-            .push_executed(Box::new(group));
+        crate::brush::sync_brush_to_ast(world, brush_entity, &front);
     });
 }
 
@@ -507,20 +444,15 @@ fn clip_face_from_plane(plane: &BrushPlane) -> BrushFaceData {
     }
 }
 
-fn push_face_command(
-    history: &mut CommandHistory,
+fn apply_clip_face(
+    commands: &mut Commands,
     entity: Entity,
     brush: &mut Brush,
     face: BrushFaceData,
-    label: &str,
 ) {
-    let old = brush.clone();
     brush.faces.push(face);
-    let cmd = SetBrush {
-        entity,
-        old,
-        new: brush.clone(),
-        label: label.to_string(),
-    };
-    history.push_executed(Box::new(cmd));
+    let new_brush = brush.clone();
+    commands.queue(move |world: &mut World| {
+        crate::brush::sync_brush_to_ast(world, entity, &new_brush);
+    });
 }

--- a/src/clip_ops.rs
+++ b/src/clip_ops.rs
@@ -479,6 +479,7 @@ fn queue_split_spawn(
         }
         let entity = spawner.id();
         crate::scene_io::register_entity_in_ast(world, entity);
+        crate::physics_brush_bridge::insert_default_brush_physics(world, entity);
 
         let create_cmd = CreateBrushCommand {
             data: brush_data_from_entity(world, entity),

--- a/src/default_style.rs
+++ b/src/default_style.rs
@@ -128,8 +128,8 @@ pub const CAPTURE_ACCENT: Color = Color::srgb(1.0, 0.62, 0.1);
 pub const LIVE_HEADER_TINT: Color = Color::srgba(0.0, 0.667, 0.733, 0.15);
 
 // -- Brush default material variants --
-pub const DEFAULT_MATERIAL_COLOR: Color = Color::srgba(0.980, 0.8549, 0.3686, 0.5);
-pub const DEFAULT_MATERIAL_SELECTED_COLOR: Color = Color::srgba(0.980, 0.8549, 0.3686, 0.75);
+pub const DEFAULT_MATERIAL_COLOR: Color = Color::srgb(0.980, 0.8549, 0.3686);
+pub const DEFAULT_MATERIAL_SELECTED_COLOR: Color = Color::srgb(0.980, 0.8549, 0.3686);
 pub const X_RAY_MATERIAL_COLOR: Color = Color::srgba(0.65, 0.75, 0.9, 0.35);
 pub const X_RAY_MATERIAL_SELECTED_COLOR: Color = Color::srgba(1.0, 0.6, 0.2, 0.45);
 

--- a/src/draw_brush/build.rs
+++ b/src/draw_brush/build.rs
@@ -94,6 +94,7 @@ pub(crate) fn spawn_drawn_brush(active: &ActiveDraw, commands: &mut Commands) {
             .id();
 
         crate::scene_io::register_entity_in_ast(world, entity);
+        crate::physics_brush_bridge::insert_default_brush_physics(world, entity);
 
         let selection = world.resource::<Selection>();
         let old_selected: Vec<Entity> = selection.entities.clone();

--- a/src/draw_brush/csg_ops.rs
+++ b/src/draw_brush/csg_ops.rs
@@ -1,20 +1,17 @@
 use crate::commands::{
-    CommandGroup, CommandHistory, DespawnEntity, EditorCommand, collect_entity_ids,
-    deselect_entities, despawn_scene_entity,
+    CommandGroup, CommandHistory, DespawnEntity, EditorCommand, despawn_scene_entity,
 };
 use crate::draw_brush::{
-    ActiveDraw, BrushData, DrawBrushState, MIN_FRAGMENT_SIZE, brush_data_from_entity,
-    cut_brush_from_active, spawn_brush_from_data, topology_aabbs_overlap,
+    ActiveDraw, DrawBrushState, MIN_FRAGMENT_SIZE, cut_brush_from_active, topology_aabbs_overlap,
 };
 use crate::keybind_focus::KeybindFocus;
 use crate::prelude::*;
-use crate::scene_io::entity_by_scene_node_id;
 use crate::selection::{Selected, Selection};
 use bevy::prelude::*;
 use jackdaw_geometry::{
     clean_degenerate_faces, compute_brush_geometry_from_planes, compute_brush_topology,
 };
-use jackdaw_scene_types::{Brush, BrushFaceData, BrushPlane, SceneNodeId};
+use jackdaw_scene_types::{Brush, BrushFaceData, BrushPlane};
 
 struct SubtractionResult {
     original_entity: Entity,
@@ -40,44 +37,31 @@ fn parent_translations_of(
 fn spawn_subtract_fragments(
     world: &mut World,
     results: &[SubtractionResult],
-    originals: &[BrushData],
     parent_translations: &std::collections::HashMap<Entity, Vec3>,
-) -> Vec<BrushData> {
-    let fragment_node_ids: Vec<Vec<SceneNodeId>> = results
-        .iter()
-        .map(|result| {
-            result
-                .fragments
-                .iter()
-                .map(|_| SceneNodeId::next())
-                .collect()
-        })
-        .collect();
-
-    let mut fragments = Vec::new();
-    for (result_index, result) in results.iter().enumerate() {
-        let parent_node_id = originals
-            .get(result_index)
-            .and_then(|original| original.parent_node_id);
+) {
+    for result in results {
         let parent_translation = parent_translations.get(&result.original_entity);
-        for (fragment_index, (brush, transform)) in result.fragments.iter().enumerate() {
+        for (brush, transform) in &result.fragments {
             let local_transform = if let Some(parent_translation) = parent_translation {
                 Transform::from_translation(transform.translation - *parent_translation)
             } else {
                 *transform
             };
-            let brush_data = BrushData {
-                node_id: fragment_node_ids[result_index][fragment_index],
-                brush: brush.clone(),
-                transform: local_transform,
-                name: "Brush".to_string(),
-                parent_node_id,
-            };
-            spawn_brush_from_data(world, &brush_data);
-            fragments.push(brush_data);
+            if crate::entity_ops::spawn_cloned_brush_with_geometry(
+                world,
+                result.original_entity,
+                brush.clone(),
+                local_transform,
+            )
+            .is_none()
+            {
+                warn!(
+                    "CSG fragment spawn failed: source {:?} has no document node",
+                    result.original_entity
+                );
+            }
         }
     }
-    fragments
 }
 
 /// Perform CSG subtraction: subtract the drawn solid from all intersecting brushes.
@@ -297,18 +281,11 @@ pub(crate) fn subtract_drawn_brush(active: &ActiveDraw, commands: &mut Commands)
             return;
         }
 
-        // Third, capture brush data for originals (assigns stable IDs).
-        let mut originals: Vec<BrushData> = Vec::new();
-        for result in &results {
-            originals.push(brush_data_from_entity(world, result.original_entity));
-        }
-
         let parent_translations = parent_translations_of(
             world,
             results.iter().map(|result| result.original_entity),
         );
 
-        // Clean up selection: remove originals that are about to be despawned
         {
             let despawning: Vec<Entity> = results.iter().map(|r| r.original_entity).collect();
             let mut selection = world.resource_mut::<Selection>();
@@ -320,65 +297,12 @@ pub(crate) fn subtract_drawn_brush(active: &ActiveDraw, commands: &mut Commands)
             }
         }
 
+        spawn_subtract_fragments(world, &results, &parent_translations);
+
         for result in &results {
             despawn_scene_entity(world, result.original_entity);
         }
-
-        let fragments =
-            spawn_subtract_fragments(world, &results, &originals, &parent_translations);
-
-        // Push undo command
-        let cmd = SubtractBrushCommand {
-            originals,
-            fragments,
-        };
-        let mut history = world.resource_mut::<CommandHistory>();
-        history.push_executed(Box::new(cmd));
     });
-}
-
-struct SubtractBrushCommand {
-    originals: Vec<BrushData>,
-    fragments: Vec<BrushData>,
-}
-
-impl EditorCommand for SubtractBrushCommand {
-    fn execute(&mut self, world: &mut World) {
-        let orig_entities: Vec<Entity> = self
-            .originals
-            .iter()
-            .filter_map(|d| entity_by_scene_node_id(world, d.node_id))
-            .collect();
-        deselect_entities(world, &orig_entities);
-        for entity in &orig_entities {
-            despawn_scene_entity(world, *entity);
-        }
-        for data in &self.fragments {
-            spawn_brush_from_data(world, data);
-        }
-    }
-
-    fn undo(&mut self, world: &mut World) {
-        let mut all_entities = Vec::new();
-        for data in &self.fragments {
-            if let Some(entity) = entity_by_scene_node_id(world, data.node_id) {
-                collect_entity_ids(world, entity, &mut all_entities);
-            }
-        }
-        deselect_entities(world, &all_entities);
-        for data in &self.fragments {
-            if let Some(entity) = entity_by_scene_node_id(world, data.node_id) {
-                despawn_scene_entity(world, entity);
-            }
-        }
-        for data in &self.originals {
-            spawn_brush_from_data(world, data);
-        }
-    }
-
-    fn description(&self) -> &str {
-        "Subtract brush"
-    }
 }
 
 /// Core logic for Join (convex merge). Callable from both keyboard shortcut and menu.
@@ -688,16 +612,9 @@ pub(crate) fn csg_subtract_selected_impl(world: &mut World) {
         return;
     }
 
-    // Capture brush data for originals (assigns stable IDs)
-    let mut originals: Vec<BrushData> = Vec::new();
-    for result in &results {
-        originals.push(brush_data_from_entity(world, result.original_entity));
-    }
-
     let parent_translations =
         parent_translations_of(world, results.iter().map(|result| result.original_entity));
 
-    // Clean up selection: remove targets about to be despawned
     {
         let despawning: Vec<Entity> = results.iter().map(|r| r.original_entity).collect();
         let mut selection = world.resource_mut::<Selection>();
@@ -709,19 +626,11 @@ pub(crate) fn csg_subtract_selected_impl(world: &mut World) {
         }
     }
 
+    spawn_subtract_fragments(world, &results, &parent_translations);
+
     for result in &results {
         despawn_scene_entity(world, result.original_entity);
     }
-
-    let fragments = spawn_subtract_fragments(world, &results, &originals, &parent_translations);
-
-    // Push undo command
-    let cmd = SubtractBrushCommand {
-        originals,
-        fragments,
-    };
-    let mut history = world.resource_mut::<CommandHistory>();
-    history.push_executed(Box::new(cmd));
 }
 
 /// Core logic for CSG Intersect. Replaces all selected brushes with their intersection.
@@ -807,12 +716,6 @@ pub(crate) fn csg_intersect_selected_impl(world: &mut World) {
         v.position -= centroid;
     }
 
-    // Capture brush data for originals (assigns stable IDs)
-    let mut originals: Vec<BrushData> = Vec::new();
-    for (entity, _, _) in &selected_brushes {
-        originals.push(brush_data_from_entity(world, *entity));
-    }
-
     // Clean up selection
     {
         let despawning: Vec<Entity> = selected_brushes.iter().map(|(e, _, _)| *e).collect();
@@ -825,13 +728,6 @@ pub(crate) fn csg_intersect_selected_impl(world: &mut World) {
         }
     }
 
-    for (entity, _, _) in &selected_brushes {
-        despawn_scene_entity(world, *entity);
-    }
-
-    // Spawn the intersection brush. Reuse the manifold-derived topology
-    // when cleaning didn't prune faces; otherwise re-derive from planes
-    // so the parallel-array invariant with `faces` is preserved.
     let topology = if clean.len() == running.faces.len() {
         local_topo
     } else {
@@ -841,29 +737,28 @@ pub(crate) fn csg_intersect_selected_impl(world: &mut World) {
         faces: clean,
         topology,
     };
-    let brush_data = BrushData {
-        node_id: SceneNodeId::next(),
-        brush: new_brush,
-        transform: Transform::from_translation(centroid),
-        name: "Brush".to_string(),
-        parent_node_id: None,
+    let Some(source) = selected_brushes.first().map(|(entity, _, _)| *entity) else {
+        return;
     };
-    let entity = spawn_brush_from_data(world, &brush_data);
+    let Some(entity) = crate::entity_ops::spawn_cloned_brush_with_geometry(
+        world,
+        source,
+        new_brush,
+        Transform::from_translation(centroid),
+    ) else {
+        warn!("CSG intersect spawn failed: source {source:?} has no document node");
+        return;
+    };
 
-    // Select the new brush
+    for (entity, _, _) in &selected_brushes {
+        despawn_scene_entity(world, *entity);
+    }
+
     {
         let mut selection = world.resource_mut::<Selection>();
         selection.entities.push(entity);
     }
     world.entity_mut(entity).insert(Selected);
-
-    // Push undo command (reuses SubtractBrushCommand, same undo/redo pattern).
-    let cmd = SubtractBrushCommand {
-        originals,
-        fragments: vec![brush_data],
-    };
-    let mut history = world.resource_mut::<CommandHistory>();
-    history.push_executed(Box::new(cmd));
 }
 
 #[operator(

--- a/src/draw_brush/interaction.rs
+++ b/src/draw_brush/interaction.rs
@@ -1,8 +1,8 @@
 use crate::default_style;
 use crate::draw_brush::{
     ConfirmDrawBrushOp, DrawBrushDashedGizmoGroup, DrawBrushGizmoGroup, DrawBrushState, DrawMode,
-    DrawPhase, DrawPlane, EXTRUDE_DEPTH_SENSITIVITY, MIN_FOOTPRINT_SIZE, draw_plane_grid,
-    footprint_corners, ray_plane_intersection, snap_to_diagonal, snap_to_plane_grid,
+    DrawPhase, DrawPlane, MIN_FOOTPRINT_SIZE, draw_plane_grid, footprint_corners,
+    ray_plane_intersection, snap_to_diagonal, snap_to_plane_grid,
 };
 use crate::prelude::*;
 use crate::{
@@ -243,25 +243,19 @@ pub(crate) fn draw_brush_update(
             }
         }
         DrawPhase::ExtrudingDepth => {
-            // Use polygon centroid if in polygon mode, otherwise rectangle midpoint
             let center = if !active.polygon_vertices.is_empty() {
                 active.polygon_vertices.iter().sum::<Vec3>() / active.polygon_vertices.len() as f32
             } else {
                 (active.corner1 + active.corner2) / 2.0
             };
-            let cam_dist = (cam_tf.translation() - center).length();
-
-            // Project the plane normal to screen space to determine drag direction
-            if let (Ok(origin_screen), Ok(normal_screen)) = (
-                camera.world_to_viewport(cam_tf, center),
-                camera.world_to_viewport(cam_tf, center + active.plane.normal),
+            if let Some(raw_depth) = crate::viewport_util::drag_along_axis(
+                camera,
+                cam_tf,
+                active.extrude_start_cursor,
+                viewport_cursor,
+                center,
+                active.plane.normal,
             ) {
-                let screen_dir = (normal_screen - origin_screen).normalize_or_zero();
-                let mouse_delta = viewport_cursor - active.extrude_start_cursor;
-                let projected = mouse_delta.dot(screen_dir);
-                let raw_depth = projected * cam_dist * EXTRUDE_DEPTH_SENSITIVITY;
-
-                // Snap depth
                 let depth = if snap_settings.translate_active(ctrl)
                     && snap_settings.translate_increment > 0.0
                 {

--- a/src/draw_brush/mod.rs
+++ b/src/draw_brush/mod.rs
@@ -424,7 +424,6 @@ pub fn add_brush(_params: In<OperatorParameters>) -> OperatorResult {
     OperatorResult::Finished
 }
 
-pub(crate) const EXTRUDE_DEPTH_SENSITIVITY: f32 = 0.003;
 pub(crate) const MIN_FOOTPRINT_SIZE: f32 = 0.01;
 pub(crate) const MIN_EXTRUDE_DEPTH: f32 = 0.01;
 pub(crate) const MIN_FRAGMENT_SIZE: f32 = 0.005;

--- a/src/draw_brush/state.rs
+++ b/src/draw_brush/state.rs
@@ -1,7 +1,4 @@
-use crate::commands::{EditorCommand, deselect_entities, despawn_scene_entity};
-use crate::scene_io::entity_by_scene_node_id;
 use bevy::prelude::*;
-use jackdaw_scene_types::{Brush, SceneNodeId};
 
 #[derive(Clone, Copy, PartialEq, Eq, Debug)]
 pub(crate) enum DrawPhase {
@@ -64,88 +61,4 @@ pub(crate) struct ActiveDraw {
 #[derive(Resource, Debug, Default)]
 pub(crate) struct DrawBrushState {
     pub(crate) active: Option<ActiveDraw>,
-}
-
-/// Minimal data needed to respawn a brush entity.
-#[derive(Clone)]
-pub(crate) struct BrushData {
-    pub(crate) node_id: SceneNodeId,
-    pub(crate) brush: Brush,
-    pub(crate) transform: Transform,
-    pub(crate) name: String,
-    pub(crate) parent_node_id: Option<SceneNodeId>,
-}
-
-fn scene_node_id_of(world: &mut World, entity: Entity) -> SceneNodeId {
-    if let Some(id) = world.get::<SceneNodeId>(entity).copied() {
-        return id;
-    }
-    let id = SceneNodeId::next();
-    world.entity_mut(entity).insert(id);
-    id
-}
-
-/// Read brush data from an existing entity. Mints a `SceneNodeId` if missing.
-pub(crate) fn brush_data_from_entity(world: &mut World, entity: Entity) -> BrushData {
-    let node_id = scene_node_id_of(world, entity);
-    let parent = world.get::<ChildOf>(entity).map(|child_of| child_of.0);
-    let parent_node_id = parent.map(|parent| scene_node_id_of(world, parent));
-
-    BrushData {
-        node_id,
-        brush: world.get::<Brush>(entity).unwrap().clone(),
-        transform: *world.get::<Transform>(entity).unwrap(),
-        name: world
-            .get::<Name>(entity)
-            .map(std::string::ToString::to_string)
-            .unwrap_or_default(),
-        parent_node_id,
-    }
-}
-
-/// Spawn a brush entity from stored data. Returns new entity ID.
-pub(crate) fn spawn_brush_from_data(world: &mut World, data: &BrushData) -> Entity {
-    let parent_entity = data
-        .parent_node_id
-        .and_then(|id| entity_by_scene_node_id(world, id));
-
-    let mut ec = world.spawn((
-        Name::new(data.name.clone()),
-        data.brush.clone(),
-        data.transform,
-        data.node_id,
-        Visibility::default(),
-    ));
-    if let Some(parent) = parent_entity {
-        ec.insert(ChildOf(parent));
-    }
-    let entity = ec.id();
-    crate::scene_io::register_entity_in_ast(world, entity);
-    entity
-}
-
-/// Per-command undo entry for brush spawns from the legacy non-
-/// operator paths (face extrude, brush clip/split). The draw-brush
-/// modal operator doesn't push this; its `SnapshotDiff` covers the
-/// whole transaction.
-pub(crate) struct CreateBrushCommand {
-    pub data: BrushData,
-}
-
-impl EditorCommand for CreateBrushCommand {
-    fn execute(&mut self, world: &mut World) {
-        let entity = spawn_brush_from_data(world, &self.data);
-        crate::physics_brush_bridge::insert_default_brush_physics(world, entity);
-    }
-
-    fn undo(&mut self, world: &mut World) {
-        if let Some(entity) = entity_by_scene_node_id(world, self.data.node_id) {
-            deselect_entities(world, &[entity]);
-            despawn_scene_entity(world, entity);
-        }
-    }
-
-    fn description(&self) -> &str {
-        "Draw brush"
-    }
 }

--- a/src/draw_brush/state.rs
+++ b/src/draw_brush/state.rs
@@ -134,7 +134,8 @@ pub(crate) struct CreateBrushCommand {
 
 impl EditorCommand for CreateBrushCommand {
     fn execute(&mut self, world: &mut World) {
-        spawn_brush_from_data(world, &self.data);
+        let entity = spawn_brush_from_data(world, &self.data);
+        crate::physics_brush_bridge::insert_default_brush_physics(world, entity);
     }
 
     fn undo(&mut self, world: &mut World) {

--- a/src/entity_ops.rs
+++ b/src/entity_ops.rs
@@ -421,6 +421,9 @@ pub fn spawn_template_in_document(world: &mut World, template: EntityTemplate) -
     let entity = create_entity(&mut commands, template, &mut selection);
     system_state.apply(world);
     crate::scene_io::register_entity_in_ast(world, entity);
+    if world.get::<crate::brush::Brush>(entity).is_some() {
+        crate::physics_brush_bridge::insert_default_brush_physics(world, entity);
+    }
     entity
 }
 

--- a/src/entity_ops.rs
+++ b/src/entity_ops.rs
@@ -1210,6 +1210,35 @@ impl crate::commands::EditorCommand for PasteEntitiesCommand {
     }
 }
 
+/// Spawn a new brush by cloning `source`'s authored document node and
+/// replacing its geometry. Parent, physics, modifiers, and extra
+/// components follow the original. Children are not copied.
+pub(crate) fn spawn_cloned_brush_with_geometry(
+    world: &mut World,
+    source: Entity,
+    brush: crate::brush::Brush,
+    transform: Transform,
+) -> Option<Entity> {
+    let (parent_ast, patches) = {
+        let ast = world.resource::<jackdaw_bsn::SceneBsnAst>();
+        let node = ast.ast_for(source)?;
+        (
+            ast.find_ast_parent_of(node),
+            ast.cloned_component_patches(node),
+        )
+    };
+    let mut temp = jackdaw_bsn::SceneBsnAst::default();
+    let root = temp.create_entity_node(patches);
+    temp.add_to_roots(root);
+    mint_scene_node_ids(world, &mut temp);
+
+    let entity = *graft_and_spawn(world, &temp, parent_ast).first()?;
+    world.entity_mut(entity).insert((brush.clone(), transform));
+    crate::brush::sync_brush_to_ast(world, entity, &brush);
+    crate::commands::sync_component_to_ast(world, entity, Transform::type_path(), &transform);
+    Some(entity)
+}
+
 /// Graft entity roots from `source` into the live document and spawn
 /// them under `parent_ast` (`None` = scene roots).
 fn graft_and_spawn(
@@ -2962,5 +2991,85 @@ mod asset_path_tests {
             .run_system_cached(crate::project::mirror_open_project)
             .expect("the mirror runs");
         assert_eq!(crate::project::open_project_assets_dir(), None);
+    }
+}
+
+#[cfg(test)]
+mod clone_brush_tests {
+    use super::*;
+    use avian3d::prelude::RigidBody;
+    use bevy::reflect::PartialReflect;
+    use jackdaw_avian_integration::AvianCollider;
+    use jackdaw_bsn::SceneBsnAst;
+    use jackdaw_scene_types::Brush;
+
+    #[derive(Component, Reflect, Default, Clone, PartialEq, Debug)]
+    #[reflect(Component, Default)]
+    struct ExtraBrushMarker;
+
+    #[test]
+    fn cloned_brush_keeps_extra_components() {
+        let mut app = App::new();
+        app.add_plugins(MinimalPlugins);
+        app.init_resource::<SceneBsnAst>();
+        app.register_type::<Brush>();
+        app.register_type::<Transform>();
+        app.register_type::<Visibility>();
+        app.register_type::<Name>();
+        app.register_type::<jackdaw_scene_types::SceneNodeId>();
+        app.register_type::<RigidBody>();
+        app.register_type::<AvianCollider>();
+        app.register_type::<ExtraBrushMarker>();
+
+        let source = app
+            .world_mut()
+            .spawn((
+                Name::new("Brush"),
+                Brush::cuboid(0.5, 0.5, 0.5),
+                Transform::default(),
+                Visibility::default(),
+            ))
+            .id();
+        crate::scene_io::register_entity_in_ast(app.world_mut(), source);
+        crate::physics_brush_bridge::insert_default_brush_physics(app.world_mut(), source);
+
+        app.world_mut().entity_mut(source).insert(ExtraBrushMarker);
+        let registry = app.world().resource::<AppTypeRegistry>().clone();
+        crate::commands::sync_component_to_bsn_doc(
+            app.world_mut(),
+            source,
+            ExtraBrushMarker.as_partial_reflect(),
+            &registry,
+        );
+
+        let new_brush = Brush::cuboid(1.0, 1.0, 1.0);
+        let spawned = spawn_cloned_brush_with_geometry(
+            app.world_mut(),
+            source,
+            new_brush.clone(),
+            Transform::from_xyz(2.0, 0.0, 0.0),
+        )
+        .expect("clone spawn");
+
+        let spawned_ref = app.world().entity(spawned);
+        assert!(
+            spawned_ref.contains::<ExtraBrushMarker>(),
+            "user-added components must copy onto the clone"
+        );
+        assert_eq!(
+            spawned_ref.get::<RigidBody>().copied(),
+            Some(RigidBody::Static),
+            "authored physics must copy onto the clone"
+        );
+        assert!(spawned_ref.contains::<AvianCollider>());
+        assert_eq!(
+            spawned_ref.get::<Brush>().map(|b| b.faces.len()),
+            Some(new_brush.faces.len()),
+            "clone should carry the replacement geometry"
+        );
+        assert_eq!(
+            spawned_ref.get::<Transform>().map(|t| t.translation.x),
+            Some(2.0)
+        );
     }
 }

--- a/src/gizmos.rs
+++ b/src/gizmos.rs
@@ -17,10 +17,7 @@ use crate::{
     selection::{Selected, Selection},
     snapping::SnapSettings,
     viewport::{MainViewportCamera, SceneViewport},
-    viewport_util::{
-        point_to_segment_dist, window_to_viewport_cursor_for,
-        window_to_viewport_cursor_for_unbounded,
-    },
+    viewport_util::{point_to_segment_dist, window_to_viewport_cursor_for},
 };
 
 /// Gizmo group for transform gizmos, rendered on top of all geometry.
@@ -467,37 +464,46 @@ pub fn gizmo_drag(
     modal: Option<Single<Entity, With<ActiveModalOperator>>>,
     mut commands: Commands,
 ) -> OperatorResult {
+    let modal_running = modal.is_some();
+    if modal_running
+        && (viewport_ctx.cursor.get().is_none() || mouse.just_released(MouseButton::Left))
+    {
+        // Sync ECS -> AST before Finished so the framework's after-snapshot
+        // (and a later save) see the dragged Transforms. Undo remains the
+        // SnapshotDiff; this only brings the document up to date. Leaving the
+        // OS window commits the same way LMB release does.
+        queue_sync_gizmo_transforms_to_ast(&drag_state, &transforms, &mut commands);
+        clear_gizmo_drag_state(&mut drag_state, &mut cursor_query);
+        return OperatorResult::Finished;
+    }
+
     let cursor_pos = viewport_ctx.cursor.get()?;
     // First-frame: pick the active (hovered) viewport. Subsequent
     // frames: use the captured one so the drag stays attached even
     // if the cursor strays into a different viewport. A captured
     // viewport that is no longer available finishes the drag; a missing
-    // active viewport on the first frame cancels it. Dragging across
-    // into a sibling viewport (or off the panel) yields no viewport
-    // cursor, cancelling the drag so the cancel handler restores the
-    // start transform, which the user sees as a snap-back.
+    // active viewport on the first frame cancels it.
     let Some((camera_entity, viewport_entity)) = resolve_drag_viewport(
-        modal.is_some(),
+        modal_running,
         &viewport_ctx,
         drag_state.camera,
         drag_state.viewport,
     ) else {
-        return if modal.is_some() {
+        return if modal_running {
             OperatorResult::Finished
         } else {
             OperatorResult::Cancelled
         };
     };
     let (camera, cam_tf) = camera_query.get(camera_entity)?;
-    let viewport_cursor = resolve_viewport_cursor(
-        modal.is_some(),
+    let viewport_cursor = window_to_viewport_cursor_for(
         cursor_pos,
         camera,
         viewport_entity,
         &viewport_ctx.viewport_query,
     )?;
 
-    if modal.is_none() {
+    if !modal_running {
         let axis = hover.hovered_axis?;
         let target_entities = topmost_selected(
             &selection.entities,
@@ -532,15 +538,6 @@ pub fn gizmo_drag(
             cursor_opts.grab_mode = CursorGrabMode::Confined;
         }
         return OperatorResult::Running;
-    }
-
-    if mouse.just_released(MouseButton::Left) {
-        // Sync ECS -> AST before Finished so the framework's after-snapshot
-        // (and a later save) see the dragged Transforms. Undo remains the
-        // SnapshotDiff; this only brings the document up to date.
-        queue_sync_gizmo_transforms_to_ast(&drag_state, &transforms, &mut commands);
-        clear_gizmo_drag_state(&mut drag_state, &mut cursor_query);
-        return OperatorResult::Finished;
     }
 
     if drag_state.targets.is_empty() {
@@ -737,6 +734,19 @@ pub fn gizmo_drag_edit(
     modal: Option<Single<Entity, With<ActiveModalOperator>>>,
     mut override_cursor: ResMut<OverrideCursor>,
 ) -> OperatorResult {
+    let modal_running = modal.is_some();
+    if modal_running
+        && (viewport_ctx.cursor.get().is_none() || mouse.just_released(MouseButton::Left))
+    {
+        // The framework captured a before-snapshot on start; returning
+        // Finished triggers the after-snapshot + SnapshotDiff push, so one
+        // Undo restores every brush touched. Leaving the OS window commits
+        // the same way LMB release does.
+        clear_gizmo_edit_drag_state(&mut drag_state, &mut cursor_query);
+        clear_gizmo_grab_cursor(&mut override_cursor);
+        return OperatorResult::Finished;
+    }
+
     let cursor_pos = viewport_ctx.cursor.get()?;
     // First frame picks the active (hovered) viewport; subsequent frames use
     // the captured one so the drag stays attached even if the cursor strays
@@ -744,27 +754,26 @@ pub fn gizmo_drag_edit(
     // finishes the drag; a missing active viewport on the first frame cancels
     // it.
     let Some((camera_entity, viewport_entity)) = resolve_drag_viewport(
-        modal.is_some(),
+        modal_running,
         &viewport_ctx,
         drag_state.camera,
         drag_state.viewport,
     ) else {
-        return if modal.is_some() {
+        return if modal_running {
             OperatorResult::Finished
         } else {
             OperatorResult::Cancelled
         };
     };
     let (camera, cam_tf) = camera_query.get(camera_entity)?;
-    let viewport_cursor = resolve_viewport_cursor(
-        modal.is_some(),
+    let viewport_cursor = window_to_viewport_cursor_for(
         cursor_pos,
         camera,
         viewport_entity,
         &viewport_ctx.viewport_query,
     )?;
 
-    if modal.is_none() {
+    if !modal_running {
         let axis = hover.hovered_axis?;
         let captures = crate::brush_drag_ops::capture_edit_brushes(
             &brush_selection,
@@ -793,15 +802,6 @@ pub fn gizmo_drag_edit(
         }
         override_cursor.0 = Some(EntityCursor::System(SystemCursorIcon::Grabbing));
         return OperatorResult::Running;
-    }
-
-    if mouse.just_released(MouseButton::Left) {
-        // The framework captured a before-snapshot on start; returning
-        // Finished triggers the after-snapshot + SnapshotDiff push, so one
-        // Undo restores every brush touched.
-        clear_gizmo_edit_drag_state(&mut drag_state, &mut cursor_query);
-        clear_gizmo_grab_cursor(&mut override_cursor);
-        return OperatorResult::Finished;
     }
 
     if drag_state.captures.is_empty() {
@@ -1400,25 +1400,6 @@ fn resolve_drag_viewport(
         let camera_entity = stored_camera?;
         let viewport_entity = stored_viewport?;
         Some((camera_entity, viewport_entity))
-    }
-}
-
-/// Viewport-local cursor position for a gizmo drag. The first frame is
-/// bounds-checked so a press that misses the viewport does not grab the gizmo;
-/// once the modal is running the cursor belongs to the drag, so positions
-/// outside the viewport rectangle are accepted. Returns `None` when the cursor
-/// is rejected.
-fn resolve_viewport_cursor(
-    modal_active: bool,
-    cursor_pos: Vec2,
-    camera: &Camera,
-    viewport_entity: Entity,
-    viewport_query: &Query<(&ComputedNode, &UiGlobalTransform), With<SceneViewport>>,
-) -> Option<Vec2> {
-    if !modal_active {
-        window_to_viewport_cursor_for(cursor_pos, camera, viewport_entity, viewport_query)
-    } else {
-        window_to_viewport_cursor_for_unbounded(cursor_pos, camera, viewport_entity, viewport_query)
     }
 }
 

--- a/src/gizmos.rs
+++ b/src/gizmos.rs
@@ -84,7 +84,6 @@ const AXIS_HIT_DISTANCE: f32 = 35.0;
 /// scale handle. Smaller than `AXIS_START_OFFSET` projected, so it never
 /// competes with the axis arms.
 const UNIFORM_HANDLE_RADIUS: f32 = 12.0;
-const EPSILON: f32 = 1e-6;
 
 #[derive(Resource, Default, PartialEq, Eq, Clone, Copy, Debug)]
 pub enum GizmoSpace {
@@ -584,10 +583,14 @@ pub fn gizmo_drag(
 
     match *mode {
         ActiveTool::Translate => {
-            // Use the pivot as the reference point for projecting the axis onto screen.
-            let Some(projected) =
-                translate_axis_amount(mouse_delta, camera, cam_tf, pivot, axis_dir)
-            else {
+            let Some(projected) = crate::viewport_util::drag_along_axis(
+                camera,
+                cam_tf,
+                drag_state.drag_start_screen,
+                viewport_cursor,
+                pivot,
+                axis_dir,
+            ) else {
                 return OperatorResult::Running;
             };
             let snapped = snap_settings.snap_translate_vec3_if(axis_dir * projected, ctrl);
@@ -835,9 +838,14 @@ pub fn gizmo_drag_edit(
 
     match *mode {
         ActiveTool::Translate => {
-            let Some(projected) =
-                translate_axis_amount(mouse_delta, camera, cam_tf, pivot, axis_dir)
-            else {
+            let Some(projected) = crate::viewport_util::drag_along_axis(
+                camera,
+                cam_tf,
+                drag_state.drag_start_screen,
+                viewport_cursor,
+                pivot,
+                axis_dir,
+            ) else {
                 return OperatorResult::Running;
             };
             let world_delta = snap_settings.snap_translate_vec3_if(axis_dir * projected, ctrl);
@@ -1358,27 +1366,6 @@ fn scale_factor(
         }
         Some(factor)
     }
-}
-
-/// Signed distance the selection should move along `axis_dir` for the current
-/// mouse delta, found by projecting the delta onto the axis as it appears on
-/// screen. Returns `None` when the pivot or axis endpoint fails to project, or
-/// when the projected axis is degenerate (zero length on screen).
-pub(crate) fn translate_axis_amount(
-    mouse_delta: Vec2,
-    camera: &Camera,
-    cam_tf: &GlobalTransform,
-    pivot: Vec3,
-    axis_dir: Vec3,
-) -> Option<f32> {
-    let origin_screen = camera.world_to_viewport(cam_tf, pivot).ok()?;
-    let axis_screen = camera.world_to_viewport(cam_tf, pivot + axis_dir).ok()?;
-    let screen_axis = axis_screen - origin_screen;
-    let len_sq = screen_axis.length_squared();
-    if len_sq < EPSILON {
-        return None;
-    }
-    Some(mouse_delta.dot(screen_axis) / len_sq)
 }
 
 /// Camera and `SceneViewport` UI-node entities a gizmo drag should use this

--- a/src/modal_transform.rs
+++ b/src/modal_transform.rs
@@ -354,30 +354,56 @@ fn viewport_drag_update(
     };
 
     let start_pos = active.start_transform.translation;
-    let cam_dist = (cam_tf.translation() - start_pos).length();
-    let scale = cam_dist * 0.003;
-    let mouse_delta = viewport_cursor - active.start_viewport_cursor;
 
     let offset = if let Some(axis) = numeric.axis {
-        // Armed numeric axis: constrain the drag to that world axis with the
-        // same screen projection the gizmo handle drag uses, so dragging the
-        // body and dragging the handle feel identical.
+        // Armed numeric axis: constrain the drag to that world axis the same
+        // way the gizmo handle does, so body and handle feel identical.
         let axis_dir = crate::numeric_transform::axis_direction(axis);
-        let amount =
-            crate::gizmos::translate_axis_amount(mouse_delta, camera, cam_tf, start_pos, axis_dir)
-                .unwrap_or(0.0);
+        let amount = crate::viewport_util::drag_along_axis(
+            camera,
+            cam_tf,
+            active.start_viewport_cursor,
+            viewport_cursor,
+            start_pos,
+            axis_dir,
+        )
+        .unwrap_or(0.0);
         axis_dir * amount
     } else if alt {
-        // Alt+drag: move along Y axis only (vertical)
-        Vec3::Y * (-mouse_delta.y) * scale
+        crate::viewport_util::drag_along_axis(
+            camera,
+            cam_tf,
+            active.start_viewport_cursor,
+            viewport_cursor,
+            start_pos,
+            Vec3::Y,
+        )
+        .map(|amount| Vec3::Y * amount)
+        .unwrap_or(Vec3::ZERO)
     } else {
-        // Normal drag: move in XZ plane
-        let cam_right = cam_tf.right().as_vec3();
-        let cam_forward = cam_tf.forward().as_vec3();
-        let right_h = Vec3::new(cam_right.x, 0.0, cam_right.z).normalize_or_zero();
-        let forward_h = Vec3::new(cam_forward.x, 0.0, cam_forward.z).normalize_or_zero();
-
-        let raw = right_h * mouse_delta.x * scale + forward_h * (-mouse_delta.y) * scale;
+        // Move on the ground plane through the grab point. If the ray is
+        // parallel to the ground (looking horizontally), fall back to a
+        // camera-facing plane flattened onto XZ.
+        let raw = crate::viewport_util::drag_on_plane(
+            camera,
+            cam_tf,
+            active.start_viewport_cursor,
+            viewport_cursor,
+            start_pos,
+            Vec3::Y,
+        )
+        .or_else(|| {
+            crate::viewport_util::drag_on_plane(
+                camera,
+                cam_tf,
+                active.start_viewport_cursor,
+                viewport_cursor,
+                start_pos,
+                cam_tf.forward().as_vec3(),
+            )
+            .map(|d| Vec3::new(d.x, 0.0, d.z))
+        })
+        .unwrap_or(Vec3::ZERO);
 
         if shift {
             // Shift+drag: restrict to dominant axis

--- a/src/modal_transform.rs
+++ b/src/modal_transform.rs
@@ -344,13 +344,14 @@ fn viewport_drag_update(
     let alt = keyboard.any_pressed([KeyCode::AltLeft, KeyCode::AltRight]);
     let shift = keyboard.any_pressed([KeyCode::ShiftLeft, KeyCode::ShiftRight]);
 
-    let viewport_cursor = crate::viewport_util::window_to_viewport_cursor_for(
+    let Some(viewport_cursor) = crate::viewport_util::window_to_viewport_cursor_for(
         cursor_pos,
         camera,
         active.viewport,
         &viewport_query,
-    )
-    .unwrap_or(cursor_pos);
+    ) else {
+        return;
+    };
 
     let start_pos = active.start_transform.translation;
     let cam_dist = (cam_tf.translation() - start_pos).length();
@@ -399,13 +400,14 @@ fn viewport_drag_update(
 
 fn viewport_drag_finish(
     mouse: Res<ButtonInput<MouseButton>>,
+    cursor: crate::viewport::UiCursorPos,
     mut drag_state: ResMut<ViewportDragState>,
     transforms: Query<&Transform>,
     mut cursor_query: Query<&mut CursorOptions, With<Window>>,
     mut numeric: ResMut<crate::numeric_transform::NumericTransformState>,
     mut commands: Commands,
 ) {
-    if !mouse.just_released(MouseButton::Left) {
+    if !mouse.just_released(MouseButton::Left) && cursor.get().is_some() {
         return;
     }
 

--- a/src/physics_brush_bridge.rs
+++ b/src/physics_brush_bridge.rs
@@ -10,7 +10,7 @@
 use avian3d::prelude::*;
 use bevy::prelude::*;
 use jackdaw_avian_integration::AvianCollider;
-use jackdaw_geometry::is_convex_topology;
+use jackdaw_geometry::{is_convex_topology, triangulate_polygons};
 
 use crate::brush::{Brush, BrushMeshCache};
 
@@ -111,22 +111,21 @@ pub(crate) fn sync_editor_collider_config(
     }
 }
 
-/// Build a triangulated `Mesh` from a `BrushMeshCache`, fan-triangulating each face polygon.
+/// Build a triangulated `Mesh` from a `BrushMeshCache`.
 fn brush_mesh_from_cache(cache: &BrushMeshCache) -> Option<Mesh> {
     if cache.vertices.is_empty() {
         return None;
     }
-    let positions: Vec<[f32; 3]> = cache.vertices.iter().map(|v| [v.x, v.y, v.z]).collect();
-    let mut indices: Vec<u32> = Vec::new();
-    for polygon in &cache.face_polygons {
-        if polygon.len() >= 3 {
-            for i in 1..polygon.len() - 1 {
-                indices.push(polygon[0] as u32);
-                indices.push(polygon[i] as u32);
-                indices.push(polygon[i + 1] as u32);
-            }
-        }
+    let tris = triangulate_polygons(
+        &cache.vertices,
+        &cache.face_polygons,
+        cache.face_normals.iter().copied(),
+    );
+    if tris.is_empty() {
+        return None;
     }
+    let positions: Vec<[f32; 3]> = cache.vertices.iter().map(|v| [v.x, v.y, v.z]).collect();
+    let indices: Vec<u32> = tris.iter().copied().flatten().collect();
     let mut m = Mesh::new(
         bevy::mesh::PrimitiveTopology::TriangleList,
         bevy::asset::RenderAssetUsages::default(),

--- a/src/physics_brush_bridge.rs
+++ b/src/physics_brush_bridge.rs
@@ -1,8 +1,9 @@
 //! Bridge between editor collider configuration and avian `Collider` components.
 //!
-//! The user adds `AvianCollider` via the inspector. This module builds
-//! the actual `Collider` from it  -- handling both mesh-backed entities and
-//! brush entities (which have `BrushMeshCache` instead of `Mesh3d`).
+//! New brushes spawn with [`RigidBody::Static`] and [`AvianCollider`]. This
+//! module builds the runtime `Collider` from that wrapper  -- handling both
+//! mesh-backed entities and brushes (which have `BrushMeshCache` instead of
+//! `Mesh3d`).
 //!
 //! `ColliderConstructor` is never placed on entities, so avian's
 //! `init_collider_constructors` system never fires and can't interfere.
@@ -20,6 +21,38 @@ impl Plugin for PhysicsBrushBridgePlugin {
     fn build(&self, app: &mut App) {
         app.add_observer(remove_collider_when_avian_collider_removed);
     }
+}
+
+/// Insert the default authored physics pair on a newly spawned brush.
+pub(crate) fn insert_default_brush_physics(world: &mut World, entity: Entity) {
+    let Ok(entity_ref) = world.get_entity(entity) else {
+        return;
+    };
+    if entity_ref.contains::<RigidBody>() || entity_ref.contains::<AvianCollider>() {
+        return;
+    }
+
+    if let Ok(mut entity_mut) = world.get_entity_mut(entity) {
+        entity_mut
+            .insert(AvianCollider::default())
+            .insert(RigidBody::Static);
+    }
+
+    let registry = world.resource::<AppTypeRegistry>().clone();
+    let rigid_body = RigidBody::Static;
+    crate::commands::sync_component_to_bsn_doc(
+        world,
+        entity,
+        rigid_body.as_partial_reflect(),
+        &registry,
+    );
+    let collider = AvianCollider::default();
+    crate::commands::sync_component_to_bsn_doc(
+        world,
+        entity,
+        collider.as_partial_reflect(),
+        &registry,
+    );
 }
 
 /// Copy a recentered brush `Transform` into avian `Position` / `Rotation`.

--- a/src/scene_io/mod.rs
+++ b/src/scene_io/mod.rs
@@ -22,7 +22,6 @@ pub use load::{
 pub(crate) use load::{
     SidecarImport, clear_scene_entities, despawn_scene_entities, import_terrain_sidecars,
 };
-pub(crate) use registration::entity_by_scene_node_id;
 pub use registration::{register_entities_in_ast, register_entity_in_ast};
 pub use save::{
     SaveOutcome, emit_bsn_scene_for_file, emit_bsn_scene_with_inline_assets, retarget_active_scene,

--- a/src/scene_io/registration.rs
+++ b/src/scene_io/registration.rs
@@ -61,15 +61,3 @@ pub fn register_entities_in_ast(world: &mut World, entities: &[Entity]) {
         register_entity_in_ast(world, entity);
     }
 }
-
-/// Live ECS entity carrying `id`, if any.
-pub(crate) fn entity_by_scene_node_id(
-    world: &mut World,
-    id: jackdaw_scene_types::SceneNodeId,
-) -> Option<Entity> {
-    world
-        .query::<(Entity, &jackdaw_scene_types::SceneNodeId)>()
-        .iter(world)
-        .find(|(_, nid)| **nid == id)
-        .map(|(e, _)| e)
-}

--- a/src/viewport.rs
+++ b/src/viewport.rs
@@ -233,9 +233,10 @@ impl ViewportCursor<'_, '_> {
     }
 
     /// Convert a window-space cursor position into the camera-space
-    /// coordinates of a specific viewport, returning `None` if the
-    /// cursor falls outside the viewport's bounds. Used by modal
-    /// operators that captured a viewport entity at drag-start.
+    /// coordinates of a specific viewport. Positions outside the pane
+    /// are still remapped, so a captured-viewport drag can keep updating
+    /// over adjacent UI. Returns `None` only if `viewport_entity` is no
+    /// longer a `SceneViewport`.
     pub fn viewport_cursor_for(
         &self,
         camera: &Camera,
@@ -244,13 +245,7 @@ impl ViewportCursor<'_, '_> {
     ) -> Option<Vec2> {
         let (computed, vp_tf, _) = self.viewports.get(viewport_entity).ok()?;
         let map = crate::viewport_util::ViewportRemap::new(camera, computed, vp_tf);
-        let local = cursor - map.top_left;
-        if local.x >= 0.0 && local.y >= 0.0 && local.x <= map.vp_size.x && local.y <= map.vp_size.y
-        {
-            Some(local * map.remap)
-        } else {
-            None
-        }
+        Some((cursor - map.top_left) * map.remap)
     }
 
     /// Cursor position in ui-logical pixels

--- a/src/viewport_util.rs
+++ b/src/viewport_util.rs
@@ -124,6 +124,65 @@ pub(crate) fn point_in_polygon_2d(point: Vec2, polygon: &[Vec2]) -> bool {
     inside
 }
 
+/// Signed world distance along `axis_dir` matching cursor motion from `start`
+/// to `current`. Uses a camera-facing plane containing the axis so perspective
+/// drags stay under the pointer. Returns `None` when the axis points at the
+/// camera or a ray misses.
+pub(crate) fn drag_along_axis(
+    camera: &Camera,
+    cam_tf: &GlobalTransform,
+    start: Vec2,
+    current: Vec2,
+    pivot: Vec3,
+    axis_dir: Vec3,
+) -> Option<f32> {
+    let start_ray = camera.viewport_to_world(cam_tf, start).ok()?;
+    let current_ray = camera.viewport_to_world(cam_tf, current).ok()?;
+    let cam_pos = cam_tf.translation();
+    let a = jackdaw_geometry::ray_axis_param(
+        start_ray.origin,
+        *start_ray.direction,
+        pivot,
+        axis_dir,
+        cam_pos,
+    )?;
+    let b = jackdaw_geometry::ray_axis_param(
+        current_ray.origin,
+        *current_ray.direction,
+        pivot,
+        axis_dir,
+        cam_pos,
+    )?;
+    Some(b - a)
+}
+
+/// World delta on the plane through `plane_point` matching cursor motion from
+/// `start` to `current`. Returns `None` when a ray is parallel to the plane.
+pub(crate) fn drag_on_plane(
+    camera: &Camera,
+    cam_tf: &GlobalTransform,
+    start: Vec2,
+    current: Vec2,
+    plane_point: Vec3,
+    plane_normal: Vec3,
+) -> Option<Vec3> {
+    let start_ray = camera.viewport_to_world(cam_tf, start).ok()?;
+    let current_ray = camera.viewport_to_world(cam_tf, current).ok()?;
+    let a = jackdaw_geometry::ray_plane_intersection(
+        start_ray.origin,
+        *start_ray.direction,
+        plane_point,
+        plane_normal,
+    )?;
+    let b = jackdaw_geometry::ray_plane_intersection(
+        current_ray.origin,
+        *current_ray.direction,
+        plane_point,
+        plane_normal,
+    )?;
+    Some(b - a)
+}
+
 /// Distance from a point to a line segment.
 pub(crate) fn point_to_segment_dist(point: Vec2, a: Vec2, b: Vec2) -> f32 {
     let ab = b - a;

--- a/src/viewport_util.rs
+++ b/src/viewport_util.rs
@@ -81,6 +81,10 @@ pub(crate) fn box_select_rect(
 /// already know which viewport the cursor is over (via `ActiveViewport`)
 /// and by modal operators that captured a viewport at start.
 ///
+/// Positions outside the pane are still remapped, so a captured-viewport
+/// drag can keep updating over adjacent UI. Returns `None` only if
+/// `viewport_entity` is no longer a `SceneViewport`.
+///
 /// The camera renders to an off-screen image whose logical size may differ
 /// from the UI node's logical size (they diverge on `HiDPI` / fractional
 /// scaling displays). This remaps UI-logical space into camera viewport
@@ -95,44 +99,8 @@ pub(crate) fn window_to_viewport_cursor_for(
     let Ok((computed, vp_transform)) = viewport_query.get(viewport_entity) else {
         return None;
     };
-    remap_cursor(cursor_pos, camera, computed, vp_transform)
-}
-
-/// Like [`window_to_viewport_cursor_for`] but does not bounds-check
-/// the cursor against the viewport rectangle. Returns `None` only if
-/// `viewport_entity` is no longer a `SceneViewport`.
-///
-/// Used by modal operators that captured the viewport at drag-start
-/// and need cursor coordinates to keep updating even when the user
-/// drags past the viewport's edge into another panel. Bounds-checking
-/// during a drag would force the operator to cancel mid-gesture and
-/// snap the entity back to its start transform.
-pub(crate) fn window_to_viewport_cursor_for_unbounded(
-    cursor_pos: Vec2,
-    camera: &Camera,
-    viewport_entity: Entity,
-    viewport_query: &Query<(&ComputedNode, &UiGlobalTransform), With<SceneViewport>>,
-) -> Option<Vec2> {
-    let Ok((computed, vp_transform)) = viewport_query.get(viewport_entity) else {
-        return None;
-    };
     let map = ViewportRemap::new(camera, computed, vp_transform);
     Some((cursor_pos - map.top_left) * map.remap)
-}
-
-fn remap_cursor(
-    cursor_pos: Vec2,
-    camera: &Camera,
-    computed: &ComputedNode,
-    vp_transform: &UiGlobalTransform,
-) -> Option<Vec2> {
-    let map = ViewportRemap::new(camera, computed, vp_transform);
-    let local = cursor_pos - map.top_left;
-    if local.x >= 0.0 && local.y >= 0.0 && local.x <= map.vp_size.x && local.y <= map.vp_size.y {
-        Some(local * map.remap)
-    } else {
-        None
-    }
 }
 
 /// Test whether a 2D point lies inside a convex or concave polygon (ray-casting algorithm).

--- a/tests/operators/operator_entity_params.rs
+++ b/tests/operators/operator_entity_params.rs
@@ -249,10 +249,66 @@ fn physics_disable_with_entity_param_detaches_components() {
     );
 }
 
+#[test]
+fn add_cube_authors_static_physics_by_default() {
+    use avian3d::prelude::RigidBody;
+    use jackdaw_bsn::SceneBsnAst;
+    use jackdaw_scene_types::Brush;
+
+    let mut app = util::editor_test_app();
+    let result = app
+        .world_mut()
+        .operator("entity.add.cube")
+        .call()
+        .expect("dispatch resolves");
+    assert_eq!(result, OperatorResult::Finished);
+    app.update();
+
+    let entity = app
+        .world_mut()
+        .query_filtered::<Entity, With<Brush>>()
+        .iter(app.world())
+        .next()
+        .expect("entity.add.cube spawned a brush");
+    let entity_ref = app.world().entity(entity);
+    assert_eq!(
+        entity_ref.get::<RigidBody>().copied(),
+        Some(RigidBody::Static),
+        "new brushes should spawn as static bodies"
+    );
+    assert!(
+        entity_ref.contains::<AvianCollider>(),
+        "new brushes should spawn with AvianCollider"
+    );
+
+    let ast = app.world().resource::<SceneBsnAst>();
+    let node = ast
+        .ast_for(entity)
+        .expect("cube is tracked in the document");
+    let paths = ast.component_type_paths(node);
+    assert!(
+        paths
+            .iter()
+            .any(|p| p.starts_with("avian3d::dynamics::rigid_body::RigidBody")),
+        "RigidBody should be authored, not only live ECS: {paths:?}"
+    );
+    assert!(
+        paths
+            .iter()
+            .any(|p| p == "jackdaw_avian_integration::AvianCollider"),
+        "AvianCollider should be authored, not only live ECS: {paths:?}"
+    );
+    assert!(
+        !paths.iter().any(|p| p.ends_with("::Position")),
+        "avian require companions must stay off the document: {paths:?}"
+    );
+}
+
 /// Every operator reading `entity` through `as_entity("entity")` must reject a
 /// `PropertyValue::Int`. `type_path` / `field_path` are filled with valid
 /// placeholders so the rejected entity param is the only thing that can drive
 /// the call to `Cancelled`.
+
 #[test]
 fn entity_param_rejects_int_across_inspector_and_hierarchy_ops() {
     let mut app = app_with_test_marker();


### PR DESCRIPTION
- Fixed colliders of brushes having incorrect geometry
- Avian collider and static rigid body added to brushes by default
- Brushes no longer remove components on edit undo
- Collider visualization set to off by default (was quite ugly to see on all brushes)
- Made brushes opaque (doesn't make sense for them to be translucent in the editor and opaque when seen in a game)
- Fix brush face drag going to infinity
- Made drag operations not cancel over UI
- Made drag operations match cursor movement