### PR TITLE
Create assets from any folder

### DIFF
--- a/book/src/developer-guide/custom-components.md
+++ b/book/src/developer-guide/custom-components.md
@@ -84,10 +84,22 @@ app.init_asset::<ItemDef>().register_asset_reflect::<ItemDef>();
 ```
 
 Nothing is declared anywhere else. The schema the build extracts
-reports the type, the editor names the kind after it (`ItemDef`
-gives `item`, `Item` on menus), and right-clicking a folder in the
-asset browser offers **New Item**. The file is a plain `.bsn`
-whose second line names the type it holds:
+reports the type and the editor names the kind after it (`ItemDef`
+gives `item`, `Item` on menus).
+
+There are three ways to create one, and none of them asks what
+flavour of file to write. Right-click any folder in the asset
+browser or the project files tree and pick **New Asset...**: the
+list offers every kind, searchable by its name or by the type it
+holds, and the one you pick lands in that folder with its card in
+the inspector. The **Add** menu lists the same kinds under
+**Assets**, creating in the folder the browser is showing. The
+**New** beside an asset field in the inspector writes one of that
+field's type and assigns it. A name of its own is optional: without
+one the file is `<kind>_1.bsn`, then `<kind>_2.bsn`.
+
+The file is a plain `.bsn` whose second line names the type it
+holds:
 
 ```text
 // jackdaw 0.19.0 | bevy 0.19

--- a/src/add_entity_picker.rs
+++ b/src/add_entity_picker.rs
@@ -74,7 +74,7 @@ pub fn add_menu_rows(world: &mut World) -> Vec<(String, String)> {
 
 /// Open the searchable Add Entity picker, the way the scene tree's Add Entity
 /// button does. Shares [`collect_add_menu_items`] with the Add menu, so the two
-/// offer the same vocabulary. Calling it again closes it.
+/// offer the same entity vocabulary. Calling it again closes it.
 #[operator(
     id = "entity.add_picker",
     label = "Add Entity",
@@ -110,7 +110,16 @@ pub fn open_add_entity_picker(
         return;
     }
 
-    let items = collect_add_menu_items(world);
+    // The picker adds an entity to the scene, so the rows that write an asset
+    // file instead stay in the Add menu.
+    let items: Vec<AddMenuItem> = collect_add_menu_items(world)
+        .into_iter()
+        .filter(|item| {
+            !item
+                .action
+                .starts_with(crate::creation_taxonomy::ASSET_ACTION_PREFIX)
+        })
+        .collect();
 
     let picker = PickerProps::new(spawn_item, on_select)
         .items(items)

--- a/src/asset_browser.rs
+++ b/src/asset_browser.rs
@@ -262,9 +262,8 @@ fn spawn_asset_drag_ghost(
         .id()
 }
 
-/// Context-menu action prefix for creating a definition of a registered kind;
-/// the kind follows it.
-const NEW_DEFINITION_ACTION: &str = "asset_browser.new.";
+/// Context-menu action that opens the list of asset kinds on a folder.
+const NEW_ASSET_ACTION: &str = "asset_browser.new_asset";
 
 fn on_asset_browser_context_action(
     event: On<jackdaw_widgets::context_menu::ContextMenuAction>,
@@ -272,14 +271,13 @@ fn on_asset_browser_context_action(
     state: Res<AssetBrowserState>,
     mut menu_state: ResMut<jackdaw_widgets::context_menu::ContextMenuState>,
 ) {
-    if let Some(kind) = event.action.strip_prefix(NEW_DEFINITION_ACTION) {
+    if event.action == NEW_ASSET_ACTION {
         let folder = state
             .selected_file
             .clone()
             .unwrap_or_else(|| state.current_directory.to_string_lossy().into_owned());
         commands
-            .operator(crate::definition_assets::AssetNewOp::ID)
-            .param("type", kind.to_string())
+            .operator(crate::new_asset::AssetNewPickerOp::ID)
             .param("path", folder)
             .call();
         if let Some(menu) = menu_state.menu_entity.take()
@@ -853,16 +851,15 @@ fn refresh_browser_on_change(
                     },
                 );
 
-            // Right-click: open context menu with a Delete entry. The
-            // click also selects the row so the breadcrumb shows the
-            // target and the Delete dispatch can pick it up.
+            // Right-click: open a context menu, with New Asset on a folder.
+            // The click also selects the row so the breadcrumb shows the
+            // target and the dispatch can pick it up.
             let rmb_path = entry.path.clone();
             commands.entity(item_entity).observe(
                 move |click: On<Pointer<Click>>,
                       mut commands: Commands,
                       mut state: ResMut<AssetBrowserState>,
                       windows: Query<&Window>,
-                      asset_kinds: Res<jackdaw_api::prelude::AssetKinds>,
                       project: Option<Res<crate::project::ProjectRoot>>,
                       mut menu_state: ResMut<jackdaw_widgets::context_menu::ContextMenuState>| {
                     if click.event().button != PointerButton::Secondary {
@@ -883,13 +880,10 @@ fn refresh_browser_on_change(
                     }
                     let mut items: Vec<(String, String)> = Vec::new();
                     if project.is_some() && rmb_path.is_dir() {
-                        for definition in asset_kinds.iter().filter(|kind| kind.scanned()) {
-                            items.push((
-                                format!("{NEW_DEFINITION_ACTION}{}", definition.kind),
-                                format!("New {}", definition.label),
-                            ));
-                        }
-                        items.sort();
+                        items.push((
+                            NEW_ASSET_ACTION.to_string(),
+                            crate::new_asset::NEW_ASSET_LABEL.to_string(),
+                        ));
                     }
                     items.push(("asset_browser.delete".to_string(), "Delete".to_string()));
                     let entries: Vec<(&str, &str)> = items

--- a/src/creation_taxonomy.rs
+++ b/src/creation_taxonomy.rs
@@ -20,6 +20,9 @@ use crate::entity_ops::{EntityAddNetworkRoomOp, EntityAddSpawnPointOp, EntityAdd
 /// Action prefix of an entry that creates a registered UI widget.
 pub const WIDGET_ACTION_PREFIX: &str = "widget:";
 
+/// Action prefix of an entry that creates an asset file; the kind follows it.
+pub const ASSET_ACTION_PREFIX: &str = "asset:";
+
 /// The group holding entity kinds that belong to no other group.
 pub const GENERAL_GROUP: &str = "general";
 
@@ -43,8 +46,17 @@ const UI_GROUP_ORDER: i32 = -8;
 /// Sort order of a widget group whose category is not in `UI_CATEGORY_ORDER`.
 const UI_UNKNOWN_CATEGORY_ORDER: i32 = UI_GROUP_ORDER - UI_CATEGORY_ORDER.len() as i32;
 
+/// The group holding one entry per asset kind.
+pub const ASSETS_GROUP: &str = "assets";
+
+/// Label of [`ASSETS_GROUP`].
+pub const ASSETS_SECTION: &str = "Assets";
+
+/// Sort order of the assets group, after the entity kinds.
+const ASSETS_GROUP_ORDER: i32 = UI_UNKNOWN_CATEGORY_ORDER - 1;
+
 /// Sort order of the per-extension groups, last in the menu.
-const EXTENSION_GROUP_ORDER: i32 = UI_UNKNOWN_CATEGORY_ORDER - 1;
+const EXTENSION_GROUP_ORDER: i32 = ASSETS_GROUP_ORDER - 1;
 
 /// Heading for entries whose owning extension cannot be named.
 pub const EXTENSIONS_SECTION: &str = "Extensions";
@@ -86,8 +98,8 @@ pub struct CreationEntry {
     pub group: String,
     /// The name shown for the entry.
     pub label: String,
-    /// What activating it does: an `op:` operator call, or a
-    /// [`WIDGET_ACTION_PREFIX`] widget id.
+    /// What activating it does: an `op:` operator call, a
+    /// [`WIDGET_ACTION_PREFIX`] widget id, or an [`ASSET_ACTION_PREFIX`] kind.
     pub action: String,
 }
 
@@ -253,6 +265,31 @@ fn widgets(taxonomy: &mut CreationTaxonomy, world: &mut World) {
     }
 }
 
+/// One entry per asset kind the editor can write a file of. An asset needs a
+/// project to land in, so the group is absent until one is open.
+fn assets(taxonomy: &mut CreationTaxonomy, world: &mut World) {
+    if world
+        .get_resource::<crate::project::ProjectRoot>()
+        .is_none()
+    {
+        return;
+    }
+    let kinds = crate::new_asset::creatable_kinds(world);
+    if kinds.is_empty() {
+        return;
+    }
+    taxonomy
+        .groups
+        .push(group(ASSETS_GROUP, ASSETS_SECTION, ASSETS_GROUP_ORDER));
+    for kind in kinds {
+        taxonomy.entries.push(entry(
+            ASSETS_GROUP,
+            &kind.label,
+            format!("{ASSET_ACTION_PREFIX}{}", kind.kind),
+        ));
+    }
+}
+
 fn ui_group_id(category: &str) -> String {
     format!("{UI_GROUP}.{}", category.to_lowercase())
 }
@@ -315,6 +352,7 @@ impl CreationTaxonomy {
         let mut taxonomy = Self::default();
         builtin(&mut taxonomy);
         widgets(&mut taxonomy, world);
+        assets(&mut taxonomy, world);
         extensions(&mut taxonomy, world);
         taxonomy.groups.sort_by_key(|group| {
             (
@@ -374,6 +412,11 @@ impl CreationTaxonomy {
     fn renders_inline(&self, group: &CreationGroup) -> bool {
         if group.id == GENERAL_GROUP {
             return true;
+        }
+        // A lone asset kind reads as an entity kind without the heading that
+        // says it writes a file.
+        if group.id == ASSETS_GROUP {
+            return false;
         }
         // An extension's group name credits the extension; inlining would make
         // its entries look built-in.

--- a/src/definition_assets.rs
+++ b/src/definition_assets.rs
@@ -34,13 +34,13 @@ use crate::project::ProjectRoot;
 /// The first `<kind>_N` name with neither an entry nor a file of its own in
 /// the folder the new file lands in.
 fn next_free_name(world: &World, kind: &str, dir: &Path) -> String {
-    let index = world.resource::<AssetIndex>();
     let mut counter = 1u32;
     loop {
         let candidate = format!("{kind}_{counter}");
-        let taken = index.of_kind(kind).any(|entry| entry.name() == candidate)
-            || definition_file_path(dir, &candidate).exists();
-        if !taken {
+        let file = definition_file_path(dir, &candidate);
+        let indexed = crate::asset_index::indexed_path(world, &file)
+            .is_some_and(|path| world.resource::<AssetIndex>().get(&path).is_some());
+        if !file.exists() && !indexed {
             return candidate;
         }
         counter += 1;
@@ -91,6 +91,15 @@ fn names_a_file(path: &Path) -> bool {
         && path
             .extension()
             .is_some_and(|extension| extension.eq_ignore_ascii_case("bsn"))
+}
+
+/// A name that carries its own extension as the file it names, so `torch.bsn`
+/// and `torch.item.bsn` each write one file rather than two extensions.
+fn bsn_file_name(name: &str) -> String {
+    match Path::new(name).extension() {
+        Some(extension) if extension.eq_ignore_ascii_case("bsn") => name.to_string(),
+        _ => format!("{name}.bsn"),
+    }
 }
 
 /// The file an asset of this name lands in, in a folder of the user's choosing.
@@ -1165,6 +1174,7 @@ fn save_indexed_asset(world: &mut World, path: &Path) -> Option<String> {
 
 pub(crate) fn add_to_extension(ctx: &mut ExtensionContext) {
     ctx.register_operator::<AssetNewOp>()
+        .register_operator::<crate::new_asset::AssetNewPickerOp>()
         .register_operator::<AssetOpenOp>()
         .register_operator::<AssetSaveOp>()
         .register_operator::<AssetDeleteOp>()
@@ -1256,12 +1266,21 @@ pub fn asset_new(params: In<OperatorParameters>, mut commands: Commands) -> Oper
     OperatorResult::Finished
 }
 
-fn new_definition(world: &mut World, kind: &str, name: Option<&str>, dir: Option<&Path>) {
+/// Create an asset of a kind, open its card and report the file it landed in.
+pub(crate) fn new_definition(
+    world: &mut World,
+    kind: &str,
+    name: Option<&str>,
+    dir: Option<&Path>,
+) -> Option<PathBuf> {
     let Some((definition, name, path)) = create_definition(world, kind, name, dir) else {
-        return;
+        crate::status_bar::notify_error(world, format!("no {kind} could be created there"));
+        return None;
     };
-    show_definition(world, &definition, &name, path);
-    report_to_caller(world, format!("Created {kind} '{name}'"));
+    show_definition(world, &definition, &name, path.clone());
+    use path_slash::PathExt as _;
+    report_to_caller(world, path.to_slash_lossy().into_owned());
+    Some(path)
 }
 
 /// Write a fresh default value of a registered kind to its file and index it.
@@ -1290,25 +1309,34 @@ pub(crate) fn create_definition(
         }
     };
     let asked_for = name.map(sanitize_definition_name);
+    let named_file = asked_for
+        .as_deref()
+        .filter(|asked| asked.contains('.'))
+        .map(|asked| dir.join(bsn_file_name(asked)));
+    let file = file.or_else(|| named_file.clone());
     let named_by_path = file.as_deref().map(definition_name_of);
     let name = match named_by_path.or_else(|| asked_for.clone()) {
         Some(name) => sanitize_definition_name(&name),
         None => next_free_name(world, kind, &dir),
     };
-    if asked_for.is_some_and(|asked| asked != name) {
+    if named_file.is_none() && asked_for.is_some_and(|asked| asked != name) {
         warn!("asset.new: the file asked for names this {kind} '{name}'");
-    }
-    if world
-        .resource::<AssetIndex>()
-        .of_kind(kind)
-        .any(|entry| entry.name() == name)
-    {
-        warn!("asset.new: a {kind} named '{name}' already exists");
-        return None;
     }
     let path = file.unwrap_or_else(|| definition_file_path(&dir, &name));
     if path.exists() {
         warn!("asset.new: {} is already there", path.display());
+        return None;
+    }
+    let under_assets = crate::asset_index::indexed_path(world, &path).is_some_and(|relative| {
+        !relative
+            .components()
+            .any(|part| part == std::path::Component::ParentDir)
+    });
+    if !under_assets {
+        warn!(
+            "asset.new: {} is outside this project's assets",
+            path.display()
+        );
         return None;
     }
     let Some(value) = default_asset_value(world, &definition) else {
@@ -1603,7 +1631,7 @@ pub fn asset_list(params: In<OperatorParameters>, mut commands: Commands) -> Ope
 
 /// Accept both a path under the project and one relative to its assets
 /// directory, so a caller can pass what the asset browser lists.
-fn resolve_project_path(world: &World, path: &Path) -> PathBuf {
+pub(crate) fn resolve_project_path(world: &World, path: &Path) -> PathBuf {
     if path.is_absolute() {
         return path.to_path_buf();
     }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -50,6 +50,7 @@ pub mod keybind_focus;
 pub mod keybind_settings;
 pub mod keybinds;
 pub mod migrate_dialog;
+pub mod new_asset;
 pub mod panel_focus;
 
 use std::{collections::BTreeMap, marker::PhantomData};
@@ -2678,6 +2679,18 @@ fn unescape_action_value(value: &str) -> String {
 /// free-standing `op:` events. Always plain `op:OP_ID` form ;
 /// parametrised dispatch goes through `ButtonOperatorCall.params`.
 fn handle_menu_action(event: On<MenuAction>, mut commands: Commands) {
+    // An Assets row creates a file of its kind in the folder the browser is
+    // showing, which is what `asset.new` does with no path of its own.
+    if let Some(kind) = event
+        .action
+        .strip_prefix(creation_taxonomy::ASSET_ACTION_PREFIX)
+    {
+        commands
+            .operator(definition_assets::AssetNewOp::ID)
+            .param("type", kind.to_string())
+            .call();
+        return;
+    }
     // The UI Widgets rows go through `instantiate_widget` so the new node
     // is authored, undoable, and in the document.
     if let Some(widget_id) = event

--- a/src/new_asset.rs
+++ b/src/new_asset.rs
@@ -1,0 +1,215 @@
+//! Creating an asset file from wherever the user is: a folder in the asset
+//! browser or the project files tree, an entry in the Add menu, or the New
+//! beside an asset field.
+//!
+//! The user never picks a file flavour. One list offers every kind the editor
+//! can write a default value for, searchable by its name and by the type it
+//! holds, and picking one writes `<kind>_<n>.bsn` in the folder the list was
+//! opened on and puts its card in the inspector.
+
+use std::path::{Path, PathBuf};
+
+use bevy::asset::ReflectAsset;
+use bevy::prelude::*;
+use bevy::reflect::TypeRegistry;
+use bevy::reflect::prelude::ReflectDefault;
+use jackdaw_api::prelude::{AssetKind, AssetKinds};
+use jackdaw_feathers::picker::{PickerProps, SelectInput, SpawnItemInput, match_text, picker_item};
+
+use crate::prelude::*;
+
+/// What the context-menu item that opens the list of kinds reads as. Each
+/// panel names the action itself, since every panel sees every action.
+pub const NEW_ASSET_LABEL: &str = "New Asset...";
+
+/// The list of kinds a folder's New Asset put up, and where its choice lands.
+#[derive(Component)]
+pub struct NewAssetList {
+    folder: PathBuf,
+    /// The kind each row stands for, in the order the rows were built.
+    kinds: Vec<String>,
+}
+
+/// The kinds the editor can write a default value of, in the order a list
+/// shows them.
+pub fn creatable_kinds(world: &World) -> Vec<AssetKind> {
+    let Some(kinds) = world.get_resource::<AssetKinds>() else {
+        return Vec::new();
+    };
+    let Some(registry) = world.get_resource::<AppTypeRegistry>() else {
+        return Vec::new();
+    };
+    let registry = registry.read();
+    let mut creatable: Vec<AssetKind> = kinds
+        .iter()
+        .filter(|kind| has_default_value(kind, &registry))
+        .cloned()
+        .collect();
+    creatable.sort_by(|one, other| one.label.cmp(&other.label));
+    creatable
+}
+
+/// Whether a fresh file of this kind can be written: a schema kind holds a
+/// patch that authors nothing, and a compiled one needs a default value its
+/// store can take.
+fn has_default_value(kind: &AssetKind, registry: &TypeRegistry) -> bool {
+    if kind.schema_backed() {
+        return true;
+    }
+    registry
+        .get_with_type_path(&kind.type_path)
+        .is_some_and(|registration| {
+            registration.data::<ReflectAsset>().is_some()
+                && registration.data::<ReflectDefault>().is_some()
+        })
+}
+
+/// The line a kind reads as in the list: its name, then the type it holds, so
+/// a search over the line matches either.
+pub fn kind_line(kind: &AssetKind) -> String {
+    format!("{}  {}", kind.label, kind.type_path)
+}
+
+/// Open the list of asset kinds, creating the one picked in a folder.
+#[operator(
+    id = "asset.new_picker",
+    label = "New Asset...",
+    description = "Open the list of asset kinds and create the one picked.",
+    allows_undo = false,
+    params(path(
+        String,
+        doc = "Folder to create in. Defaults to the folder the browser is showing."
+    ))
+)]
+pub fn asset_new_picker(params: In<OperatorParameters>, mut commands: Commands) -> OperatorResult {
+    let path = params.as_str("path").map(PathBuf::from);
+    commands.queue(move |world: &mut World| {
+        open_new_asset_list(world, path.as_deref());
+    });
+    OperatorResult::Finished
+}
+
+/// Put up the list of kinds for a folder, in place of one already open.
+pub fn open_new_asset_list(world: &mut World, folder: Option<&Path>) {
+    let Some(folder) = folder_for_new_asset(world, folder) else {
+        crate::status_bar::notify_error(world, "no project is open");
+        return;
+    };
+    let kinds = creatable_kinds(world);
+    if kinds.is_empty() {
+        crate::status_bar::notify_warn(world, "this project registers no asset kinds");
+        return;
+    }
+    close_new_asset_list(world);
+    let items: Vec<String> = kinds.iter().map(kind_line).collect();
+    let list = NewAssetList {
+        folder,
+        kinds: kinds.into_iter().map(|kind| kind.kind).collect(),
+    };
+    world.commands().spawn((
+        PickerProps::new(spawn_kind_item, pick_kind)
+            .items(items)
+            .title("New Asset")
+            .placeholder(Some("Search asset kinds..")),
+        list,
+        crate::EditorEntity,
+        crate::BlocksCameraInput,
+    ));
+    world.flush();
+}
+
+/// Drop a list left open, so a second New Asset replaces it rather than
+/// stacking another list over it.
+pub fn close_new_asset_list(world: &mut World) {
+    let open: Vec<Entity> = world
+        .query_filtered::<Entity, With<NewAssetList>>()
+        .iter(world)
+        .collect();
+    for list in open {
+        if let Ok(entity) = world.get_entity_mut(list) {
+            entity.despawn();
+        }
+    }
+}
+
+/// The folder a list writes into: the one it was opened on, the folder holding
+/// the file it was opened on, or the one the browser is showing.
+fn folder_for_new_asset(world: &World, folder: Option<&Path>) -> Option<PathBuf> {
+    let asked = folder.map(|folder| crate::definition_assets::resolve_project_path(world, folder));
+    let chosen = match asked {
+        Some(folder) if folder.is_dir() => Some(folder),
+        Some(file) => file
+            .parent()
+            .filter(|parent| parent.is_dir())
+            .map(Path::to_path_buf),
+        None => None,
+    };
+    chosen.or_else(|| crate::definition_assets::new_definition_dir(world))
+}
+
+fn spawn_kind_item(
+    In(SpawnItemInput { matched, entities }): In<SpawnItemInput>,
+    mut commands: Commands,
+) -> Result {
+    commands.spawn((
+        picker_item(matched.index),
+        ChildOf(entities.list),
+        children![match_text(matched.segments)],
+    ));
+    Ok(())
+}
+
+fn pick_kind(
+    input: In<SelectInput>,
+    lists: Query<&NewAssetList>,
+    mut commands: Commands,
+) -> Result {
+    let picker = input.entities.picker;
+    let list = lists.get(picker)?;
+    let chosen = list.kinds.get(input.index).cloned();
+    let folder = list.folder.clone();
+    commands.entity(picker).try_despawn();
+    let Some(kind) = chosen else {
+        return Ok(());
+    };
+    commands.queue(move |world: &mut World| {
+        create_in_folder(world, &kind, &folder);
+    });
+    Ok(())
+}
+
+/// Write a fresh asset of a kind into a folder, open its card, and take the
+/// browser to the file so it can be renamed where it sits.
+pub fn create_in_folder(world: &mut World, kind: &str, folder: &Path) -> Option<PathBuf> {
+    let path = crate::definition_assets::new_definition(world, kind, None, Some(folder))?;
+    show_in_browser(world, &path);
+    Some(path)
+}
+
+/// Point the asset browser at a file the editor just wrote.
+fn show_in_browser(world: &mut World, indexed: &Path) {
+    let file = crate::asset_index::absolute_path(world, indexed);
+    let Some(folder) = file.parent().map(Path::to_path_buf) else {
+        return;
+    };
+    let Some(mut browser) = world.get_resource_mut::<crate::asset_browser::AssetBrowserState>()
+    else {
+        return;
+    };
+    if folder.starts_with(&browser.root_directory) {
+        browser.current_directory = folder;
+    }
+    browser.selected_file = Some(file.to_string_lossy().into_owned());
+    browser.needs_refresh = true;
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn a_kind_reads_as_its_name_and_the_type_it_holds() {
+        let kind = AssetKind::from_schema("my_game::content::ItemDef");
+        assert_eq!(kind_line(&kind), "Item  my_game::content::ItemDef");
+    }
+}

--- a/src/project_files.rs
+++ b/src/project_files.rs
@@ -42,16 +42,31 @@ struct PendingProjectFilesAction {
     path: PathBuf,
 }
 
+/// Context-menu action that opens the list of asset kinds on a folder.
+const NEW_ASSET_ACTION: &str = "project_files.new_asset";
+
 fn on_project_files_context_action(
     event: On<jackdaw_widgets::context_menu::ContextMenuAction>,
     mut commands: Commands,
     pending: Res<PendingProjectFilesAction>,
     mut state: ResMut<jackdaw_widgets::context_menu::ContextMenuState>,
 ) {
+    let path = pending.path.to_string_lossy().into_owned();
+    if event.action == NEW_ASSET_ACTION {
+        commands
+            .operator(crate::new_asset::AssetNewPickerOp::ID)
+            .param("path", path)
+            .call();
+        if let Some(menu) = state.menu_entity.take()
+            && let Ok(mut ec) = commands.get_entity(menu)
+        {
+            ec.despawn();
+        }
+        return;
+    }
     if event.action != "project_files.delete" {
         return;
     }
-    let path = pending.path.to_string_lossy().into_owned();
     commands.operator("file.delete").param("path", path).call();
     if let Some(menu) = state.menu_entity.take()
         && let Ok(mut ec) = commands.get_entity(menu)
@@ -437,7 +452,7 @@ fn spawn_file_tree_row(
         },
     );
 
-    // Right-click: open a per-row context menu with a Delete entry.
+    // Right-click: open a per-row context menu, with New Asset on a folder.
     let rmb_path = path.to_path_buf();
     commands.entity(content).observe(
         move |click: On<Pointer<Click>>,
@@ -458,11 +473,16 @@ fn spawn_file_tree_row(
                 ec.despawn();
             }
             let path_owned = rmb_path.clone();
+            let mut items: Vec<(&str, &str)> = Vec::new();
+            if is_dir {
+                items.push((NEW_ASSET_ACTION, crate::new_asset::NEW_ASSET_LABEL));
+            }
+            items.push(("project_files.delete", "Delete"));
             let menu = jackdaw_feathers::context_menu::spawn_context_menu(
                 &mut commands,
                 cursor_pos,
                 None,
-                &[("project_files.delete", "Delete")],
+                &items,
             );
             state.menu_entity = Some(menu);
             commands.insert_resource(PendingProjectFilesAction { path: path_owned });

--- a/tests/inspector/main.rs
+++ b/tests/inspector/main.rs
@@ -14,6 +14,7 @@ mod definition_card;
 mod inspector_panel_width;
 mod inspector_preview_guard;
 mod inspector_val;
+mod new_asset_list;
 mod opened_definition_card;
 mod schema_definition_card;
 mod widget_cards;

--- a/tests/inspector/new_asset_list.rs
+++ b/tests/inspector/new_asset_list.rs
@@ -1,0 +1,128 @@
+//! The New Asset list a folder puts up, and what the inspector shows once a
+//! kind is picked from it: the new file's card, ready to be filled in.
+
+use crate::util;
+
+use bevy::asset::Asset;
+use bevy::prelude::*;
+use jackdaw::definition_assets::{DefinitionAssetEdit, OpenDefinition};
+use jackdaw_api::prelude::*;
+use jackdaw_api_internal::operator::{CallOperatorSettings, ExecutionContext};
+use jackdaw_feathers::picker::{PickerItems, PickerSelect};
+
+#[derive(Asset, Reflect, Clone, Default)]
+#[reflect(Default)]
+struct MobDef {
+    health: u32,
+    move_speed: f32,
+}
+
+/// An editor showing the inspector, with a project of its own and one asset
+/// type registered.
+fn editor_with_mobs() -> (App, tempfile::TempDir) {
+    let tmp = tempfile::tempdir().expect("tempdir");
+    std::fs::create_dir_all(tmp.path().join("assets/content/mobs")).expect("a content folder");
+    let mut app = util::editor_test_app();
+    app.init_asset::<MobDef>();
+    app.register_asset_reflect::<MobDef>();
+    app.register_type::<MobDef>();
+    app.world_mut()
+        .insert_resource(jackdaw::project::ProjectRoot {
+            root: tmp.path().to_path_buf(),
+            config: default(),
+        });
+    app.world_mut()
+        .resource_mut::<AssetKinds>()
+        .register(AssetKind::extension("mob", "Mob", MobDef::type_path()));
+    app.world_mut()
+        .spawn(jackdaw::layout::inspector_components_content(default()));
+    app.world_mut()
+        .resource_mut::<NextState<jackdaw::AppState>>()
+        .set(jackdaw::AppState::Editor);
+    settle(&mut app);
+    (app, tmp)
+}
+
+fn settle(app: &mut App) {
+    for _ in 0..8 {
+        app.update();
+    }
+}
+
+/// Every control on the panel writing a field of a type.
+fn rows_of(app: &mut App, type_path: &str) -> Vec<String> {
+    let entities: Vec<Entity> = app
+        .world_mut()
+        .query::<Entity>()
+        .iter(app.world())
+        .collect();
+    entities
+        .into_iter()
+        .filter_map(|entity| jackdaw::inspector::field_edited_by(app.world(), entity))
+        .filter(|(known, _)| *known == type_path)
+        .map(|(_, field)| field.to_string())
+        .collect()
+}
+
+#[test]
+fn choosing_a_kind_from_a_folder_writes_the_file_there_and_shows_its_card() {
+    let (mut app, tmp) = editor_with_mobs();
+    let mobs = tmp.path().join("assets/content/mobs");
+
+    let result = app
+        .world_mut()
+        .operator("asset.new_picker")
+        .settings(CallOperatorSettings {
+            execution_context: ExecutionContext::Invoke,
+            creates_history_entry: false,
+        })
+        .param("path", mobs.to_string_lossy().into_owned())
+        .call()
+        .expect("the operator dispatched");
+    assert_eq!(result, OperatorResult::Finished);
+    settle(&mut app);
+
+    let picker = app
+        .world_mut()
+        .query_filtered::<Entity, With<PickerItems<String>>>()
+        .iter(app.world())
+        .next()
+        .expect("the folder put up the list of kinds");
+    let index = app
+        .world()
+        .get::<PickerItems<String>>(picker)
+        .expect("the list holds its lines")
+        .items()
+        .iter()
+        .position(|line| line.starts_with("Mob  "))
+        .expect("the list offers the mob kind");
+    app.world_mut().trigger(PickerSelect {
+        entity: picker,
+        index,
+    });
+    settle(&mut app);
+
+    assert!(
+        mobs.join("mob_1.bsn").is_file(),
+        "the file lands in the folder the list was opened on"
+    );
+    let open = app
+        .world()
+        .resource::<OpenDefinition>()
+        .0
+        .expect("the new asset is open in the inspector");
+    let edit = app
+        .world()
+        .get::<DefinitionAssetEdit>(open)
+        .expect("the card stands for the file just written");
+    assert_eq!(edit.name, "mob_1");
+    assert_eq!(edit.path, std::path::Path::new("content/mobs/mob_1.bsn"));
+
+    let fields = rows_of(&mut app, MobDef::type_path());
+    for expected in ["health", "move_speed"] {
+        assert!(
+            fields.iter().any(|field| field == expected),
+            "the card has a row for {expected}, got {fields:?}"
+        );
+    }
+}

--- a/tests/stage/main.rs
+++ b/tests/stage/main.rs
@@ -19,6 +19,7 @@ mod definition_assets;
 mod gltf_authoring;
 mod mesh_quick_menu;
 mod modeling_essentials;
+mod new_asset;
 mod positionable_mirror_plane;
 mod project_definitions;
 mod selection_undo;

--- a/tests/stage/new_asset.rs
+++ b/tests/stage/new_asset.rs
@@ -1,0 +1,443 @@
+//! Creating an asset from wherever the user is: `asset.new` with a folder of
+//! its own, the New Asset list a folder puts up, and the Add menu's Assets
+//! group. The kind of file follows from what was picked, never from a dialog
+//! asking what flavour of file to write.
+
+use crate::util;
+
+use std::path::{Path, PathBuf};
+
+use bevy::asset::Asset;
+use bevy::prelude::*;
+use jackdaw::asset_index::AssetIndex;
+use jackdaw::definition_assets::{MATERIAL_KIND, OpenDefinition};
+use jackdaw::material_assets::MaterialRegistry;
+use jackdaw_api::prelude::*;
+use jackdaw_api_internal::operator::{CallOperatorSettings, ExecutionContext};
+use jackdaw_feathers::picker::{PickerItems, PickerSelect};
+use jackdaw_scene_types::PropertyValue;
+
+const OUTFIT_TYPE: &str = "my_game::content::OutfitDef";
+
+#[derive(Asset, Reflect, Clone, Default)]
+#[reflect(Default)]
+struct ItemDef {
+    stack_size: u32,
+}
+
+/// An editor with a project of its own, one type it has registered and one the
+/// project's schema reports.
+fn editor_with_kinds() -> (App, tempfile::TempDir) {
+    let tmp = tempfile::tempdir().expect("tempdir");
+    std::fs::create_dir_all(tmp.path().join("assets")).expect("an assets folder");
+    let mut app = util::editor_test_app();
+    app.init_asset::<ItemDef>();
+    app.register_asset_reflect::<ItemDef>();
+    app.register_type::<ItemDef>();
+    app.world_mut()
+        .insert_resource(jackdaw::project::ProjectRoot {
+            root: tmp.path().to_path_buf(),
+            config: default(),
+        });
+    {
+        let mut kinds = app.world_mut().resource_mut::<AssetKinds>();
+        kinds.register(AssetKind::extension("item", "Item", ItemDef::type_path()));
+        kinds.register(AssetKind::from_schema(OUTFIT_TYPE));
+    }
+    app.world_mut()
+        .resource_mut::<NextState<jackdaw::AppState>>()
+        .set(jackdaw::AppState::Editor);
+    settle(&mut app);
+    (app, tmp)
+}
+
+fn settle(app: &mut App) {
+    for _ in 0..6 {
+        app.update();
+    }
+}
+
+#[track_caller]
+fn call(app: &mut App, id: &'static str, params: &[(&'static str, PropertyValue)]) {
+    let mut call = app.world_mut().operator(id).settings(CallOperatorSettings {
+        execution_context: ExecutionContext::Invoke,
+        creates_history_entry: true,
+    });
+    for (key, value) in params {
+        call = call.param(*key, value.clone());
+    }
+    let result = call.call().expect("the operator dispatched");
+    assert_eq!(result, OperatorResult::Finished, "{id} did not finish");
+    settle(app);
+}
+
+/// A folder under the project's assets named after nothing in particular.
+fn folder(tmp: &tempfile::TempDir, relative: &str) -> PathBuf {
+    let dir = tmp.path().join("assets").join(relative);
+    std::fs::create_dir_all(&dir).expect("the directory is made");
+    dir
+}
+
+fn indexed(app: &App, relative: &str) -> bool {
+    app.world()
+        .resource::<AssetIndex>()
+        .get(Path::new(relative))
+        .is_some()
+}
+
+/// The lines the open list offers, one per kind.
+fn listed(app: &mut App) -> Vec<String> {
+    let entities: Vec<Entity> = app
+        .world_mut()
+        .query_filtered::<Entity, With<PickerItems<String>>>()
+        .iter(app.world())
+        .collect();
+    entities
+        .into_iter()
+        .filter_map(|entity| app.world().get::<PickerItems<String>>(entity))
+        .flat_map(|items| items.items().to_vec())
+        .collect()
+}
+
+/// Choose the line the list shows for a kind, the way a click on the row does.
+#[track_caller]
+fn choose(app: &mut App, label: &str) {
+    let index = listed(app)
+        .iter()
+        .position(|line| line.starts_with(label))
+        .unwrap_or_else(|| panic!("the list offers {label}, got {:?}", listed(app)));
+    let picker = app
+        .world_mut()
+        .query_filtered::<Entity, With<PickerItems<String>>>()
+        .iter(app.world())
+        .next()
+        .expect("a list is open");
+    app.world_mut().trigger(PickerSelect {
+        entity: picker,
+        index,
+    });
+    settle(app);
+}
+
+#[test]
+fn an_asset_is_written_into_whatever_folder_it_is_asked_for() {
+    let (mut app, tmp) = editor_with_kinds();
+    let dir = folder(&tmp, "content/odds_and_ends");
+
+    call(
+        &mut app,
+        "asset.new",
+        &[
+            ("type", "item".into()),
+            ("name", "torch".into()),
+            ("path", dir.to_string_lossy().into_owned().into()),
+        ],
+    );
+
+    let written = std::fs::read_to_string(dir.join("torch.bsn")).expect("the file reads");
+    assert!(
+        written.contains(&format!("jackdaw asset {}", ItemDef::type_path())),
+        "the file says what it holds: {written}"
+    );
+    assert!(
+        indexed(&app, "content/odds_and_ends/torch.bsn"),
+        "the index keys it by the path it landed on"
+    );
+}
+
+#[test]
+fn an_asset_with_no_name_takes_the_next_free_one() {
+    let (mut app, tmp) = editor_with_kinds();
+    let dir = folder(&tmp, "content/items");
+    let path: PropertyValue = dir.to_string_lossy().into_owned().into();
+
+    call(
+        &mut app,
+        "asset.new",
+        &[("type", "item".into()), ("path", path.clone())],
+    );
+    call(
+        &mut app,
+        "asset.new",
+        &[("type", "item".into()), ("path", path)],
+    );
+
+    assert!(dir.join("item_1.bsn").is_file(), "the first takes item_1");
+    assert!(
+        dir.join("item_2.bsn").is_file(),
+        "a second creation in the same folder does not fight the first for its name"
+    );
+    assert!(indexed(&app, "content/items/item_2.bsn"));
+}
+
+#[test]
+fn the_new_asset_list_offers_every_kind_and_no_scene() {
+    let (mut app, tmp) = editor_with_kinds();
+    let dir = folder(&tmp, "content");
+
+    call(
+        &mut app,
+        "asset.new_picker",
+        &[("path", dir.to_string_lossy().into_owned().into())],
+    );
+
+    let lines = listed(&mut app);
+    assert!(
+        lines
+            .iter()
+            .any(|line| *line == format!("Item  {}", ItemDef::type_path())),
+        "the type the editor holds is offered under its own type: {lines:?}"
+    );
+    assert!(
+        lines
+            .iter()
+            .any(|line| *line == format!("Outfit  {OUTFIT_TYPE}")),
+        "the kind the schema reports is offered under its type: {lines:?}"
+    );
+    assert!(
+        lines.iter().any(|line| line.starts_with("Material  ")),
+        "a material is an asset file like any other: {lines:?}"
+    );
+    assert!(
+        !lines
+            .iter()
+            .any(|line| line.to_lowercase().contains("scene")),
+        "a scene is made by File > New, not by picking a type: {lines:?}"
+    );
+    assert!(
+        !lines.iter().any(|line| line.starts_with("Prefab")),
+        "a prefab is packed from a selection, and has no blank value to write: {lines:?}"
+    );
+}
+
+#[test]
+fn a_material_picked_from_the_list_joins_the_materials_panel() {
+    let (mut app, tmp) = editor_with_kinds();
+    let dir = folder(&tmp, "content/looks");
+
+    call(
+        &mut app,
+        "asset.new_picker",
+        &[("path", dir.to_string_lossy().into_owned().into())],
+    );
+    choose(&mut app, "Material");
+
+    let created = format!("{MATERIAL_KIND}_1");
+    assert!(
+        dir.join(format!("{created}.bsn")).is_file(),
+        "the material lands in the folder the list was opened on"
+    );
+    assert!(
+        app.world()
+            .resource::<MaterialRegistry>()
+            .get_by_name(&created)
+            .is_some(),
+        "the panel lists it with the rest of the project's materials"
+    );
+}
+
+#[test]
+fn the_add_menu_offers_every_kind_and_creates_where_the_browser_is() {
+    let (mut app, tmp) = editor_with_kinds();
+    let dir = folder(&tmp, "content/things");
+    app.world_mut()
+        .resource_mut::<jackdaw::asset_browser::AssetBrowserState>()
+        .current_directory = dir.clone();
+
+    let items = jackdaw::add_entity_picker::collect_add_menu_items(app.world_mut());
+    let assets: Vec<(String, String)> = items
+        .iter()
+        .filter(|item| item.category.name.as_deref() == Some("Assets"))
+        .map(|item| (item.action.clone(), item.label.clone()))
+        .collect();
+    for expected in [("asset:item", "Item"), ("asset:outfit", "Outfit")] {
+        assert!(
+            assets
+                .iter()
+                .any(|(action, label)| (action.as_str(), label.as_str()) == expected),
+            "the Assets group offers {expected:?}, got {assets:?}"
+        );
+    }
+
+    app.world_mut()
+        .trigger(jackdaw_widgets::menu_bar::MenuAction {
+            action: String::from("asset:item"),
+        });
+    settle(&mut app);
+
+    assert!(
+        dir.join("item_1.bsn").is_file(),
+        "the menu writes into the folder the browser is showing"
+    );
+    assert!(indexed(&app, "content/things/item_1.bsn"));
+}
+
+#[test]
+fn creating_where_nothing_can_be_written_leaves_no_entry_behind() {
+    let (mut app, tmp) = editor_with_kinds();
+    let dir = folder(&tmp, "content/locked");
+    let mut locked = std::fs::metadata(&dir)
+        .expect("the folder is there")
+        .permissions();
+    locked.set_readonly(true);
+    std::fs::set_permissions(&dir, locked).expect("the folder locks");
+
+    call(
+        &mut app,
+        "asset.new",
+        &[
+            ("type", "item".into()),
+            ("path", dir.to_string_lossy().into_owned().into()),
+        ],
+    );
+
+    let entries = app.world().resource::<AssetIndex>().iter().count();
+    assert!(
+        !dir.join("item_1.bsn").exists(),
+        "nothing was written into a folder that refuses writes"
+    );
+    assert_eq!(
+        entries, 0,
+        "and the index holds no entry for what is not there"
+    );
+    assert!(
+        app.world().resource::<OpenDefinition>().0.is_none(),
+        "and no card stands for it"
+    );
+
+    let mut open = std::fs::metadata(&dir)
+        .expect("the folder is there")
+        .permissions();
+    #[expect(
+        clippy::permissions_set_readonly_false,
+        reason = "the folder is torn down next"
+    )]
+    open.set_readonly(false);
+    std::fs::set_permissions(&dir, open).expect("the folder unlocks");
+}
+
+#[test]
+fn nothing_is_written_outside_the_project_assets() {
+    let (mut app, tmp) = editor_with_kinds();
+    let outside = tmp.path().join("notes");
+    std::fs::create_dir_all(&outside).expect("a folder beside the assets");
+
+    call(
+        &mut app,
+        "asset.new",
+        &[
+            ("type", "item".into()),
+            ("path", outside.to_string_lossy().into_owned().into()),
+        ],
+    );
+
+    assert!(
+        !outside.join("item_1.bsn").exists(),
+        "a folder the index cannot key is no place for an asset"
+    );
+    assert_eq!(app.world().resource::<AssetIndex>().iter().count(), 0);
+}
+
+#[test]
+fn a_name_that_carries_its_own_extension_writes_one_file() {
+    let (mut app, tmp) = editor_with_kinds();
+    let dir = folder(&tmp, "content/items");
+
+    call(
+        &mut app,
+        "asset.new",
+        &[
+            ("type", "item".into()),
+            ("name", "torch.bsn".into()),
+            ("path", dir.to_string_lossy().into_owned().into()),
+        ],
+    );
+
+    assert!(
+        dir.join("torch.bsn").is_file(),
+        "the name already said what file to write"
+    );
+    assert!(
+        !dir.join("torch.bsn.bsn").exists(),
+        "and it was not written again on the end"
+    );
+    assert!(indexed(&app, "content/items/torch.bsn"));
+}
+
+#[test]
+fn a_name_with_a_flavour_keeps_the_flavour_and_is_known_by_its_stem() {
+    let (mut app, tmp) = editor_with_kinds();
+    let dir = folder(&tmp, "content/items");
+
+    call(
+        &mut app,
+        "asset.new",
+        &[
+            ("type", "item".into()),
+            ("name", "lamp.item.bsn".into()),
+            ("path", dir.to_string_lossy().into_owned().into()),
+        ],
+    );
+
+    let written = std::fs::read_to_string(dir.join("lamp.item.bsn")).expect("the file reads");
+    assert!(
+        written.contains("lamp"),
+        "the file names what it holds by the stem before its first dot: {written}"
+    );
+    assert!(indexed(&app, "content/items/lamp.item.bsn"));
+}
+
+#[test]
+fn a_creation_never_writes_over_a_file_already_there() {
+    let (mut app, tmp) = editor_with_kinds();
+    let dir = folder(&tmp, "content/items");
+    let path = dir.join("torch.bsn");
+    std::fs::write(&path, "hand written").expect("a file is there first");
+
+    call(
+        &mut app,
+        "asset.new",
+        &[
+            ("type", "item".into()),
+            ("name", "torch".into()),
+            ("path", dir.to_string_lossy().into_owned().into()),
+        ],
+    );
+
+    assert_eq!(
+        std::fs::read_to_string(&path).expect("the file still reads"),
+        "hand written",
+        "what was there is what is still there"
+    );
+    assert!(
+        app.world().resource::<OpenDefinition>().0.is_none(),
+        "and no card stands for a file that was not written"
+    );
+}
+
+#[test]
+fn the_same_name_in_two_folders_is_two_assets() {
+    let (mut app, tmp) = editor_with_kinds();
+    let items = folder(&tmp, "content/items");
+    let props = folder(&tmp, "content/props");
+
+    for dir in [&items, &props] {
+        call(
+            &mut app,
+            "asset.new",
+            &[
+                ("type", "item".into()),
+                ("name", "torch".into()),
+                ("path", dir.to_string_lossy().into_owned().into()),
+            ],
+        );
+    }
+
+    assert!(items.join("torch.bsn").is_file());
+    assert!(props.join("torch.bsn").is_file());
+    assert!(indexed(&app, "content/items/torch.bsn"));
+    assert!(
+        indexed(&app, "content/props/torch.bsn"),
+        "a name is the file's, not the whole project's"
+    );
+}


### PR DESCRIPTION
Assets could only be created from a folder that already held their kind, and asset.new refused a name another file of that kind used.

Any folder now offers a searchable New Asset list, the Add menu lists the same kinds, and asset.new writes into any folder under assets.

LLM disclaimer: Claude Code was used to help plan and implement this change, but all code was human reviewed by myself!
