### PR TITLE
Add asset rows to the inspector

### DIFF
--- a/book/src/developer-guide/architecture.md
+++ b/book/src/developer-guide/architecture.md
@@ -110,12 +110,28 @@ that shows on `+ Add Component` enumerates the type registry,
 filters out anything tagged `@EditorHidden`, and sorts by
 category.
 
+A field holding a handle is an asset field: the row shows the path
+of the file behind it, with Pick, Clear and New beside it, and takes
+a file dragged onto it from the asset browser. Pick lists the files
+the project holds of that field's asset type, and offers the
+desktop's file dialog for a type with no asset files of its own,
+such as an image. Every one of the three writes through the same
+undoable field edit a scalar row uses, so one choice is one history
+entry. A material's texture slots are the same row.
+
+A project whose schema spells a reference as the path itself rather
+than as a handle gets the row too: a string field of an asset whose
+value names a file the project holds is shown as that file, and every
+element of a list of them keeps the row even while it is empty, so a
+list of material paths is picked from rather than typed.
+
 Code:
 
 - `src/inspector/mod.rs` is the dispatcher.
 - `src/inspector/component_picker.rs` is the `+ Add Component`
   flow.
 - `src/inspector/reflect_fields.rs` renders primitive fields.
+- `src/inspector/asset_row.rs` renders a field that names an asset.
 
 ## Extensions
 

--- a/crates/jackdaw_bsn/src/apply.rs
+++ b/crates/jackdaw_bsn/src/apply.rs
@@ -980,13 +980,12 @@ pub fn bsn_value_to_reflect(
                 return Some(typed.into_partial_reflect());
             }
         }
-        // Empty string or no asset server: return the default handle.
-        if let Some(registration) = registry.get(expected)
-            && let Some(reflect_default) = registration.data::<ReflectDefault>()
-        {
-            return Some(reflect_default.default().into_partial_reflect());
-        }
-        return None;
+        // Empty string or no asset server: the handle a field holds when it
+        // names nothing.
+        let cleared = reflect_handle.typed(bevy::asset::UntypedHandle::default_for_type(
+            reflect_handle.asset_type_id(),
+        ));
+        return Some(cleared.into_partial_reflect());
     }
 
     // If the expected type is `Option<Handle<T>>`, resolve a path string into

--- a/crates/jackdaw_bsn/src/header.rs
+++ b/crates/jackdaw_bsn/src/header.rs
@@ -105,13 +105,19 @@ pub fn asset_text_type(text: &str, path: &Path) -> Option<String> {
 /// Every `.bsn` and `.jsn` file under `dir`, as absolute paths, skipping
 /// hidden directories and following no symlink out of the tree.
 pub fn walk_document_files(dir: &Path) -> Vec<PathBuf> {
+    walk_files_with_extensions(dir, &["bsn", "jsn"])
+}
+
+/// Every file under `dir` whose extension is one of `extensions`, as absolute
+/// paths, skipping hidden directories and following no symlink out of the tree.
+pub fn walk_files_with_extensions(dir: &Path, extensions: &[&str]) -> Vec<PathBuf> {
     let mut found = Vec::new();
-    collect_document_files(dir, 0, &mut found);
+    collect_files(dir, extensions, 0, &mut found);
     found.sort();
     found
 }
 
-fn collect_document_files(dir: &Path, depth: usize, found: &mut Vec<PathBuf>) {
+fn collect_files(dir: &Path, extensions: &[&str], depth: usize, found: &mut Vec<PathBuf>) {
     if depth > MAX_ASSET_DEPTH {
         return;
     }
@@ -132,12 +138,14 @@ fn collect_document_files(dir: &Path, depth: usize, found: &mut Vec<PathBuf>) {
             continue;
         }
         if file_type.is_dir() {
-            collect_document_files(&path, depth + 1, found);
+            collect_files(&path, extensions, depth + 1, found);
         } else if path
             .extension()
             .and_then(|extension| extension.to_str())
             .is_some_and(|extension| {
-                extension.eq_ignore_ascii_case("bsn") || extension.eq_ignore_ascii_case("jsn")
+                extensions
+                    .iter()
+                    .any(|wanted| extension.eq_ignore_ascii_case(wanted))
             })
         {
             found.push(path);

--- a/crates/jackdaw_bsn/src/lib.rs
+++ b/crates/jackdaw_bsn/src/lib.rs
@@ -27,7 +27,7 @@ pub use catalog::{
 pub use header::{
     ASSET_HEADER, AssetFileError, PREFAB_TYPE, asset_file_type, asset_text_type,
     document_type_path, read_asset_file, read_asset_header, root_type_path, walk_asset_files,
-    walk_document_files, with_asset_header,
+    walk_document_files, walk_files_with_extensions, with_asset_header,
 };
 
 pub use parse::{ParseError, parse_bsn};

--- a/crates/jackdaw_feathers/src/swatch_row.rs
+++ b/crates/jackdaw_feathers/src/swatch_row.rs
@@ -15,6 +15,8 @@ pub struct SwatchRow {
     pub row: Entity,
     /// The square image node, for a caller that wants to observe it.
     pub swatch: Entity,
+    /// The text naming what is bound, for a caller that keeps it in step.
+    pub value: Entity,
     /// Trailing slot for assign/clear buttons.
     pub actions: Entity,
 }
@@ -30,6 +32,8 @@ pub struct SwatchRowProps {
     /// Dim the value text: nothing is bound, so the text is a placeholder
     /// rather than a name.
     pub unbound: bool,
+    /// Room the swatch, the name and the buttons need before the row wraps.
+    pub control_min_width: Option<f32>,
 }
 
 impl SwatchRowProps {
@@ -40,6 +44,7 @@ impl SwatchRowProps {
             image: None,
             indent: 0,
             unbound: true,
+            control_min_width: None,
         }
     }
 
@@ -60,6 +65,13 @@ impl SwatchRowProps {
         self.indent = levels;
         self
     }
+
+    /// Raise the floor under the control, so a row carrying more than a name
+    /// wraps rather than squeezing the name away.
+    pub fn with_control_min_width(mut self, width: f32) -> Self {
+        self.control_min_width = Some(width);
+        self
+    }
 }
 
 pub fn spawn_swatch_row(
@@ -67,11 +79,11 @@ pub fn spawn_swatch_row(
     parent: Entity,
     props: SwatchRowProps,
 ) -> SwatchRow {
-    let field = spawn_field_row(
-        commands,
-        parent,
-        FieldRowProps::new(props.label).indented(props.indent),
-    );
+    let mut row_props = FieldRowProps::new(props.label).indented(props.indent);
+    if let Some(width) = props.control_min_width {
+        row_props = row_props.with_control_min_width(width);
+    }
+    let field = spawn_field_row(commands, parent, row_props);
 
     let mut swatch = commands.spawn((
         Node {
@@ -89,26 +101,42 @@ pub fn spawn_swatch_row(
     }
     let swatch = swatch.id();
 
-    commands.spawn((
-        Text::new(props.value),
-        TextFont {
-            font_size: tokens::TEXT_SIZE_SM,
-            ..Default::default()
-        },
-        TextColor(if props.unbound {
-            tokens::TEXT_DISABLED
-        } else {
-            tokens::TEXT_TERTIARY
-        }),
-        Node {
-            flex_grow: 1.0,
-            flex_shrink: 1.0,
-            min_width: Val::Px(0.0),
-            overflow: Overflow::clip(),
-            ..Default::default()
-        },
-        ChildOf(field.control),
-    ));
+    // The text cannot clip its own glyphs, so it rides in a box that can: a
+    // name too long for the row is cut at the edge rather than drawn over
+    // whatever sits beside it.
+    let name_box = commands
+        .spawn((
+            Node {
+                flex_direction: FlexDirection::Row,
+                align_items: AlignItems::Center,
+                flex_grow: 1.0,
+                flex_shrink: 1.0,
+                min_width: Val::Px(0.0),
+                overflow: Overflow::clip(),
+                ..Default::default()
+            },
+            ChildOf(field.control),
+        ))
+        .id();
+    let value = commands
+        .spawn((
+            Text::new(props.value),
+            TextFont {
+                font_size: tokens::TEXT_SIZE_SM,
+                ..Default::default()
+            },
+            TextColor(if props.unbound {
+                tokens::TEXT_DISABLED
+            } else {
+                tokens::TEXT_TERTIARY
+            }),
+            Node {
+                flex_shrink: 0.0,
+                ..Default::default()
+            },
+            ChildOf(name_box),
+        ))
+        .id();
 
     let actions = commands
         .spawn((
@@ -126,6 +154,7 @@ pub fn spawn_swatch_row(
     SwatchRow {
         row: field.row,
         swatch,
+        value,
         actions,
     }
 }

--- a/src/commands.rs
+++ b/src/commands.rs
@@ -1603,6 +1603,15 @@ pub(crate) fn json_field_edit_to_bsn_value(
     let mut merged: Box<dyn Reflect> = registration
         .data::<bevy::reflect::ReflectFromReflect>()?
         .from_reflect(component.as_partial_reflect())?;
+    // A field naming an asset is authored as the path itself.
+    if let Some(text) = value.as_str()
+        && let Ok(field) = merged.reflect_path(field_path)
+        && field
+            .get_represented_type_info()
+            .is_some_and(|info| crate::typed_values::takes_asset_path(&registry, info.type_id()))
+    {
+        return Some(jackdaw_bsn::BsnValue::String(text.to_string()));
+    }
     if let Ok(field) = merged.reflect_path_mut(field_path) {
         apply_json_to_reflect(field, value, &registry);
     }

--- a/src/definition_assets.rs
+++ b/src/definition_assets.rs
@@ -802,6 +802,82 @@ pub(crate) fn commit_definition_field(
     true
 }
 
+/// The path a field of the open asset names, whichever way the asset is held.
+pub(crate) fn asset_field_text(
+    world: &World,
+    entity: Entity,
+    type_path: &str,
+    field_path: &str,
+) -> Option<String> {
+    let json = field_as_json(world, entity, type_path, field_path)?;
+    Some(json.as_str().unwrap_or_default().to_string())
+}
+
+/// The path a field of the asset behind a handle names.
+pub(crate) fn handle_field_text(
+    world: &World,
+    handle: &UntypedHandle,
+    field_path: &str,
+) -> Option<String> {
+    let type_path = handle_type_path(world, handle)?;
+    let json = asset_field_json(world, handle, &type_path, field_path)?;
+    Some(json.as_str().unwrap_or_default().to_string())
+}
+
+/// Set one field of the asset a handle points at, as one undo entry.
+///
+/// An asset with a file of its own is edited through that file, so undo reaches
+/// it the way it reaches the open card. One the editor only holds in memory,
+/// such as a material created and not yet saved, is written straight to its
+/// store and mints no history, since there is no file to key an entry by.
+pub(crate) fn commit_handle_field(
+    world: &mut World,
+    handle: &UntypedHandle,
+    field_path: &str,
+    new_json: &serde_json::Value,
+) -> bool {
+    let entry = world
+        .get_resource::<AssetIndex>()
+        .and_then(|index| index.by_handle(handle))
+        .map(|entry| (entry.path.clone(), entry.type_path.clone()));
+    let Some((path, type_path)) = entry else {
+        let Some(type_path) = handle_type_path(world, handle) else {
+            return false;
+        };
+        return write_asset_field(world, handle, &type_path, field_path, new_json);
+    };
+    let Some(old_json) = asset_field_json(world, handle, &type_path, field_path) else {
+        return false;
+    };
+    let command = SetDefinitionField {
+        path,
+        type_path,
+        field_path: field_path.to_string(),
+        old_json,
+        new_json: new_json.clone(),
+        rebuilds_rows: false,
+    };
+    if !command.apply(world, new_json) {
+        return false;
+    }
+    world
+        .resource_mut::<CommandHistory>()
+        .push_executed(Box::new(command));
+    true
+}
+
+/// The type a handle's asset store holds, as its files name it.
+fn handle_type_path(world: &World, handle: &UntypedHandle) -> Option<String> {
+    let registry = world.resource::<AppTypeRegistry>().read();
+    Some(
+        registry
+            .get(handle.type_id())?
+            .type_info()
+            .type_path()
+            .to_string(),
+    )
+}
+
 /// Write a field of the open asset without an undo entry, for the ticks of a
 /// drag.
 pub(crate) fn preview_definition_field(
@@ -1093,6 +1169,8 @@ pub(crate) fn add_to_extension(ctx: &mut ExtensionContext) {
         .register_operator::<AssetSaveOp>()
         .register_operator::<AssetDeleteOp>()
         .register_operator::<AssetSetOp>()
+        .register_operator::<AssetPickOp>()
+        .register_operator::<AssetClearOp>()
         .register_operator::<AssetListOp>();
 }
 
@@ -1187,7 +1265,7 @@ fn new_definition(world: &mut World, kind: &str, name: Option<&str>, dir: Option
 }
 
 /// Write a fresh default value of a registered kind to its file and index it.
-fn create_definition(
+pub(crate) fn create_definition(
     world: &mut World,
     kind: &str,
     name: Option<&str>,
@@ -1197,10 +1275,6 @@ fn create_definition(
         warn!("asset.new: '{kind}' is not a registered asset type");
         return None;
     };
-    if !definition.scanned() {
-        warn!("asset.new: {kind} files are created by the panel that loads them");
-        return None;
-    }
     let (dir, file) = match dir {
         Some(file) if names_a_file(file) => (
             file.parent().unwrap_or(file).to_path_buf(),
@@ -1415,6 +1489,92 @@ fn set_definition_field(world: &mut World, field: &str, value: &str) {
     } else {
         warn!("asset.set: {type_path} did not take '{value}' for '{field}'");
     }
+}
+
+/// Drive the Pick beside an asset field, so the row's own choice can be made
+/// without the pointer.
+#[operator(
+    id = "asset.pick",
+    label = "Pick Asset",
+    description = "Choose the file an asset field names, or put up the list to choose from.",
+    allows_undo = false,
+    params(
+        field(
+            String,
+            doc = "Field path of the asset field, for example 'materials[0]'."
+        ),
+        value(
+            String,
+            doc = "File to assign, as a path under the project's assets. Left \
+                   out, the picker opens on the field instead."
+        )
+    )
+)]
+pub(crate) fn asset_pick(
+    params: In<OperatorParameters>,
+    rows: Query<(Entity, &crate::inspector::asset_row::AssetFieldRow)>,
+    mut commands: Commands,
+) -> OperatorResult {
+    let Some(field) = params.as_str("field").map(str::to_owned) else {
+        warn!("asset.pick: no field given");
+        return OperatorResult::Cancelled;
+    };
+    let Some(row) = showing_asset_field(&rows, &field) else {
+        warn!("asset.pick: no asset field is showing for '{field}'");
+        return OperatorResult::Cancelled;
+    };
+    let value = params.as_str("value").map(str::to_owned);
+    commands.queue(move |world: &mut World| match value {
+        Some(value) => {
+            if crate::inspector::asset_row::commit_asset_row(world, row, &value) {
+                report_to_caller(world, format!("Set {field}"));
+            } else {
+                warn!("asset.pick: '{field}' did not take '{value}'");
+            }
+        }
+        None => crate::inspector::asset_row::open_asset_picker(world, row),
+    });
+    OperatorResult::Finished
+}
+
+/// The row writing this field, for an operator that names a field rather than
+/// clicking a row.
+fn showing_asset_field(
+    rows: &Query<(Entity, &crate::inspector::asset_row::AssetFieldRow)>,
+    field: &str,
+) -> Option<Entity> {
+    rows.iter()
+        .find(|(_, row)| row.field_path == field)
+        .map(|(entity, _)| entity)
+}
+
+/// Leave an asset field naming nothing.
+#[operator(
+    id = "asset.clear",
+    label = "Clear Asset",
+    description = "Leave an asset field naming no file.",
+    allows_undo = false,
+    params(field(String, doc = "Field path of the asset field to clear."))
+)]
+pub(crate) fn asset_clear(
+    params: In<OperatorParameters>,
+    rows: Query<(Entity, &crate::inspector::asset_row::AssetFieldRow)>,
+    mut commands: Commands,
+) -> OperatorResult {
+    let Some(field) = params.as_str("field").map(str::to_owned) else {
+        warn!("asset.clear: no field given");
+        return OperatorResult::Cancelled;
+    };
+    let Some(row) = showing_asset_field(&rows, &field) else {
+        warn!("asset.clear: no asset field is showing for '{field}'");
+        return OperatorResult::Cancelled;
+    };
+    commands.queue(move |world: &mut World| {
+        if crate::inspector::asset_row::commit_asset_row(world, row, "") {
+            report_to_caller(world, format!("Cleared {field}"));
+        }
+    });
+    OperatorResult::Finished
 }
 
 /// Report the files of a kind this project holds.

--- a/src/inspector/asset_row.rs
+++ b/src/inspector/asset_row.rs
@@ -1,0 +1,857 @@
+//! The inspector row for a field that names an asset.
+//!
+//! A field holding a `Handle<T>`, an `Option<Handle<T>>`, or a path a schema
+//! asset spells as a string, shows the file it names, with Pick, Clear and New
+//! beside it and a drop target for the asset browser's drag. Every action
+//! commits through the undoable field edit the scalar rows use, so one choice
+//! is one history entry and undo puts the previous path back.
+
+use std::path::{Path, PathBuf};
+
+use bevy::asset::UntypedHandle;
+use bevy::picking::events::{DragDrop, Pointer};
+use bevy::prelude::*;
+use bevy::reflect::PartialReflect;
+use jackdaw_api::prelude::AssetKinds;
+use jackdaw_feathers::picker::{
+    PickerItems, PickerProps, SelectInput, SpawnItemInput, match_text, picker_item,
+};
+use jackdaw_feathers::{
+    button::{ButtonClickEvent, ButtonVariant, IconButtonProps, icon_button},
+    field_row::{FieldRowProps, spawn_field_row},
+    icons::Icon,
+    tokens,
+    tooltip::Tooltip,
+};
+
+use crate::asset_browser::ActiveAssetDrag;
+use crate::asset_index::AssetIndex;
+
+/// Shown in place of a path when the field names nothing.
+const NOTHING: &str = "None";
+
+/// Room a file name and the three actions need beside a label before the row
+/// wraps the control onto a line of its own.
+pub(crate) const ASSET_CONTROL_MIN_WIDTH: f32 = 144.0;
+
+/// How many characters of a file name a row shows before it cuts the rest
+/// away. The names in one folder differ at the front, so the front is what a
+/// shortened one keeps.
+const NAME_BUDGET: usize = 28;
+
+/// The picker entry that hands the choice to the desktop's own file dialog,
+/// for an asset kind whose files the project does not index.
+const BROWSE: &str = "Browse...";
+
+/// The file extensions an image field offers, for a type with no asset files
+/// of its own to list.
+const IMAGE_EXTENSIONS: &[&str] = &[
+    "png", "jpg", "jpeg", "ktx2", "basis", "dds", "tga", "exr", "hdr", "webp", "bmp",
+];
+
+/// What a handle row writes to.
+#[derive(Clone)]
+pub(crate) enum AssetFieldTarget {
+    /// A field of the component, or the open asset, the inspector is showing.
+    Inspected { source: Entity, type_path: String },
+    /// A field of an asset the editor holds a handle to, such as the material
+    /// a texture slot sits on.
+    Held(UntypedHandle),
+}
+
+/// A row showing, and writing, one field that names an asset.
+#[derive(Component, Clone)]
+pub(crate) struct AssetFieldRow {
+    pub(crate) target: AssetFieldTarget,
+    pub(crate) field_path: String,
+    /// Reflect type path of the asset the field names.
+    pub(crate) asset_type_path: String,
+    /// The text showing the path, for a row that draws one of its own.
+    pub(crate) path_text: Option<Entity>,
+}
+
+/// One of the row's actions, and the row it acts on.
+#[derive(Component, Clone, Copy)]
+pub(crate) struct AssetRowAction {
+    row: Entity,
+    action: Action,
+}
+
+#[derive(Clone, Copy, PartialEq, Eq)]
+pub(crate) enum Action {
+    Pick,
+    Clear,
+    New,
+}
+
+/// The three actions every asset row carries, as the glyph and the words that
+/// stand for each.
+const ACTIONS: [(Action, Icon, &str, &str); 3] = [
+    (
+        Action::Pick,
+        Icon::FolderOpen,
+        "Pick",
+        "Choose the file this field names",
+    ),
+    (
+        Action::Clear,
+        Icon::X,
+        "Clear",
+        "Leave this field naming nothing",
+    ),
+    (
+        Action::New,
+        Icon::Plus,
+        "New",
+        "Create a file of this type and name it here",
+    ),
+];
+
+/// A row whose host writes the path itself, for a slot that loads its file in
+/// a way of its own. The hook reports whether it wrote.
+#[derive(Component)]
+pub(crate) struct AssetFieldWriter(pub(crate) Box<dyn Fn(&mut World, &str) -> bool + Send + Sync>);
+
+/// The picker a row's Pick opened, so its choice reaches the row that asked.
+#[derive(Component)]
+pub(crate) struct AssetFieldPicker(pub(crate) Entity);
+
+/// Everything a row needs to know about the field it stands for.
+#[derive(Clone)]
+pub(crate) struct AssetRowProps {
+    pub(crate) target: AssetFieldTarget,
+    pub(crate) field_path: String,
+    pub(crate) asset_type_path: String,
+    pub(crate) label: String,
+    pub(crate) indent: u8,
+}
+
+/// Spawn a row of its own for an asset field: the label, the path, and the
+/// actions that change it.
+pub(crate) fn spawn_asset_row(
+    commands: &mut Commands,
+    parent: Entity,
+    props: AssetRowProps,
+    icon_font: &Handle<Font>,
+) -> Entity {
+    let (row, control) = if props.label.is_empty() {
+        let row = commands
+            .spawn((
+                Node {
+                    flex_direction: FlexDirection::Row,
+                    align_items: AlignItems::Center,
+                    column_gap: Val::Px(tokens::SPACING_XS),
+                    flex_grow: 1.0,
+                    flex_shrink: 1.0,
+                    min_width: Val::Px(0.0),
+                    ..default()
+                },
+                ChildOf(parent),
+            ))
+            .id();
+        (row, row)
+    } else {
+        let field = spawn_field_row(
+            commands,
+            parent,
+            FieldRowProps::new(props.label.clone())
+                .indented(props.indent)
+                .with_control_min_width(ASSET_CONTROL_MIN_WIDTH),
+        );
+        commands
+            .entity(field.row)
+            .entry::<Node>()
+            .and_modify(|mut node| {
+                node.min_width = Val::Px(0.0);
+                node.flex_shrink = 1.0;
+            });
+        (field.row, field.control)
+    };
+    let name_box = commands
+        .spawn((
+            Node {
+                flex_direction: FlexDirection::Row,
+                align_items: AlignItems::Center,
+                flex_grow: 1.0,
+                flex_shrink: 1.0,
+                min_width: Val::Px(0.0),
+                overflow: Overflow::clip(),
+                ..default()
+            },
+            ChildOf(control),
+        ))
+        .id();
+    let path_text = commands
+        .spawn((
+            Text::new(NOTHING),
+            TextFont {
+                font_size: tokens::TEXT_SIZE_SM,
+                ..default()
+            },
+            TextColor(tokens::TEXT_DISABLED),
+            Node {
+                flex_shrink: 0.0,
+                ..default()
+            },
+            ChildOf(name_box),
+        ))
+        .id();
+    let actions = commands
+        .spawn((
+            Node {
+                flex_direction: FlexDirection::Row,
+                align_items: AlignItems::Center,
+                column_gap: Val::Px(tokens::SPACING_XS),
+                flex_shrink: 0.0,
+                ..default()
+            },
+            ChildOf(control),
+        ))
+        .id();
+    attach_asset_field(commands, row, actions, props, Some(path_text), icon_font);
+    row
+}
+
+/// Put the actions, the drop target and the row marker on a row another panel
+/// already built, such as a material's texture slot.
+pub(crate) fn attach_asset_field(
+    commands: &mut Commands,
+    row: Entity,
+    actions: Entity,
+    props: AssetRowProps,
+    path_text: Option<Entity>,
+    icon_font: &Handle<Font>,
+) {
+    commands.entity(row).insert(AssetFieldRow {
+        target: props.target,
+        field_path: props.field_path,
+        asset_type_path: props.asset_type_path,
+        path_text,
+    });
+    if let Some(text) = path_text {
+        commands
+            .entity(text)
+            .insert((
+                TextLayout {
+                    linebreak: bevy::text::LineBreak::NoWrap,
+                    ..default()
+                },
+                bevy::picking::hover::Hovered::default(),
+                Tooltip::title(NOTHING),
+            ))
+            .observe(move |_: On<Pointer<Click>>, mut commands: Commands| {
+                commands.queue(move |world: &mut World| {
+                    open_asset_picker(world, row);
+                });
+            });
+    }
+    for (action, icon, title, description) in ACTIONS {
+        commands.spawn((
+            icon_button(
+                IconButtonProps::new(icon).variant(ButtonVariant::Ghost),
+                icon_font,
+            ),
+            bevy::picking::hover::Hovered::default(),
+            Tooltip::title(title).with_description(description),
+            AssetRowAction { row, action },
+            ChildOf(actions),
+        ));
+    }
+    commands.entity(row).observe(
+        move |mut event: On<Pointer<DragDrop>>,
+              mut drag: ResMut<ActiveAssetDrag>,
+              mut commands: Commands| {
+            let Some(dropped) = drag.path.take().or_else(|| drag.image.take()) else {
+                return;
+            };
+            event.propagate(false);
+            commands.queue(move |world: &mut World| {
+                accept_asset_drop(world, row, &dropped);
+            });
+        },
+    );
+    commands.queue(move |world: &mut World| {
+        show_asset_row_path(world, row);
+    });
+}
+
+/// The asset a field names, ready for a row, or `None` when the field names no
+/// asset at all.
+pub(crate) fn asset_type_of_field(
+    registry: &AppTypeRegistry,
+    value: &dyn PartialReflect,
+) -> Option<String> {
+    let type_id = value.get_represented_type_info()?.type_id();
+    let registry = registry.read();
+    crate::typed_values::asset_type_path(&registry, type_id)
+}
+
+// -- Reading what a row shows ----------------------------------------------
+
+/// The path a row's field names, or `None` when the editor cannot read it.
+fn field_path_text(world: &World, row: &AssetFieldRow) -> Option<String> {
+    match &row.target {
+        AssetFieldTarget::Inspected { source, type_path } => {
+            if let Some(text) = crate::definition_assets::asset_field_text(
+                world,
+                *source,
+                type_path,
+                &row.field_path,
+            ) {
+                return Some(text);
+            }
+            component_field_text(world, *source, type_path, &row.field_path)
+        }
+        AssetFieldTarget::Held(handle) => {
+            crate::definition_assets::handle_field_text(world, handle, &row.field_path)
+        }
+    }
+}
+
+/// The path a field of a component on a live entity names.
+fn component_field_text(
+    world: &World,
+    source: Entity,
+    type_path: &str,
+    field_path: &str,
+) -> Option<String> {
+    use bevy::reflect::GetPath as _;
+
+    let registry = world.resource::<AppTypeRegistry>().clone();
+    let registry = registry.read();
+    let registration = registry.get_with_type_path(type_path)?;
+    let entity_ref = world.get_entity(source).ok()?;
+    let value = super::reflect_fields::inspected_value(world, entity_ref, registration, &registry)?;
+    let field = if field_path.is_empty() {
+        value.as_partial_reflect()
+    } else {
+        value.reflect_path(field_path).ok()?
+    };
+    let server = world.get_resource::<AssetServer>();
+    let index = world.get_resource::<AssetIndex>();
+    let json = crate::typed_values::asset_path_json(&registry, server, index, field)?;
+    Some(json.as_str().unwrap_or_default().to_string())
+}
+
+/// Write what the field names into the row's text, for a row that draws one.
+pub(crate) fn show_asset_row_path(world: &mut World, row: Entity) {
+    let Some(field) = world.get::<AssetFieldRow>(row).cloned() else {
+        return;
+    };
+    let Some(text_entity) = field.path_text else {
+        return;
+    };
+    let Some(path) = field_path_text(world, &field) else {
+        return;
+    };
+    let shown = if path.is_empty() {
+        NOTHING.to_string()
+    } else {
+        shown_name(&path)
+    };
+    let Ok(mut entity) = world.get_entity_mut(text_entity) else {
+        return;
+    };
+    if entity.get::<Text>().is_some_and(|text| text.0 == shown) {
+        return;
+    }
+    let told = if path.is_empty() {
+        NOTHING.to_string()
+    } else {
+        path.clone()
+    };
+    entity.insert((
+        Text::new(shown),
+        Tooltip::title(told),
+        TextColor(if path.is_empty() {
+            tokens::TEXT_DISABLED
+        } else {
+            tokens::TEXT_TERTIARY
+        }),
+    ));
+}
+
+/// The file a path names, shortened to what a row can hold, so the row stays
+/// one line. The whole path is on the row's tooltip.
+pub(crate) fn shown_name(path: &str) -> String {
+    let name = path.rsplit('/').next().unwrap_or(path);
+    if name.chars().count() <= NAME_BUDGET {
+        return name.to_string();
+    }
+    let kept: String = name.chars().take(NAME_BUDGET - 3).collect();
+    format!("{kept}...")
+}
+
+/// Keep every asset row showing what its field holds, so an undo, an operator
+/// or an edit from another panel moves the text with it.
+///
+/// A row reading the inspected entity is read only when something it shows
+/// changed, the way the scalar rows refresh, so a still panel costs nothing. A
+/// row reading an asset of its own, such as a material's texture slot, sits
+/// outside that entity and is read every run.
+pub(crate) fn refresh_asset_rows(
+    world: &mut World,
+    mut last_run: Local<Option<bevy::ecs::change_detection::Tick>>,
+) {
+    let this_run = world.read_change_tick();
+    let previous = last_run.replace(this_run);
+    let inspected_changed = inspected_rows_changed(world, previous, this_run);
+    let rows: Vec<Entity> = world
+        .query_filtered::<Entity, With<AssetFieldRow>>()
+        .iter(world)
+        .collect();
+    for row in rows {
+        let held = world
+            .get::<AssetFieldRow>(row)
+            .is_some_and(|field| matches!(field.target, AssetFieldTarget::Held(_)));
+        if held || inspected_changed {
+            show_asset_row_path(world, row);
+        }
+    }
+}
+
+/// Whether the entity the inspector is showing changed since the last run.
+fn inspected_rows_changed(
+    world: &World,
+    previous: Option<bevy::ecs::change_detection::Tick>,
+    this_run: bevy::ecs::change_detection::Tick,
+) -> bool {
+    let Some(primary) = world
+        .get_resource::<crate::selection::Selection>()
+        .and_then(crate::selection::Selection::primary)
+    else {
+        return false;
+    };
+    let Some(previous) = previous else {
+        return true;
+    };
+    let Ok(entity_ref) = world.get_entity(primary) else {
+        return false;
+    };
+    super::reflect_fields::entity_components_changed(entity_ref, previous, this_run)
+}
+
+// -- Writing --------------------------------------------------------------
+
+/// Write a path into the field a row stands for, as one undo entry.
+pub(crate) fn commit_asset_row(world: &mut World, row: Entity, path: &str) -> bool {
+    let Some(field) = world.get::<AssetFieldRow>(row).cloned() else {
+        return false;
+    };
+    if world.get::<AssetFieldWriter>(row).is_some() {
+        let Some(writer) = world.entity_mut(row).take::<AssetFieldWriter>() else {
+            return false;
+        };
+        let written = (writer.0)(world, path);
+        if let Ok(mut entity) = world.get_entity_mut(row) {
+            entity.insert(writer);
+        }
+        show_asset_row_path(world, row);
+        return written;
+    }
+    let json = serde_json::Value::String(path.to_string());
+    let written = match &field.target {
+        AssetFieldTarget::Inspected { source, type_path } => {
+            select_source(world, *source);
+            crate::commands::field_edit_commit(
+                world,
+                type_path,
+                &field.field_path,
+                &json,
+                "Set asset field",
+            );
+            field_path_text(world, &field).is_none_or(|now| now == path)
+        }
+        AssetFieldTarget::Held(handle) => {
+            crate::definition_assets::commit_handle_field(world, handle, &field.field_path, &json)
+        }
+    };
+    show_asset_row_path(world, row);
+    written
+}
+
+/// Put the selection on the entity a row edits, since a field edit writes what
+/// is selected.
+fn select_source(world: &mut World, source: Entity) {
+    if world
+        .get_resource::<crate::selection::Selection>()
+        .and_then(crate::selection::Selection::primary)
+        == Some(source)
+    {
+        return;
+    }
+    if world.get_entity(source).is_ok() {
+        crate::selection::select_only(world, source);
+    }
+}
+
+// -- Actions ---------------------------------------------------------------
+
+/// Run a row's Pick, Clear or New when its button is clicked.
+pub(crate) fn on_asset_row_button(
+    event: On<ButtonClickEvent>,
+    actions: Query<&AssetRowAction>,
+    mut commands: Commands,
+) {
+    let Ok(&AssetRowAction { row, action }) = actions.get(event.entity) else {
+        return;
+    };
+    commands.queue(move |world: &mut World| match action {
+        Action::Pick => open_asset_picker(world, row),
+        Action::Clear => {
+            commit_asset_row(world, row, "");
+        }
+        Action::New => new_asset_for_row(world, row),
+    });
+}
+
+/// The files this project holds of a row's asset type, as the paths that name
+/// them.
+pub(crate) fn assets_for_row(world: &World, row: &AssetFieldRow) -> Vec<String> {
+    if let Some(kind) = world
+        .get_resource::<AssetKinds>()
+        .and_then(|kinds| kinds.by_type_path(&row.asset_type_path))
+    {
+        return world
+            .get_resource::<AssetIndex>()
+            .map(|index| index.paths_of_kind(&kind.kind))
+            .unwrap_or_default();
+    }
+    let extensions = file_extensions(&row.asset_type_path);
+    if extensions.is_empty() {
+        return Vec::new();
+    }
+    let Some(assets) = crate::asset_index::assets_dir(world) else {
+        return Vec::new();
+    };
+    use path_slash::PathExt as _;
+    jackdaw_bsn::walk_files_with_extensions(&assets, extensions)
+        .into_iter()
+        .filter_map(|path| {
+            Some(
+                path.strip_prefix(&assets)
+                    .ok()?
+                    .to_slash_lossy()
+                    .into_owned(),
+            )
+        })
+        .collect()
+}
+
+/// The extensions the files of an asset type carry, for a type whose files the
+/// project does not index as assets of its own.
+fn file_extensions(asset_type_path: &str) -> &'static [&'static str] {
+    use bevy::reflect::TypePath as _;
+
+    if asset_type_path == Image::type_path() {
+        IMAGE_EXTENSIONS
+    } else {
+        &[]
+    }
+}
+
+/// Put up the list of files the row's field can name, in place of the list
+/// another row left open.
+pub(crate) fn open_asset_picker(world: &mut World, row: Entity) {
+    let Some(field) = world.get::<AssetFieldRow>(row).cloned() else {
+        return;
+    };
+    close_open_asset_picker(world);
+    let mut items = assets_for_row(world, &field);
+    let browsable = !file_extensions(&field.asset_type_path).is_empty();
+    if browsable {
+        items.push(BROWSE.to_string());
+    }
+    if items.is_empty() {
+        crate::status_bar::notify_warn(
+            world,
+            format!(
+                "this project holds no {}",
+                short_type(&field.asset_type_path)
+            ),
+        );
+        return;
+    }
+    let title = format!("Pick {}", short_type(&field.asset_type_path));
+    world.commands().spawn((
+        PickerProps::new(spawn_picker_item, pick_asset)
+            .items(items)
+            .title(title)
+            .placeholder(Some("Search assets..")),
+        AssetFieldPicker(row),
+        crate::EditorEntity,
+        crate::BlocksCameraInput,
+    ));
+    world.flush();
+}
+
+/// The last segment of a type path, for a line a person reads.
+fn short_type(type_path: &str) -> &str {
+    type_path.rsplit("::").next().unwrap_or(type_path)
+}
+
+/// Drop the list a row put up, so a second Pick replaces it rather than
+/// stacking another list over it.
+pub(crate) fn close_open_asset_picker(world: &mut World) {
+    let open: Vec<Entity> = world
+        .query_filtered::<Entity, With<AssetFieldPicker>>()
+        .iter(world)
+        .collect();
+    for picker in open {
+        if let Ok(entity) = world.get_entity_mut(picker) {
+            entity.despawn();
+        }
+    }
+}
+
+fn spawn_picker_item(
+    In(SpawnItemInput { matched, entities }): In<SpawnItemInput>,
+    mut commands: Commands,
+) -> Result {
+    commands.spawn((
+        picker_item(matched.index),
+        ChildOf(entities.list),
+        children![match_text(matched.segments)],
+    ));
+    Ok(())
+}
+
+fn pick_asset(
+    input: In<SelectInput>,
+    items: Query<&PickerItems<String>>,
+    pickers: Query<&AssetFieldPicker>,
+    mut commands: Commands,
+) -> Result {
+    let picker = input.entities.picker;
+    let chosen = items.get(picker)?.at(input.index)?.clone();
+    let row = pickers.get(picker).map(|picker| picker.0);
+    commands.entity(picker).try_despawn();
+    let Ok(row) = row else { return Ok(()) };
+    commands.queue(move |world: &mut World| {
+        if chosen == BROWSE {
+            browse_for_asset(world, row);
+            return;
+        }
+        commit_asset_row(world, row, &chosen);
+    });
+    Ok(())
+}
+
+/// Hand the choice to the desktop's file dialog, for a file the project does
+/// not hold as an asset of its own. The dialog opens beside the asset the
+/// field belongs to, which is where its files usually sit.
+fn browse_for_asset(world: &mut World, row: Entity) {
+    let Some(field) = world.get::<AssetFieldRow>(row).cloned() else {
+        return;
+    };
+    let extensions = file_extensions(&field.asset_type_path);
+    if extensions.is_empty() {
+        return;
+    }
+    let beside = folder_of_asset(world, &field);
+    let dialog = match beside {
+        Some(folder) => crate::native_dialog::dialog_starting_at(world, Some(folder)),
+        None => {
+            crate::native_dialog::file_dialog(world, crate::native_dialog::DialogPurpose::Texture)
+        }
+    }
+    .set_title(format!("Select a file for {}", field.field_path))
+    .add_filter(short_type(&field.asset_type_path), extensions);
+    let task =
+        bevy::tasks::AsyncComputeTaskPool::get().spawn(async move { dialog.pick_file().await });
+    world.insert_resource(AssetBrowsePick { task, row });
+}
+
+/// A file dialog a row opened, waiting on what the user chose.
+#[derive(Resource)]
+struct AssetBrowsePick {
+    task: bevy::tasks::Task<Option<rfd::FileHandle>>,
+    row: Entity,
+}
+
+/// Assign what a row's file dialog came back with.
+pub(crate) fn poll_asset_browse_pick(world: &mut World) {
+    let Some(pick) = world.get_resource::<AssetBrowsePick>() else {
+        return;
+    };
+    if !pick.task.is_finished() {
+        return;
+    }
+    let Some(mut pick) = world.remove_resource::<AssetBrowsePick>() else {
+        return;
+    };
+    let Some(chosen) = bevy::tasks::block_on(bevy::tasks::poll_once(&mut pick.task)).flatten()
+    else {
+        return;
+    };
+    let file = chosen.path().to_path_buf();
+    crate::native_dialog::remember_pick(world, crate::native_dialog::DialogPurpose::Texture, &file);
+    let Some(relative) = crate::asset_index::indexed_path(world, &file) else {
+        crate::status_bar::notify_error(
+            world,
+            "that file is outside this project's assets".to_string(),
+        );
+        return;
+    };
+    use path_slash::PathExt as _;
+    let path = relative.to_slash_lossy().into_owned();
+    commit_asset_row(world, pick.row, &path);
+}
+
+// -- New -------------------------------------------------------------------
+
+/// Write a fresh asset of the field's type beside whatever is being edited and
+/// assign it, without taking the inspector off the field.
+fn new_asset_for_row(world: &mut World, row: Entity) {
+    let Some(field) = world.get::<AssetFieldRow>(row).cloned() else {
+        return;
+    };
+    let Some(kind) = world
+        .get_resource::<AssetKinds>()
+        .and_then(|kinds| kinds.by_type_path(&field.asset_type_path))
+        .map(|kind| kind.kind.clone())
+    else {
+        crate::status_bar::notify_error(
+            world,
+            format!("nothing creates a {}", short_type(&field.asset_type_path)),
+        );
+        return;
+    };
+    let dir = new_asset_dir(world, &field);
+    let Some((_, _, path)) =
+        crate::definition_assets::create_definition(world, &kind, None, dir.as_deref())
+    else {
+        crate::status_bar::notify_error(world, format!("no {kind} could be written there"));
+        return;
+    };
+    use path_slash::PathExt as _;
+    let path = path.to_slash_lossy().into_owned();
+    commit_asset_row(world, row, &path);
+}
+
+/// Where a row's New writes: beside the asset the field belongs to, and in the
+/// folder the browser is showing for anything else.
+fn new_asset_dir(world: &World, field: &AssetFieldRow) -> Option<PathBuf> {
+    folder_of_asset(world, field).or_else(|| crate::definition_assets::new_definition_dir(world))
+}
+
+/// The folder holding the asset whose field a row writes, when that asset came
+/// from a file and the folder is still there.
+fn folder_of_asset(world: &World, field: &AssetFieldRow) -> Option<PathBuf> {
+    let file = match &field.target {
+        AssetFieldTarget::Inspected { .. } => crate::definition_assets::open_definition_path(world),
+        AssetFieldTarget::Held(handle) => world
+            .get_resource::<AssetIndex>()
+            .and_then(|index| index.by_handle(handle))
+            .map(|entry| entry.path.clone()),
+    };
+    folder_beside(&crate::asset_index::assets_dir(world)?, &file?)
+}
+
+/// The folder an asset file sits in, as an absolute path, when it is there.
+fn folder_beside(assets_root: &Path, asset: &Path) -> Option<PathBuf> {
+    let folder = assets_root.join(asset.parent()?);
+    folder.is_dir().then_some(folder)
+}
+
+// -- Dropping --------------------------------------------------------------
+
+/// Take a file dragged out of the asset browser, when it holds what the field
+/// names, and say so when it does not.
+fn accept_asset_drop(world: &mut World, row: Entity, dropped: &Path) {
+    let Some(field) = world.get::<AssetFieldRow>(row).cloned() else {
+        return;
+    };
+    let Some(relative) = crate::asset_index::indexed_path(world, dropped) else {
+        crate::status_bar::notify_error(world, "that file is outside this project's assets");
+        return;
+    };
+    use path_slash::PathExt as _;
+    let path = relative.to_slash_lossy().into_owned();
+    if !assets_for_row(world, &field)
+        .iter()
+        .any(|held| held == &path)
+    {
+        crate::status_bar::notify_error(
+            world,
+            format!("{path} holds no {}", short_type(&field.asset_type_path)),
+        );
+        return;
+    }
+    commit_asset_row(world, row, &path);
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::project::{ProjectConfig, ProjectRoot};
+
+    fn row_naming(asset_type_path: &str) -> AssetFieldRow {
+        AssetFieldRow {
+            target: AssetFieldTarget::Inspected {
+                source: Entity::PLACEHOLDER,
+                type_path: String::new(),
+            },
+            field_path: "base_color_texture".to_string(),
+            asset_type_path: asset_type_path.to_string(),
+            path_text: None,
+        }
+    }
+
+    /// No asset file holds an image, so an image field offers the image files
+    /// the project holds rather than nothing.
+    #[test]
+    fn an_image_field_offers_the_image_files_the_project_holds() {
+        use bevy::reflect::TypePath as _;
+
+        let tmp = tempfile::tempdir().expect("tempdir");
+        let textures = tmp.path().join("assets/textures");
+        std::fs::create_dir_all(&textures).expect("a textures folder");
+        std::fs::write(textures.join("rock.png"), []).expect("an image file");
+        std::fs::write(textures.join("rock.bsn"), []).expect("a document beside it");
+        let mut world = World::new();
+        world.insert_resource(ProjectRoot {
+            root: tmp.path().to_path_buf(),
+            config: ProjectConfig::default(),
+        });
+
+        assert_eq!(
+            assets_for_row(&world, &row_naming(Image::type_path())),
+            vec!["textures/rock.png".to_string()],
+            "the files offered are the ones an image field can name",
+        );
+    }
+
+    /// A dialog a row opens starts in the folder the asset it edits sits in.
+    #[test]
+    fn a_browse_starts_in_the_folder_holding_the_asset() {
+        let tmp = tempfile::tempdir().expect("tempdir");
+        let assets = tmp.path();
+        std::fs::create_dir_all(assets.join("materials/stone")).expect("the material folder");
+
+        assert_eq!(
+            folder_beside(assets, Path::new("materials/stone/granite.bsn")),
+            Some(assets.join("materials/stone")),
+        );
+        assert_eq!(
+            folder_beside(assets, Path::new("materials/gone/granite.bsn")),
+            None,
+            "a folder that is not there sends the dialog somewhere else",
+        );
+    }
+
+    /// A type with neither asset files nor an extension of its own offers
+    /// nothing rather than the whole project.
+    #[test]
+    fn a_type_with_no_files_of_its_own_offers_nothing() {
+        let tmp = tempfile::tempdir().expect("tempdir");
+        std::fs::create_dir_all(tmp.path().join("assets")).expect("an assets folder");
+        let mut world = World::new();
+        world.insert_resource(ProjectRoot {
+            root: tmp.path().to_path_buf(),
+            config: ProjectConfig::default(),
+        });
+
+        assert!(assets_for_row(&world, &row_naming("my_game::Mystery")).is_empty());
+    }
+}

--- a/src/inspector/definition_card.rs
+++ b/src/inspector/definition_card.rs
@@ -161,6 +161,7 @@ pub(crate) fn fill_definition_card(world: &mut World, inspector: Entity, source:
             state.apply(world);
         }
         CardBody::Schema(schema, value) => {
+            let asset_types = super::schema_fields::asset_path_types(world);
             world.resource_scope(|world, types: Mut<crate::project_types::ProjectTypes>| {
                 let mut state: SystemState<(Commands, Query<&Name>)> = SystemState::new(world);
                 let Ok((mut commands, names)) = state.get_mut(world) else {
@@ -173,6 +174,7 @@ pub(crate) fn fill_definition_card(world: &mut World, inspector: Entity, source:
                     names: &names,
                     registry: &registry,
                     server: server.as_ref(),
+                    asset_types: &asset_types,
                     editor_font: &editor_font,
                     icon_font: &icon_font,
                 };

--- a/src/inspector/material_display.rs
+++ b/src/inspector/material_display.rs
@@ -81,7 +81,7 @@ pub(super) fn fill_textures_card(
     };
     let icon_font = world
         .get_resource::<IconFont>()
-        .map(|f| f.0.clone())
+        .map(|font| font.0.clone())
         .unwrap_or_default();
     fill_texture_rows(&mut world.commands(), body, &m, &handle, &icon_font);
     world.flush();

--- a/src/inspector/mod.rs
+++ b/src/inspector/mod.rs
@@ -1,6 +1,7 @@
 pub(crate) mod add_header;
 pub(crate) mod anim_diamond;
 mod animation_graph_card;
+pub(crate) mod asset_row;
 pub mod bindings_card;
 mod brush_display;
 pub(crate) mod category_strip;
@@ -128,6 +129,7 @@ impl Plugin for InspectorPlugin {
             .add_observer(add_header::on_add_header_mount_added)
             .add_observer(add_header::on_physics_chip_click)
             .add_observer(add_header::on_material_new_click)
+            .add_observer(asset_row::on_asset_row_button)
             .add_systems(
                 Update,
                 component_display::sync_inspector_to_selection
@@ -148,6 +150,8 @@ impl Plugin for InspectorPlugin {
                         node_card::refresh_node_optional_numbers,
                         bindings_card::refresh_bindings_card_on_change,
                         definition_card::keep_unsaved_marker_in_step,
+                        asset_row::refresh_asset_rows,
+                        asset_row::poll_asset_browse_pick,
                     ),
                     brush_display::update_brush_face_properties,
                     category_strip::resolve_active_on_rebuild,
@@ -369,6 +373,22 @@ pub fn field_edited_by(world: &World, widget: Entity) -> Option<(&str, &str)> {
     world
         .get::<FieldBinding>(widget)
         .map(|binding| (binding.type_path.as_str(), binding.field_path.as_str()))
+}
+
+/// The asset type a row names, and the field path it writes, or `None` when
+/// the entity is no asset row. Addresses an asset row by the field it writes.
+pub fn asset_field_shown_by(world: &World, row: Entity) -> Option<(&str, &str)> {
+    world
+        .get::<asset_row::AssetFieldRow>(row)
+        .map(|row| (row.asset_type_path.as_str(), row.field_path.as_str()))
+}
+
+/// The control an asset row draws the file it names on, or `None` when the
+/// entity is no asset row. Clicking it is what opens the row's picker.
+pub fn asset_field_value_of(world: &World, row: Entity) -> Option<Entity> {
+    world
+        .get::<asset_row::AssetFieldRow>(row)
+        .and_then(|row| row.path_text)
 }
 
 /// Marker on the row-level container of a labeled inspector field,

--- a/src/inspector/reflect_fields.rs
+++ b/src/inspector/reflect_fields.rs
@@ -351,6 +351,27 @@ pub(crate) fn spawn_field_row(
         return;
     }
 
+    // Ahead of the enum and opaque arms, which a handle would otherwise fall
+    // into.
+    if let Some(asset_type_path) = super::asset_row::asset_type_of_field(type_registry, value) {
+        super::asset_row::spawn_asset_row(
+            commands,
+            parent,
+            super::asset_row::AssetRowProps {
+                target: super::asset_row::AssetFieldTarget::Inspected {
+                    source: source_entity,
+                    type_path: type_path.to_string(),
+                },
+                field_path,
+                asset_type_path,
+                label: name.to_string(),
+                indent: depth.min(u8::MAX as usize) as u8,
+            },
+            icon_font,
+        );
+        return;
+    }
+
     // List/Array -> expand with ListView
     if let ReflectRef::List(list) = value.reflect_ref() {
         spawn_text_row(

--- a/src/inspector/schema_fields.rs
+++ b/src/inspector/schema_fields.rs
@@ -28,6 +28,9 @@ pub(crate) struct SchemaFieldContext<'a> {
     pub(crate) names: &'a Query<'a, 'a, &'static Name>,
     pub(crate) registry: &'a AppTypeRegistry,
     pub(crate) server: Option<&'a AssetServer>,
+    /// What each file the project holds says it is, for a field spelling a
+    /// reference as the path itself.
+    pub(crate) asset_types: &'a AssetPathTypes,
     pub(crate) editor_font: &'a Handle<Font>,
     pub(crate) icon_font: &'a Handle<Font>,
 }
@@ -61,6 +64,18 @@ fn spawn_one_field(
     path: &str,
     depth: usize,
 ) {
+    if let Some(asset_type_path) = asset_type_of_path(ctx, &field.type_path, held) {
+        spawn_path_row(
+            commands,
+            parent,
+            ctx,
+            &field.name,
+            asset_type_path,
+            path,
+            depth,
+        );
+        return;
+    }
     if let Some(item_type) = item_type_path(field) {
         spawn_list_field(
             commands,
@@ -143,6 +158,9 @@ fn spawn_list_field(
     depth: usize,
 ) {
     let items = held.as_array().cloned().unwrap_or_default();
+    let element_asset = items
+        .iter()
+        .find_map(|item| asset_type_of_path(ctx, item_type, item));
     spawn_text_row(
         commands,
         parent,
@@ -172,7 +190,28 @@ fn spawn_list_field(
                         depth + 1,
                     );
                 }
-                _ => spawn_item_value(commands, row, ctx, item_type, item, &item_path, depth + 1),
+                _ => match element_asset.clone() {
+                    Some(asset_type_path) => spawn_path_row(
+                        commands,
+                        row,
+                        ctx,
+                        "",
+                        asset_type_path,
+                        &item_path,
+                        depth + 1,
+                    ),
+                    None => {
+                        spawn_item_value(
+                            commands,
+                            row,
+                            ctx,
+                            item_type,
+                            item,
+                            &item_path,
+                            depth + 1,
+                        );
+                    }
+                },
             }
             spawn_list_row_controls(
                 commands,
@@ -186,6 +225,69 @@ fn spawn_list_field(
         }
     }
     spawn_list_add_button(commands, parent, ctx.source, ctx.type_path, path);
+}
+
+/// The asset a string field names, for a schema that spells a reference as the
+/// path itself rather than as a handle. `None` when the type is not a string,
+/// or the string names no file this project holds.
+fn asset_type_of_path(ctx: &SchemaFieldContext, type_path: &str, held: &Value) -> Option<String> {
+    use bevy::reflect::TypePath as _;
+
+    if type_path != String::type_path() {
+        return None;
+    }
+    let named = held.as_str().filter(|path| !path.is_empty())?;
+    ctx.asset_types.get(named).cloned()
+}
+
+/// The type each file the project holds is, keyed by the path naming it.
+pub(crate) type AssetPathTypes = bevy::platform::collections::HashMap<String, String>;
+
+/// Read what every indexed file says it is, so the walk can tell a path from
+/// any other string without the index in hand.
+pub(crate) fn asset_path_types(world: &World) -> AssetPathTypes {
+    use path_slash::PathExt as _;
+
+    let Some(index) = world.get_resource::<crate::asset_index::AssetIndex>() else {
+        return AssetPathTypes::default();
+    };
+    index
+        .iter()
+        .map(|entry| {
+            (
+                entry.path.to_slash_lossy().into_owned(),
+                entry.type_path.clone(),
+            )
+        })
+        .collect()
+}
+
+/// A row for a field naming a file, whether the schema spells it as a handle
+/// or as the path itself.
+fn spawn_path_row(
+    commands: &mut Commands,
+    parent: Entity,
+    ctx: &SchemaFieldContext,
+    label: &str,
+    asset_type_path: String,
+    path: &str,
+    depth: usize,
+) {
+    super::asset_row::spawn_asset_row(
+        commands,
+        parent,
+        super::asset_row::AssetRowProps {
+            target: super::asset_row::AssetFieldTarget::Inspected {
+                source: ctx.source,
+                type_path: ctx.type_path.to_string(),
+            },
+            field_path: path.to_string(),
+            asset_type_path,
+            label: label.to_string(),
+            indent: depth.min(u8::MAX as usize) as u8,
+        },
+        ctx.icon_font,
+    );
 }
 
 fn spawn_item_value(

--- a/src/material_browser.rs
+++ b/src/material_browser.rs
@@ -60,15 +60,12 @@ impl Plugin for MaterialBrowserPlugin {
                     update_material_browser_ui.after(rescan_material_definitions),
                     update_preview_area,
                     poll_material_browser_folder,
-                    poll_texture_slot_pick,
                 )
                     .run_if(in_state(crate::AppState::Editor)),
             )
             .add_observer(on_material_grid_added)
             .add_observer(handle_apply_material)
-            .add_observer(handle_select_material_preview)
-            .add_observer(handle_browse_texture_slot)
-            .add_observer(handle_clear_texture_slot);
+            .add_observer(handle_select_material_preview);
     }
 }
 
@@ -114,25 +111,6 @@ struct MaterialActionBar;
 /// Container for the editing sections shown for the selected material.
 #[derive(Component)]
 struct PreviewAreaContainer;
-
-#[derive(Event)]
-struct BrowseTextureSlot {
-    slot: TextureSlot,
-    material_handle: Handle<StandardMaterial>,
-}
-
-#[derive(Event)]
-struct ClearTextureSlot {
-    slot: TextureSlot,
-    material_handle: Handle<StandardMaterial>,
-}
-
-#[derive(Resource)]
-struct TextureSlotPickTask {
-    task: Task<Option<rfd::FileHandle>>,
-    slot: TextureSlot,
-    material_handle: Handle<StandardMaterial>,
-}
 
 /// Load a texture path into an `Image` handle for the given role, choosing the
 /// color space from `role.is_srgb()`.
@@ -724,112 +702,6 @@ fn poll_material_browser_folder(world: &mut World) {
     }
 }
 
-fn handle_browse_texture_slot(
-    event: On<BrowseTextureSlot>,
-    mut commands: Commands,
-    existing_task: Option<Res<TextureSlotPickTask>>,
-) {
-    if existing_task.is_some() {
-        return;
-    }
-    let slot = event.slot;
-    let material_handle = event.material_handle.clone();
-    commands.queue(move |world: &mut World| {
-        if world.contains_resource::<TextureSlotPickTask>() {
-            return;
-        }
-        let directory = material_file_directory(world, &material_handle);
-        let dialog = match directory {
-            Some(directory) => crate::native_dialog::dialog_starting_at(world, Some(directory)),
-            None => crate::native_dialog::file_dialog(
-                world,
-                crate::native_dialog::DialogPurpose::Texture,
-            ),
-        }
-        .set_title(format!("Select image for {}", slot.field()))
-        .add_filter(
-            "Images",
-            &["png", "jpg", "jpeg", "ktx2", "bmp", "tga", "webp"],
-        );
-        let task = AsyncComputeTaskPool::get().spawn(async move { dialog.pick_file().await });
-        world.insert_resource(TextureSlotPickTask {
-            task,
-            slot,
-            material_handle,
-        });
-    });
-}
-
-/// The folder holding the material's own asset file, when it came from one.
-fn material_file_directory(
-    world: &World,
-    material_handle: &Handle<StandardMaterial>,
-) -> Option<PathBuf> {
-    let asset_server = world.get_resource::<AssetServer>()?;
-    let asset_path = asset_server.get_path(material_handle.id())?;
-    let assets_root = crate::project::open_project_assets_dir()?;
-    texture_browse_directory(&assets_root, asset_path.path())
-}
-
-/// The folder a texture browse starts in for a material stored at
-/// `material_path`, relative to `assets_root`.
-fn texture_browse_directory(assets_root: &Path, material_path: &Path) -> Option<PathBuf> {
-    let directory = assets_root.join(material_path.parent()?);
-    directory.is_dir().then_some(directory)
-}
-
-fn poll_texture_slot_pick(world: &mut World) {
-    let Some(mut task_res) = world.get_resource_mut::<TextureSlotPickTask>() else {
-        return;
-    };
-    let Some(result) = future::block_on(future::poll_once(&mut task_res.task)) else {
-        return;
-    };
-    let slot = task_res.slot;
-    let material_handle = task_res.material_handle.clone();
-    world.remove_resource::<TextureSlotPickTask>();
-
-    let Some(file_handle) = result else {
-        return;
-    };
-    let path = file_handle.path().to_path_buf();
-    crate::native_dialog::remember_pick(world, crate::native_dialog::DialogPurpose::Texture, &path);
-    let fs_path = path.to_slash_lossy();
-    let asset_path = crate::entity_ops::to_asset_path(&fs_path);
-    let asset_server = world.resource::<AssetServer>().clone();
-    let image_handle = if slot.is_srgb() {
-        asset_server.load::<Image>(asset_path)
-    } else {
-        asset_server
-            .load_builder()
-            .with_settings(|s: &mut ImageLoaderSettings| s.is_srgb = false)
-            .load::<Image>(asset_path)
-    };
-
-    let mut materials = world.resource_mut::<Assets<StandardMaterial>>();
-    if let Some(mut mat) = materials.get_mut(&material_handle) {
-        slot.set_on(&mut mat, Some(image_handle));
-    }
-
-    world
-        .resource_mut::<crate::asset_catalog::AssetCatalog>()
-        .dirty = true;
-    world.resource_mut::<MaterialPreviewState>().set_changed();
-}
-
-fn handle_clear_texture_slot(
-    event: On<ClearTextureSlot>,
-    mut materials: ResMut<Assets<StandardMaterial>>,
-    mut catalog: ResMut<crate::asset_catalog::AssetCatalog>,
-    mut preview_state: ResMut<MaterialPreviewState>,
-) {
-    if let Some(mut mat) = materials.get_mut(&event.material_handle) {
-        event.slot.set_on(&mut mat, None);
-    }
-    catalog.dirty = true;
-    preview_state.set_changed();
-}
-
 fn update_material_browser_ui(
     mut commands: Commands,
     registry: Res<MaterialRegistry>,
@@ -1068,30 +940,12 @@ fn rescan_button(icon_font: Handle<Font>) -> impl Bundle {
 
 // -- Operators --------------------------------------------------------------
 
-/// Resource set by the texture-slot button click before dispatching
-/// `material.browse_texture_slot` / `material.clear_texture_slot`. The
-/// operator reads this and clears it. `Handle<StandardMaterial>` doesn't
-/// fit `PropertyValue`, so we route it through a sidecar resource the
-/// same way `hierarchy.rename_begin` uses `PendingRenameTarget`.
-#[derive(Resource, Default)]
-pub(crate) struct PendingTextureSlot {
-    pub(crate) slot: Option<TextureSlot>,
-    pub(crate) material_handle: Option<Handle<StandardMaterial>>,
-}
-
 pub(crate) fn add_to_extension(ctx: &mut ExtensionContext) {
-    ctx.init_resource::<PendingTextureSlot>()
-        .register_operator::<MaterialCreateOp>()
+    ctx.register_operator::<MaterialCreateOp>()
         .register_operator::<MaterialSelectOp>()
         .register_operator::<MaterialApplyOp>()
         .register_operator::<MaterialRescanOp>()
-        .register_operator::<MaterialSelectFolderOp>()
-        .register_operator::<MaterialBrowseTextureSlotOp>()
-        .register_operator::<MaterialClearTextureSlotOp>();
-}
-
-fn pending_texture_slot_set(pending: Res<PendingTextureSlot>) -> bool {
-    pending.slot.is_some() && pending.material_handle.is_some()
+        .register_operator::<MaterialSelectFolderOp>();
 }
 
 /// Create a fresh empty material and select it for preview. It stays unsaved
@@ -1219,56 +1073,6 @@ pub fn material_select_folder(_: In<OperatorParameters>, mut commands: Commands)
     OperatorResult::Finished
 }
 
-/// Pick an image from disk for the targeted material's texture slot.
-///
-/// The slot and target material are routed through the
-/// [`PendingTextureSlot`] resource by the inspector button before
-/// dispatch.
-#[operator(
-    id = "material.browse_texture_slot",
-    label = "Browse Texture",
-    description = "Pick an image to assign to this material's texture slot.",
-    is_available = pending_texture_slot_set
-)]
-pub(crate) fn material_browse_texture_slot(
-    _: In<OperatorParameters>,
-    mut pending: ResMut<PendingTextureSlot>,
-    mut commands: Commands,
-) -> OperatorResult {
-    let slot = pending.slot.take()?;
-    let material_handle = pending.material_handle.take()?;
-    commands.trigger(BrowseTextureSlot {
-        slot,
-        material_handle,
-    });
-    OperatorResult::Finished
-}
-
-/// Remove the image from the targeted material's texture slot.
-///
-/// The slot and target material are routed through the
-/// [`PendingTextureSlot`] resource by the inspector button before
-/// dispatch.
-#[operator(
-    id = "material.clear_texture_slot",
-    label = "Clear Texture",
-    description = "Remove the image from this material's texture slot.",
-    is_available = pending_texture_slot_set
-)]
-pub(crate) fn material_clear_texture_slot(
-    _: In<OperatorParameters>,
-    mut pending: ResMut<PendingTextureSlot>,
-    mut commands: Commands,
-) -> OperatorResult {
-    let slot = pending.slot.take()?;
-    let material_handle = pending.material_handle.take()?;
-    commands.trigger(ClearTextureSlot {
-        slot,
-        material_handle,
-    });
-    OperatorResult::Finished
-}
-
 #[cfg(test)]
 mod tests {
     use super::*;
@@ -1280,27 +1084,6 @@ mod tests {
         app.init_asset::<Image>();
         app.init_asset::<StandardMaterial>();
         app
-    }
-
-    #[test]
-    fn a_texture_browse_starts_in_the_folder_holding_the_material() {
-        let dir = tempfile::tempdir().expect("a temporary directory");
-        let assets = dir.path();
-        std::fs::create_dir_all(assets.join("materials/stone")).expect("the material folder");
-
-        let start = texture_browse_directory(assets, Path::new("materials/stone/granite.bsn"))
-            .expect("a start directory");
-        assert_eq!(start, assets.join("materials/stone"));
-    }
-
-    #[test]
-    fn a_texture_browse_ignores_a_material_folder_that_is_not_there() {
-        let dir = tempfile::tempdir().expect("a temporary directory");
-
-        assert_eq!(
-            texture_browse_directory(dir.path(), Path::new("materials/gone/granite.bsn")),
-            None
-        );
     }
 
     fn detected(paths: &[&str]) -> jackdaw_material::MaterialSet {

--- a/src/material_ui.rs
+++ b/src/material_ui.rs
@@ -24,7 +24,7 @@ use bevy::{
     ui::Checked,
     ui_widgets::{Activate, SliderDragState, SliderValue, ValueChange},
 };
-use jackdaw_api::op::{Operator as _, OperatorCommandsExt as _};
+use jackdaw_api::op::Operator as _;
 use jackdaw_feathers::{
     button::{ButtonOperatorCall, ButtonVariant, IconButtonProps, icon_button},
     field_row::{FieldRowProps, spawn_field_row},
@@ -171,11 +171,12 @@ pub(crate) struct MaterialTextureSlotRow;
 #[derive(Component)]
 pub(crate) struct MaterialFieldMarker;
 
-/// A texture slot row: square swatch, the bound file's name, then assign and clear.
+/// A texture slot row: square swatch, the bound file's path, then the actions
+/// every asset field has.
 ///
-/// Assign and clear route the slot and target material through
-/// [`crate::material_browser::PendingTextureSlot`] before dispatching the operators, because
-/// a material handle is not a `PropertyValue`.
+/// The slot is a field of the material like any other, so it hosts the shared
+/// asset row; only the write is its own, since an image bound to a slot that is
+/// not colour has to load in linear space.
 pub(crate) fn spawn_texture_slot_row(
     commands: &mut Commands,
     parent: Entity,
@@ -184,73 +185,139 @@ pub(crate) fn spawn_texture_slot_row(
     handle: Handle<StandardMaterial>,
     icon_font: &Handle<Font>,
 ) -> Entity {
-    use crate::material_browser::{
-        MaterialBrowseTextureSlotOp, MaterialClearTextureSlotOp, PendingTextureSlot,
+    use crate::inspector::asset_row::{
+        AssetFieldTarget, AssetFieldWriter, AssetRowProps, attach_asset_field,
     };
+    use bevy::reflect::TypePath as _;
 
     let name = current
         .as_ref()
         .and_then(Handle::path)
-        .and_then(|p| {
-            p.path()
-                .file_name()
-                .map(|f| f.to_string_lossy().to_string())
-        })
+        .map(|path| crate::inspector::asset_row::shown_name(&path.path().to_string_lossy()))
         .unwrap_or_else(|| "None".to_string());
 
-    let props = SwatchRowProps::new(slot.label());
+    let props = SwatchRowProps::new(slot.label())
+        .with_control_min_width(crate::inspector::asset_row::ASSET_CONTROL_MIN_WIDTH);
     let props = match current.clone() {
         Some(image) => props.bound(image, name),
         None => props.placeholder(name),
     };
     let row = spawn_swatch_row(commands, parent, props);
 
+    let material = handle.clone();
     commands
         .entity(row.row)
         .insert((MaterialTextureSlotRow, Hovered::default()))
-        .insert(Tooltip::title(slot.label()).with_description(slot.field()));
+        .insert(Tooltip::title(slot.label()).with_description(slot.field()))
+        .insert(AssetFieldWriter(Box::new(move |world, path| {
+            commit_texture_slot(world, &material, slot, path)
+        })));
 
-    let browse_handle = handle.clone();
-    commands
-        .spawn((
-            icon_button(
-                IconButtonProps::new(Icon::FolderOpen).variant(ButtonVariant::Ghost),
-                icon_font,
-            ),
-            ChildOf(row.actions),
-        ))
-        .observe(
-            move |_: On<Pointer<Click>>,
-                  mut pending: ResMut<PendingTextureSlot>,
-                  mut commands: Commands| {
-                pending.slot = Some(slot);
-                pending.material_handle = Some(browse_handle.clone());
-                commands.operator(MaterialBrowseTextureSlotOp::ID).call();
-            },
-        );
-
-    if current.is_some() {
-        let clear_handle = handle;
-        commands
-            .spawn((
-                icon_button(
-                    IconButtonProps::new(Icon::X).variant(ButtonVariant::Ghost),
-                    icon_font,
-                ),
-                ChildOf(row.actions),
-            ))
-            .observe(
-                move |_: On<Pointer<Click>>,
-                      mut pending: ResMut<PendingTextureSlot>,
-                      mut commands: Commands| {
-                    pending.slot = Some(slot);
-                    pending.material_handle = Some(clear_handle.clone());
-                    commands.operator(MaterialClearTextureSlotOp::ID).call();
-                },
-            );
-    }
+    attach_asset_field(
+        commands,
+        row.row,
+        row.actions,
+        AssetRowProps {
+            target: AssetFieldTarget::Held(handle.untyped()),
+            field_path: slot.field().to_string(),
+            asset_type_path: Image::type_path().to_string(),
+            label: slot.label().to_string(),
+            indent: 0,
+        },
+        Some(row.value),
+        icon_font,
+    );
 
     row.row
+}
+
+/// Bind one texture slot of a material to a file, or to nothing, as one undo
+/// entry.
+struct SetTextureSlot {
+    material: Handle<StandardMaterial>,
+    slot: TextureSlot,
+    old_path: String,
+    new_path: String,
+}
+
+impl crate::commands::EditorCommand for SetTextureSlot {
+    fn execute(&mut self, world: &mut World) {
+        bind_texture_slot(world, &self.material, self.slot, &self.new_path);
+    }
+
+    fn undo(&mut self, world: &mut World) {
+        bind_texture_slot(world, &self.material, self.slot, &self.old_path);
+    }
+
+    fn description(&self) -> &str {
+        "Bind texture slot"
+    }
+}
+
+/// Write a texture slot and push the entry undo walks back over.
+fn commit_texture_slot(
+    world: &mut World,
+    material: &Handle<StandardMaterial>,
+    slot: TextureSlot,
+    path: &str,
+) -> bool {
+    let old_path = world
+        .resource::<Assets<StandardMaterial>>()
+        .get(material)
+        .and_then(|value| slot.get_from(value))
+        .and_then(|image| {
+            image
+                .path()
+                .map(|path| path.path().to_string_lossy().into_owned())
+        })
+        .unwrap_or_default();
+    if !bind_texture_slot(world, material, slot, path) {
+        return false;
+    }
+    world
+        .resource_mut::<jackdaw_commands::CommandHistory>()
+        .push_executed(Box::new(SetTextureSlot {
+            material: material.clone(),
+            slot,
+            old_path,
+            new_path: path.to_string(),
+        }));
+    true
+}
+
+/// Load the file a slot names in the colour space that slot reads and put it on
+/// the material. An empty path leaves the slot bound to nothing.
+fn bind_texture_slot(
+    world: &mut World,
+    material: &Handle<StandardMaterial>,
+    slot: TextureSlot,
+    path: &str,
+) -> bool {
+    let image = (!path.is_empty()).then(|| {
+        let server = world.resource::<AssetServer>();
+        if slot.is_srgb() {
+            server.load::<Image>(path.to_string())
+        } else {
+            server
+                .load_builder()
+                .with_settings(|settings: &mut bevy::image::ImageLoaderSettings| {
+                    settings.is_srgb = false;
+                })
+                .load::<Image>(path.to_string())
+        }
+    });
+    {
+        let mut materials = world.resource_mut::<Assets<StandardMaterial>>();
+        let Some(mut value) = materials.get_mut(material) else {
+            return false;
+        };
+        slot.set_on(&mut value, image);
+    }
+    world
+        .resource_mut::<crate::asset_catalog::AssetCatalog>()
+        .dirty = true;
+    world.resource_mut::<MaterialPreviewState>().set_changed();
+    true
 }
 
 // ---------------------------------------------------------------------------
@@ -1913,5 +1980,169 @@ mod focus_gate_tests {
         });
         app.update();
         assert_eq!(app.world().get::<TabIndex>(control).expect("index").0, 0);
+    }
+}
+
+#[cfg(test)]
+mod texture_slot_tests {
+    use super::fill_texture_rows;
+    use crate::inspector::asset_row::AssetFieldRow;
+    use bevy::ecs::system::RunSystemOnce;
+    use bevy::prelude::*;
+
+    /// The texture slots of a material are asset rows, so the material card and
+    /// the terrain panel's slot editor both show a path, a picker and a drop
+    /// target where they used to show a browse button.
+    #[test]
+    fn every_texture_slot_is_an_asset_field_naming_an_image() {
+        let mut app = App::new();
+        app.add_plugins(MinimalPlugins)
+            .add_plugins(bevy::asset::AssetPlugin::default())
+            .add_plugins(bevy::scene::ScenePlugin)
+            .init_asset::<StandardMaterial>()
+            .init_asset::<Image>()
+            .init_asset::<Font>();
+        let handle = app
+            .world_mut()
+            .resource_mut::<Assets<StandardMaterial>>()
+            .add(StandardMaterial::default());
+        let body = app.world_mut().spawn_empty().id();
+
+        let material = handle.clone();
+        app.world_mut()
+            .run_system_once(move |mut commands: Commands| {
+                fill_texture_rows(
+                    &mut commands,
+                    body,
+                    &StandardMaterial::default(),
+                    &material,
+                    &Handle::default(),
+                );
+            })
+            .expect("the rows spawn");
+        app.world_mut().flush();
+
+        let mut rows = app.world_mut().query::<&AssetFieldRow>();
+        let mut fields: Vec<String> = rows
+            .iter(app.world())
+            .map(|row| row.field_path.clone())
+            .collect();
+        fields.sort();
+        assert_eq!(
+            fields,
+            vec![
+                "base_color_texture".to_string(),
+                "depth_map".to_string(),
+                "emissive_texture".to_string(),
+                "metallic_roughness_texture".to_string(),
+                "normal_map_texture".to_string(),
+                "occlusion_texture".to_string(),
+            ],
+            "every slot on the material is an asset row",
+        );
+        let image = <Image as bevy::reflect::TypePath>::type_path();
+        assert!(
+            rows.iter(app.world())
+                .all(|row| row.asset_type_path == image),
+            "and each of them names an image",
+        );
+    }
+
+    /// The slot reads the material rather than the value it was built with, so
+    /// a bind made from anywhere, and the undo that walks it back, both show.
+    #[test]
+    fn a_slot_shows_the_file_bound_to_it_and_none_again_after_undo() {
+        use crate::inspector::asset_row::{commit_asset_row, refresh_asset_rows};
+
+        let mut app = App::new();
+        app.add_plugins(MinimalPlugins)
+            .add_plugins(bevy::asset::AssetPlugin::default())
+            .add_plugins(bevy::scene::ScenePlugin)
+            .init_asset::<StandardMaterial>()
+            .init_asset::<Image>()
+            .init_asset::<Font>()
+            .register_type::<StandardMaterial>()
+            .register_asset_reflect::<StandardMaterial>()
+            .init_resource::<crate::asset_catalog::AssetCatalog>()
+            .init_resource::<crate::material_preview::MaterialPreviewState>()
+            .init_resource::<jackdaw_commands::CommandHistory>();
+        let handle = app
+            .world_mut()
+            .resource_mut::<Assets<StandardMaterial>>()
+            .add(StandardMaterial::default());
+        let body = app.world_mut().spawn_empty().id();
+        let material = handle.clone();
+        app.world_mut()
+            .run_system_once(move |mut commands: Commands| {
+                fill_texture_rows(
+                    &mut commands,
+                    body,
+                    &StandardMaterial::default(),
+                    &material,
+                    &Handle::default(),
+                );
+            })
+            .expect("the rows spawn");
+        app.world_mut().flush();
+
+        let row = app
+            .world_mut()
+            .query::<(Entity, &AssetFieldRow)>()
+            .iter(app.world())
+            .find(|(_, row)| row.field_path == "base_color_texture")
+            .map(|(entity, _)| entity)
+            .expect("the base colour slot is an asset row");
+
+        assert!(commit_asset_row(app.world_mut(), row, "textures/rock.png"));
+        assert_eq!(
+            slot_text(&mut app, row),
+            "rock.png",
+            "the slot names the file, on one line",
+        );
+        assert_eq!(
+            slot_tooltip(&mut app, row),
+            "textures/rock.png",
+            "and carries the whole path for a hover",
+        );
+
+        app.world_mut().resource_scope(
+            |world, mut history: Mut<jackdaw_commands::CommandHistory>| {
+                history.undo(world);
+            },
+        );
+        app.world_mut()
+            .run_system_once(refresh_asset_rows)
+            .expect("the rows refresh");
+        assert_eq!(
+            slot_text(&mut app, row),
+            "None",
+            "undo puts the slot back to naming nothing",
+        );
+    }
+
+    /// The whole path the slot's own line stands for.
+    fn slot_tooltip(app: &mut App, row: Entity) -> String {
+        let text = app
+            .world()
+            .get::<AssetFieldRow>(row)
+            .and_then(|row| row.path_text)
+            .expect("the slot draws its path");
+        app.world()
+            .get::<jackdaw_feathers::tooltip::Tooltip>(text)
+            .map(|tip| tip.title.clone())
+            .expect("the path is there to hover")
+    }
+
+    /// The line under a slot row that names what is bound.
+    fn slot_text(app: &mut App, row: Entity) -> String {
+        let text = app
+            .world()
+            .get::<AssetFieldRow>(row)
+            .and_then(|row| row.path_text)
+            .expect("the slot draws its path");
+        app.world()
+            .get::<Text>(text)
+            .map(|text| text.0.clone())
+            .expect("the path is written")
     }
 }

--- a/src/typed_values.rs
+++ b/src/typed_values.rs
@@ -92,15 +92,15 @@ pub fn text_value_for_field(
     text: &str,
 ) -> Option<Box<dyn PartialReflect>> {
     if takes_asset_path(registry, type_id) {
-        let assets = BsnApplyAssets {
-            server: server?,
+        let assets = server.map(|server| BsnApplyAssets {
+            server,
             local: references,
-        };
+        });
         return bsn_value_to_reflect(
             &BsnValue::String(text.to_string()),
             type_id,
             registry,
-            Some(&assets),
+            assets.as_ref(),
         );
     }
     if type_id == TypeId::of::<Color>() {
@@ -134,6 +134,39 @@ pub fn asset_path_json(
         })
         .unwrap_or_default();
     Some(serde_json::Value::String(path))
+}
+
+/// The type path of the asset a field names, for the rows and pickers that
+/// offer the files holding it. `None` when the field takes no asset path.
+pub fn asset_type_path(registry: &TypeRegistry, type_id: TypeId) -> Option<String> {
+    let handle_type = handle_type_id(registry, type_id)?;
+    let asset_type = registry
+        .get_type_data::<ReflectHandle>(handle_type)?
+        .asset_type_id();
+    Some(
+        registry
+            .get(asset_type)?
+            .type_info()
+            .type_path()
+            .to_string(),
+    )
+}
+
+/// The `Handle<T>` a field's type is, reaching through an `Option` to find it.
+fn handle_type_id(registry: &TypeRegistry, type_id: TypeId) -> Option<TypeId> {
+    if registry.get_type_data::<ReflectHandle>(type_id).is_some() {
+        return Some(type_id);
+    }
+    if !takes_asset_path(registry, type_id) {
+        return None;
+    }
+    let TypeInfo::Enum(info) = registry.get(type_id)?.type_info() else {
+        return None;
+    };
+    let VariantInfo::Tuple(variant) = info.variant("Some")? else {
+        return None;
+    };
+    Some(variant.field_at(0)?.type_id())
 }
 
 /// The handle a field holds, reaching through an `Option` to find it.

--- a/tests/fixtures/definition_project/schema.json
+++ b/tests/fixtures/definition_project/schema.json
@@ -110,6 +110,52 @@
       "entity_fields": [],
       "fills_gaps": true,
       "asset": false
+    },
+    {
+      "type_path": "definition_project::content::OutfitDef",
+      "short_name": "OutfitDef",
+      "module_path": "definition_project::content",
+      "category": "",
+      "description": "",
+      "editor_description": "",
+      "hidden": false,
+      "preview": "",
+      "default_constructible": true,
+      "fields": [
+        {
+          "name": "material",
+          "type_path": "bevy_asset::handle::Handle<bevy_pbr::pbr_material::StandardMaterial>",
+          "item_type_path": ""
+        },
+        {
+          "name": "materials",
+          "type_path": "alloc::vec::Vec<bevy_asset::handle::Handle<bevy_pbr::pbr_material::StandardMaterial>>",
+          "item_type_path": "bevy_asset::handle::Handle<bevy_pbr::pbr_material::StandardMaterial>"
+        },
+        {
+          "name": "skin",
+          "type_path": "alloc::string::String",
+          "item_type_path": ""
+        },
+        {
+          "name": "skins",
+          "type_path": "alloc::vec::Vec<alloc::string::String>",
+          "item_type_path": "alloc::string::String"
+        }
+      ],
+      "kind": "Struct",
+      "default": {
+        "definition_project::content::OutfitDef": {
+          "material": "",
+          "materials": [],
+          "skin": "",
+          "skins": []
+        }
+      },
+      "variants": [],
+      "entity_fields": [],
+      "fills_gaps": true,
+      "asset": true
     }
   ]
 }

--- a/tests/inspector/asset_row.rs
+++ b/tests/inspector/asset_row.rs
@@ -1,0 +1,706 @@
+//! The inspector row beside a field that names an asset.
+//!
+//! A field holding a handle is shown as the path of the file behind it, with
+//! Pick, Clear and New beside it and a drop target on the row, so an outfit's
+//! material is chosen the way a material's texture is.
+
+use std::path::{Path, PathBuf};
+
+use bevy::camera::{NormalizedRenderTarget, RenderTarget};
+use bevy::picking::backend::HitData;
+use bevy::picking::events::{DragDrop, Pointer};
+use bevy::picking::pointer::{Location, PointerButton, PointerId};
+use bevy::prelude::*;
+use bevy::window::{PrimaryWindow, WindowRef};
+use jackdaw::asset_browser::ActiveAssetDrag;
+use jackdaw::commands::CommandHistory;
+use jackdaw_api::prelude::*;
+use jackdaw_api_internal::operator::{CallOperatorSettings, ExecutionContext};
+use jackdaw_feathers::button::{ButtonClickEvent, EditorButton};
+use jackdaw_feathers::icons::Icon;
+use jackdaw_feathers::picker::PickerItems;
+use jackdaw_feathers::tooltip::Tooltip;
+use jackdaw_scene_types::PropertyValue;
+
+use crate::util;
+
+const MATERIAL_TYPE: &str = "bevy_pbr::pbr_material::StandardMaterial";
+
+fn fixture_dir() -> PathBuf {
+    Path::new(env!("CARGO_MANIFEST_DIR")).join("tests/fixtures/definition_project")
+}
+
+fn settle(app: &mut App) {
+    for _ in 0..6 {
+        app.update();
+    }
+}
+
+fn call(app: &mut App, id: &'static str, params: &[(&'static str, PropertyValue)]) {
+    let mut call = app.world_mut().operator(id).settings(CallOperatorSettings {
+        execution_context: ExecutionContext::Invoke,
+        creates_history_entry: true,
+    });
+    for (name, value) in params {
+        call = call.param(*name, value.clone());
+    }
+    let result = call.call().expect("the operator dispatched");
+    assert_eq!(result, OperatorResult::Finished, "{id} ran");
+    settle(app);
+}
+
+/// An editor with the fixture project open, two material files and an item
+/// file under its assets, and an outfit open in the inspector.
+fn app_with_open_outfit() -> (App, tempfile::TempDir) {
+    let tmp = tempfile::tempdir().expect("tempdir");
+    let fixture = fixture_dir();
+    std::fs::copy(
+        fixture.join("jackdaw.toml"),
+        tmp.path().join("jackdaw.toml"),
+    )
+    .expect("the manifest copies");
+    let jackdaw_dir = tmp.path().join(".jackdaw");
+    std::fs::create_dir_all(&jackdaw_dir).expect("the jackdaw directory is made");
+    std::fs::copy(fixture.join("schema.json"), jackdaw_dir.join("schema.json"))
+        .expect("the schema copies");
+    std::fs::create_dir_all(tmp.path().join("assets/materials")).expect("a materials folder");
+    std::fs::create_dir_all(tmp.path().join("assets/content")).expect("a content folder");
+
+    let mut app = util::editor_test_app();
+    app.world_mut()
+        .insert_resource(jackdaw::project::ProjectRoot {
+            root: tmp.path().to_path_buf(),
+            config: default(),
+        });
+    app.world_mut()
+        .spawn(jackdaw::layout::inspector_components_content(default()));
+    app.world_mut()
+        .resource_mut::<NextState<jackdaw::AppState>>()
+        .set(jackdaw::AppState::Editor);
+    app.update();
+    jackdaw::pie::refresh_project_types(app.world_mut());
+    settle(&mut app);
+
+    for name in ["slate", "moss"] {
+        call(
+            &mut app,
+            "asset.new",
+            &[
+                ("type", "material".into()),
+                ("name", name.into()),
+                ("path", "materials".into()),
+            ],
+        );
+    }
+    call(
+        &mut app,
+        "asset.new",
+        &[
+            ("type", "item".into()),
+            ("name", "torch".into()),
+            ("path", "content".into()),
+        ],
+    );
+    call(
+        &mut app,
+        "asset.new",
+        &[
+            ("type", "outfit".into()),
+            ("name", "ranger".into()),
+            ("path", "content".into()),
+        ],
+    );
+    (app, tmp)
+}
+
+fn open_outfit(app: &App) -> serde_json::Value {
+    let path =
+        jackdaw::definition_assets::open_definition_path(app.world()).expect("an asset is open");
+    jackdaw::definition_assets::schema_definition_json(app.world(), "outfit", &path)
+        .expect("the asset reads back")
+}
+
+fn all_entities(app: &mut App) -> Vec<Entity> {
+    app.world_mut()
+        .query::<Entity>()
+        .iter(app.world())
+        .collect()
+}
+
+/// Every asset row the inspector is showing, as the field it writes.
+fn asset_rows(app: &mut App) -> Vec<(Entity, String, String)> {
+    all_entities(app)
+        .into_iter()
+        .filter_map(|entity| {
+            jackdaw::inspector::asset_field_shown_by(app.world(), entity)
+                .map(|(asset, field)| (entity, asset.to_string(), field.to_string()))
+        })
+        .collect()
+}
+
+fn asset_row(app: &mut App, field_path: &str) -> Entity {
+    let rows = asset_rows(app);
+    rows.iter()
+        .find(|(_, _, field)| field == field_path)
+        .map(|(entity, _, _)| *entity)
+        .unwrap_or_else(|| {
+            let shown: Vec<&String> = rows.iter().map(|(_, _, field)| field).collect();
+            let bound: Vec<String> = all_entities(app)
+                .into_iter()
+                .filter_map(|entity| {
+                    jackdaw::inspector::field_edited_by(app.world(), entity)
+                        .map(|(known, field)| format!("{known}.{field}"))
+                })
+                .collect();
+            panic!("no asset row writes `{field_path}`; the inspector shows {shown:?} and binds {bound:?}")
+        })
+}
+
+/// Every line of text under a row, for a row that draws its path.
+fn row_text(app: &mut App, row: Entity) -> Vec<String> {
+    let mut found = Vec::new();
+    let mut stack = vec![row];
+    while let Some(entity) = stack.pop() {
+        if let Some(text) = app.world().get::<Text>(entity) {
+            found.push(text.0.clone());
+        }
+        if let Some(children) = app.world().get::<Children>(entity) {
+            stack.extend(children.iter());
+        }
+    }
+    found
+}
+
+/// The button under a row whose tooltip names this action.
+fn row_button(app: &mut App, row: Entity, label: &str) -> Entity {
+    let mut stack = vec![row];
+    while let Some(entity) = stack.pop() {
+        if app.world().get::<EditorButton>(entity).is_some()
+            && app
+                .world()
+                .get::<Tooltip>(entity)
+                .is_some_and(|tip| tip.title == label)
+        {
+            return entity;
+        }
+        if let Some(children) = app.world().get::<Children>(entity) {
+            stack.extend(children.iter());
+        }
+    }
+    panic!("no '{label}' button sits beside the row")
+}
+
+fn undo(app: &mut App) {
+    app.world_mut()
+        .resource_scope(|world, mut history: Mut<CommandHistory>| {
+            history.undo(world);
+        });
+    settle(app);
+}
+
+#[test]
+fn a_handle_field_shows_the_path_it_names_rather_than_an_opaque_marker() {
+    let (mut app, _tmp) = app_with_open_outfit();
+
+    let row = asset_row(&mut app, "material");
+    assert_eq!(
+        jackdaw::inspector::asset_field_shown_by(app.world(), row).map(|(asset, _)| asset),
+        Some(MATERIAL_TYPE),
+        "the row knows which files the field can name",
+    );
+    assert!(
+        row_text(&mut app, row).iter().any(|line| line == "None"),
+        "a field naming nothing says so, got {:?}",
+        row_text(&mut app, row),
+    );
+
+    call(
+        &mut app,
+        "asset.pick",
+        &[
+            ("field", "material".into()),
+            ("value", "materials/slate.bsn".into()),
+        ],
+    );
+
+    let row = asset_row(&mut app, "material");
+    assert!(
+        row_text(&mut app, row)
+            .iter()
+            .any(|line| line == "slate.bsn"),
+        "the row shows the file it now names, got {:?}",
+        row_text(&mut app, row),
+    );
+    assert_eq!(
+        row_tooltips(&mut app, row)
+            .into_iter()
+            .find(|tip| tip.contains('/')),
+        Some("materials/slate.bsn".to_string()),
+        "and the whole path is there to hover",
+    );
+    assert!(
+        !row_text(&mut app, row)
+            .iter()
+            .any(|line| line.contains("<opaque>")),
+        "and nothing is left showing the handle as opaque",
+    );
+}
+
+/// Every tooltip title under a row.
+fn row_tooltips(app: &mut App, row: Entity) -> Vec<String> {
+    let mut found = Vec::new();
+    let mut stack = vec![row];
+    while let Some(entity) = stack.pop() {
+        if let Some(tip) = app.world().get::<Tooltip>(entity) {
+            found.push(tip.title.clone());
+        }
+        if let Some(children) = app.world().get::<Children>(entity) {
+            stack.extend(children.iter());
+        }
+    }
+    found
+}
+
+#[test]
+fn the_three_actions_are_icons_that_say_what_they_do() {
+    let (mut app, _tmp) = app_with_open_outfit();
+    let row = asset_row(&mut app, "material");
+
+    for (label, icon) in [
+        ("Pick", Icon::FolderOpen),
+        ("Clear", Icon::X),
+        ("New", Icon::Plus),
+    ] {
+        let button = row_button(&mut app, row, label);
+        let glyph = String::from(icon.unicode());
+        assert!(
+            row_text(&mut app, button).contains(&glyph),
+            "{label} draws its own glyph rather than a caption, got {:?}",
+            row_text(&mut app, button),
+        );
+        assert!(
+            app.world()
+                .get::<Tooltip>(button)
+                .is_some_and(|tip| !tip.description.is_empty()),
+            "{label} says what it does on hover",
+        );
+    }
+}
+
+#[test]
+fn clicking_the_file_a_row_shows_opens_the_list_to_choose_from() {
+    let (mut app, _tmp) = app_with_open_outfit();
+    let row = asset_row(&mut app, "material");
+    let value = jackdaw::inspector::asset_field_value_of(app.world(), row)
+        .expect("the row draws the file it names");
+
+    let target = primary_target(&mut app);
+    app.world_mut().trigger(Pointer::new(
+        PointerId::Mouse,
+        Location {
+            target,
+            position: Vec2::ZERO,
+        },
+        bevy::picking::events::Click {
+            button: PointerButton::Primary,
+            hit: HitData::new(value, 0.0, None, None),
+            duration: std::time::Duration::ZERO,
+            count: 1,
+        },
+        value,
+    ));
+    settle(&mut app);
+
+    assert!(
+        app.world_mut()
+            .query_filtered::<Entity, With<PickerItems<String>>>()
+            .iter(app.world())
+            .next()
+            .is_some(),
+        "the file itself opens the list, the way a resource field does",
+    );
+}
+
+#[test]
+fn the_picker_lists_only_the_files_the_field_can_name() {
+    let (mut app, _tmp) = app_with_open_outfit();
+
+    call(&mut app, "asset.pick", &[("field", "material".into())]);
+
+    let listed: Vec<String> = all_entities(&mut app)
+        .into_iter()
+        .filter_map(|entity| app.world().get::<PickerItems<String>>(entity))
+        .flat_map(|items| items.items().to_vec())
+        .collect();
+    assert_eq!(
+        listed,
+        vec![
+            "materials/moss.bsn".to_string(),
+            "materials/slate.bsn".to_string()
+        ],
+        "the picker offers the project's materials and nothing else",
+    );
+}
+
+#[test]
+fn picking_a_file_assigns_it_and_undo_puts_back_what_was_there() {
+    let (mut app, _tmp) = app_with_open_outfit();
+
+    call(
+        &mut app,
+        "asset.pick",
+        &[
+            ("field", "material".into()),
+            ("value", "materials/slate.bsn".into()),
+        ],
+    );
+    assert_eq!(open_outfit(&app)["material"], "materials/slate.bsn");
+
+    call(
+        &mut app,
+        "asset.pick",
+        &[
+            ("field", "material".into()),
+            ("value", "materials/moss.bsn".into()),
+        ],
+    );
+    assert_eq!(open_outfit(&app)["material"], "materials/moss.bsn");
+
+    undo(&mut app);
+
+    assert_eq!(
+        open_outfit(&app)["material"],
+        "materials/slate.bsn",
+        "undo puts back the file the field named before",
+    );
+}
+
+#[test]
+fn clearing_a_field_leaves_it_naming_nothing_and_undo_puts_the_path_back() {
+    let (mut app, _tmp) = app_with_open_outfit();
+    call(
+        &mut app,
+        "asset.pick",
+        &[
+            ("field", "material".into()),
+            ("value", "materials/slate.bsn".into()),
+        ],
+    );
+
+    call(&mut app, "asset.clear", &[("field", "material".into())]);
+
+    assert_eq!(
+        open_outfit(&app)["material"],
+        "",
+        "Clear leaves the field naming no file",
+    );
+    let row = asset_row(&mut app, "material");
+    assert!(
+        row_text(&mut app, row).iter().any(|line| line == "None"),
+        "and the row says so, got {:?}",
+        row_text(&mut app, row),
+    );
+
+    undo(&mut app);
+
+    assert_eq!(
+        open_outfit(&app)["material"],
+        "materials/slate.bsn",
+        "undo puts the path back",
+    );
+}
+
+#[test]
+fn new_writes_a_file_beside_the_open_asset_and_assigns_it() {
+    let (mut app, tmp) = app_with_open_outfit();
+    let row = asset_row(&mut app, "material");
+
+    let new = row_button(&mut app, row, "New");
+    app.world_mut().trigger(ButtonClickEvent { entity: new });
+    settle(&mut app);
+
+    let written = open_outfit(&app)["material"]
+        .as_str()
+        .expect("the field names a file")
+        .to_string();
+    assert!(
+        written.starts_with("content/"),
+        "New wrote beside the open asset, got {written}",
+    );
+    assert!(
+        tmp.path().join("assets").join(&written).is_file(),
+        "and the file it named is on disk",
+    );
+}
+
+#[test]
+fn a_drop_of_a_file_of_another_type_leaves_the_field_as_it_was() {
+    let (mut app, tmp) = app_with_open_outfit();
+    call(
+        &mut app,
+        "asset.pick",
+        &[
+            ("field", "material".into()),
+            ("value", "materials/slate.bsn".into()),
+        ],
+    );
+    let row = asset_row(&mut app, "material");
+
+    drop_file_on(&mut app, row, tmp.path().join("assets/content/torch.bsn"));
+
+    assert_eq!(
+        open_outfit(&app)["material"],
+        "materials/slate.bsn",
+        "a file holding something else is refused",
+    );
+    assert!(
+        !app.world()
+            .resource::<jackdaw::status_bar::StatusNotice>()
+            .text()
+            .is_empty(),
+        "and the refusal is said out loud",
+    );
+}
+
+#[test]
+fn a_drop_of_a_file_the_field_can_name_assigns_it() {
+    let (mut app, tmp) = app_with_open_outfit();
+    let row = asset_row(&mut app, "material");
+
+    drop_file_on(&mut app, row, tmp.path().join("assets/materials/moss.bsn"));
+
+    assert_eq!(
+        open_outfit(&app)["material"],
+        "materials/moss.bsn",
+        "the dropped file is what the field now names",
+    );
+}
+
+/// The window a synthetic pointer event is aimed at.
+fn primary_target(app: &mut App) -> NormalizedRenderTarget {
+    let window = app
+        .world_mut()
+        .query_filtered::<Entity, With<PrimaryWindow>>()
+        .single(app.world())
+        .expect("headless apps still have a primary window");
+    RenderTarget::Window(WindowRef::Primary)
+        .normalize(Some(window))
+        .expect("the primary window normalizes")
+}
+
+/// Drag a file out of the asset browser and drop it on a row.
+fn drop_file_on(app: &mut App, row: Entity, file: PathBuf) {
+    app.world_mut().resource_mut::<ActiveAssetDrag>().path = Some(file);
+    let target = primary_target(app);
+    let dropped = app.world_mut().spawn_empty().id();
+    app.world_mut().trigger(Pointer::new(
+        PointerId::Mouse,
+        Location {
+            target,
+            position: Vec2::ZERO,
+        },
+        DragDrop {
+            button: PointerButton::Primary,
+            dropped,
+            hit: HitData::new(row, 0.0, None, None),
+        },
+        row,
+    ));
+    settle(app);
+}
+
+#[test]
+fn a_list_of_material_paths_shows_one_row_per_element() {
+    let (mut app, _tmp) = app_with_open_outfit();
+    call(
+        &mut app,
+        "asset.set",
+        &[
+            ("field", "materials".into()),
+            (
+                "value",
+                serde_json::json!(["materials/slate.bsn", "materials/moss.bsn"])
+                    .to_string()
+                    .into(),
+            ),
+        ],
+    );
+
+    let mut fields: Vec<String> = asset_rows(&mut app)
+        .into_iter()
+        .map(|(_, _, field)| field)
+        .filter(|field| field.starts_with("materials["))
+        .collect();
+    fields.sort();
+    fields.dedup();
+    assert_eq!(
+        fields,
+        vec!["materials[0]".to_string(), "materials[1]".to_string()],
+        "each element of the list has a row of its own",
+    );
+
+    call(
+        &mut app,
+        "asset.pick",
+        &[
+            ("field", "materials[1]".into()),
+            ("value", "materials/slate.bsn".into()),
+        ],
+    );
+    assert_eq!(
+        open_outfit(&app)["materials"],
+        serde_json::json!(["materials/slate.bsn", "materials/slate.bsn"]),
+        "Pick on one element writes only that element",
+    );
+
+    call(&mut app, "asset.clear", &[("field", "materials[0]".into())]);
+    assert_eq!(
+        open_outfit(&app)["materials"],
+        serde_json::json!(["", "materials/slate.bsn"]),
+        "and Clear empties only the element it stands beside",
+    );
+}
+
+/// Build the card again, the way reopening the file does, so a row whose kind
+/// follows the value is decided against what the value now holds.
+fn reopen_outfit(app: &mut App) {
+    let path =
+        jackdaw::definition_assets::open_definition_path(app.world()).expect("an asset is open");
+    let path = path.to_string_lossy().into_owned();
+    call(app, "asset.open", &[("path", path.into())]);
+}
+
+#[test]
+fn a_material_a_string_field_names_gets_the_row_a_handle_gets() {
+    let (mut app, _tmp) = app_with_open_outfit();
+    call(
+        &mut app,
+        "asset.set",
+        &[
+            ("field", "skin".into()),
+            ("value", "materials/slate.bsn".into()),
+        ],
+    );
+    reopen_outfit(&mut app);
+
+    let row = asset_row(&mut app, "skin");
+    assert!(
+        row_text(&mut app, row)
+            .iter()
+            .any(|line| line == "slate.bsn"),
+        "the row shows the file the string names",
+    );
+
+    call(
+        &mut app,
+        "asset.pick",
+        &[
+            ("field", "skin".into()),
+            ("value", "materials/moss.bsn".into()),
+        ],
+    );
+    assert_eq!(
+        open_outfit(&app)["skin"],
+        serde_json::json!("materials/moss.bsn"),
+        "and picking writes the path the field spells",
+    );
+}
+
+#[test]
+fn a_string_naming_no_file_stays_a_plain_text_row() {
+    let (mut app, _tmp) = app_with_open_outfit();
+    call(
+        &mut app,
+        "asset.set",
+        &[("field", "skin".into()), ("value", "ranger".into())],
+    );
+    reopen_outfit(&mut app);
+
+    assert!(
+        !asset_rows(&mut app)
+            .iter()
+            .any(|(_, _, field)| field == "skin"),
+        "a string that names nothing the project holds is no asset field",
+    );
+}
+
+#[test]
+fn an_empty_element_beside_a_path_still_offers_the_picker() {
+    let (mut app, _tmp) = app_with_open_outfit();
+    call(
+        &mut app,
+        "asset.set",
+        &[
+            ("field", "skins".into()),
+            (
+                "value",
+                serde_json::json!(["materials/slate.bsn", ""])
+                    .to_string()
+                    .into(),
+            ),
+        ],
+    );
+    reopen_outfit(&mut app);
+
+    let mut fields: Vec<String> = asset_rows(&mut app)
+        .into_iter()
+        .map(|(_, _, field)| field)
+        .filter(|field| field.starts_with("skins["))
+        .collect();
+    fields.sort();
+    fields.dedup();
+    assert_eq!(
+        fields,
+        vec!["skins[0]".to_string(), "skins[1]".to_string()],
+        "the element holding nothing takes its kind from the list it sits in",
+    );
+
+    call(
+        &mut app,
+        "asset.pick",
+        &[
+            ("field", "skins[1]".into()),
+            ("value", "materials/moss.bsn".into()),
+        ],
+    );
+    assert_eq!(
+        open_outfit(&app)["skins"],
+        serde_json::json!(["materials/slate.bsn", "materials/moss.bsn"]),
+        "and the empty element takes the file picked for it",
+    );
+}
+
+#[test]
+fn a_second_pick_replaces_the_list_the_first_put_up() {
+    let (mut app, _tmp) = app_with_open_outfit();
+    call(&mut app, "asset.pick", &[("field", "material".into())]);
+    call(&mut app, "asset.pick", &[("field", "material".into())]);
+
+    let open = app
+        .world_mut()
+        .query_filtered::<Entity, With<PickerItems<String>>>()
+        .iter(app.world())
+        .count();
+    assert_eq!(open, 1, "one list is open, not one per click");
+}
+
+#[test]
+fn clearing_a_field_no_row_shows_is_refused_rather_than_reported_as_done() {
+    let (mut app, _tmp) = app_with_open_outfit();
+
+    let result = app
+        .world_mut()
+        .operator("asset.clear")
+        .settings(CallOperatorSettings {
+            execution_context: ExecutionContext::Invoke,
+            creates_history_entry: true,
+        })
+        .param("field", PropertyValue::from("nothing_shows_this"))
+        .call()
+        .expect("the operator dispatched");
+    assert_eq!(
+        result,
+        OperatorResult::Cancelled,
+        "a caller naming a field the inspector is not showing is told so",
+    );
+}

--- a/tests/inspector/main.rs
+++ b/tests/inspector/main.rs
@@ -7,6 +7,7 @@
 #[path = "../util/mod.rs"]
 mod util;
 
+mod asset_row;
 mod bindings_card;
 mod bindings_link;
 mod definition_card;


### PR DESCRIPTION
Every asset field in the inspector rendered as the literal <opaque>, so a material or texture could only be changed through a bespoke panel or a native dialog, and clearing one left the old handle in place.

A field that names an asset is now a row showing the file name, with Pick, Clear and New beside it and a drop target on the row. A schema field holding a path gets the same row, material texture slots use it in place of their browse button, and asset.pick and asset.clear drive it from the remote.

LLM disclaimer: Claude Code was used to help plan and implement this change, but all code was human reviewed by myself!
