### PR TITLE
Fold materials, graphs and the catalog into the asset model and add a migration

### DIFF
--- a/book/src/developer-guide/bsn-format.md
+++ b/book/src/developer-guide/bsn-format.md
@@ -115,12 +115,27 @@ intentionally opaque to the config (consumers parse it as the
 
 An asset file is a `.bsn` naming the type it holds, and it can
 sit in any folder under `assets/`; the editor indexes every one
-it finds by the path it sits at. `assets/catalog.bsn` holds only
-what has no file of its own. Any scene in the project can
-reference either with `@Name`. Legacy
-catalogs at `.jsn/catalog.jsn` or `assets/catalog.jsn` are read
-for migration and rewritten to `assets/catalog.bsn` on the
-next save.
+it finds by the path it sits at.
+
+`assets/catalog.bsn` is how a project kept its named assets
+before each had a file. It is read, never written: its entries
+load under the `@Name` a scene spells them by, and opening a
+project whose catalog still holds entries says how many and
+points at `project.migrate_asset_references`, which writes each
+one out as a file of its own. Legacy catalogs at
+`.jsn/catalog.jsn` or `assets/catalog.jsn` are read the same
+way. The game's runtime reads the catalog too, so a project
+that has not migrated yet still runs.
+
+The suffixes jackdaw grew for itself are decoration now. A
+material and an animation graph are asset files like any other,
+known by the type their document holds, so either can sit in any
+folder under any name: the Materials panel lists every material
+the index holds, the Graph window opens every graph, and a game
+loads one through the asset server by the path it sits at.
+`assets/materials/<name>.bsn` and
+`assets/animation/<name>.animgraph.bsn` are only where a save
+with no folder in mind puts one.
 
 ## Asset files in a game
 

--- a/book/src/getting-started/migrating-an-existing-project.md
+++ b/book/src/getting-started/migrating-an-existing-project.md
@@ -73,6 +73,30 @@ That rewrites the `[jackdaw]` pins and moves any `jackdaw_*` dependency to the
 matching version, leaving your run configurations, comments, features, and
 every other dependency untouched. Path and git dependencies are left alone.
 
+## Bringing asset references up to date
+
+A project written before assets were files at paths spells a material or any
+other asset by a bare name (`@grass`), keeps entries in `assets/catalog.bsn`,
+carries asset files with no header naming their type, and holds terrain
+sidecars at an older format version. All of that still loads. One operator
+writes it out in the current spelling:
+
+```
+project.migrate_asset_references
+```
+
+It rewrites every name a scene or a prefab spells for an asset as the path of
+the file that answers to it, writes each `catalog.bsn` entry out as a file of
+its own and leaves the catalog empty, puts the header naming its type on every
+asset file that has none, and re-encodes every terrain sidecar with its
+material slots as paths. It reports what it rewrote and what it left alone: a
+name two files carry, which stands for neither, and a name no file carries,
+such as a material that was never saved.
+
+The operator writes over the project's files and undo does not reach them, so
+it refuses to run while anything open has unsaved edits. Running it a second
+time reports that there is nothing to migrate.
+
 ## Checking a project
 
 ```bash

--- a/book/src/user-guide/materials-textures.md
+++ b/book/src/user-guide/materials-textures.md
@@ -33,27 +33,50 @@ mention is just this panel filtered to images.
 
 ## Material browser
 
-A sibling panel for named PBR materials: bundles of textures
-plus material parameters (metallic, roughness, normal
-strength, parallax) registered in the `MaterialRegistry`
-resource. Use this when one texture isn't enough, or when
+A sibling panel for PBR materials: bundles of textures plus
+material parameters (metallic, roughness, normal strength,
+parallax). Use this when one texture isn't enough, or when
 you want to share material settings across many brushes.
+
+### What it lists
+
+Every material file the project holds, wherever it sits. The
+editor indexes each `.bsn` under `assets/` by what the file
+says it holds, so the panel is a view of that index rather
+than of one folder; there is no materials directory to point
+it at. Beside those sit the materials that have no file yet,
+marked unsaved: the texture sets detected under `assets/`, one
+you made with **New Material**, and one whose file has gone.
 
 ### Auto-detection
 
 If you drop a folder of textures named consistently (e.g.
 `brick_albedo.png`, `brick_normal.png`,
-`brick_roughness.png`), the material browser groups them
-into one auto-detected entry. The regex driving detection
-is `pbr_filename_regex` in `src/material_browser.rs`; it
-recognises common suffixes (`_albedo`, `_diffuse`, `_normal`,
-`_n`, `_roughness`, `_r`, `_metallic`, `_m`, `_ao`,
-`_height`, `_displacement`).
+`brick_roughness.png`), the panel groups them into one
+detected entry, wherever under `assets/` they sit. The regex
+driving detection is `pbr_filename_regex` in the
+`jackdaw_material` crate; it recognises common suffixes
+(`_albedo`, `_diffuse`, `_normal`, `_n`, `_roughness`, `_r`,
+`_metallic`, `_m`, `_ao`, `_height`, `_displacement`).
 
-You can edit the resulting material in the inspector.
-A material saved to a file of its own is referenced by that
-file's path; a material that belongs to one scene serializes
-into that scene's asset table and rides along with save.
+A detected entry is a material you can edit and apply at
+once; **Save Material** writes it a file of its own, and from
+then on the panel lists it from the index rather than from the
+scan.
+
+### Saving
+
+**Save Material** writes the material back to its own file,
+or, for one that has none yet, to `assets/materials/<name>.bsn`.
+**Save Material As** opens a file dialog on that same default
+so you can put it anywhere under `assets/`; what you name the
+file is what the material is called. A material that is edited
+in the panel and already has a file is written back as the
+edit lands.
+
+An edit to a material with no file stays in memory, and a
+scene that uses it embeds it inline on save, so it keeps
+rendering outside this editor run.
 
 ### Applying
 
@@ -80,9 +103,10 @@ Two storage tiers:
   reading what the file holds. A save with no folder in mind
   puts it under `assets/materials/`. Any scene in the project
   can reference it, and references spell its path, such as
-  `materials/slate.material.bsn`. Scenes written before paths
-  spell `@Name` instead; they still load, and the next save
-  writes the path.
+  `materials/slate.bsn`. Scenes written before paths spell
+  `@Name` instead; they still load, and the next save writes
+  the path. `project.migrate_asset_references` writes every
+  such name out as a path in one go.
 
 The browser shows both, with the source labelled.
 
@@ -92,11 +116,10 @@ The browser shows both, with the source labelled.
   watcher catches new files but only existing scenes reload
   their materials. Re-select the brush face to refresh.
 - **The auto-detect groups two unrelated textures.**
-  Filename heuristics are coarse. Rename the files or open
-  the affected definition and split it manually.
+  Filename heuristics are coarse. Rename the files, or save
+  the material and edit its slots in the panel.
 - **Material disappears in the standalone build.** Standalone
-  loads the scene file plus every material file under
-  `assets/materials/`. Scene-local materials still ship inline;
-  a reference resolves to the file at that path, so a material
-  file left out of the build, or kept in another folder, falls
-  back to a default.
+  walks every `.bsn` under `assets/` and loads the ones holding
+  a material. Scene-local materials still ship inline; a
+  reference resolves to the file at that path, so a material
+  file left out of the build falls back to a default.

--- a/crates/jackdaw_animation_runtime/tests/animation_graphs.rs
+++ b/crates/jackdaw_animation_runtime/tests/animation_graphs.rs
@@ -979,3 +979,45 @@ fn a_clip_that_takes_the_blend_partway_through_sends_no_marker_behind_it() {
         "and it sends the marker on the pass that reaches it"
     );
 }
+
+/// A graph file says what it is, so one under any name in any folder loads
+/// like one written as `animation/<name>.animgraph.bsn`.
+#[test]
+fn a_graph_file_in_another_folder_loads_under_a_plain_bsn_name() {
+    let dir = tempfile::tempdir().expect("tempdir");
+    std::fs::create_dir_all(dir.path().join("rigs")).expect("the folder is made");
+    let text = "// jackdaw asset jackdaw_animation_runtime::graph::AnimationGraphDef\n\
+                #hero\n\
+                jackdaw_animation_runtime::graph::AnimationGraphDef {\n\
+                    entry: \"idle\",\n\
+                }\n";
+    std::fs::write(dir.path().join("rigs/hero.bsn"), text).expect("the file is written");
+
+    let mut app = App::new();
+    app.add_plugins(MinimalPlugins)
+        .add_plugins(AssetPlugin {
+            file_path: dir.path().to_string_lossy().into_owned(),
+            ..AssetPlugin::default()
+        })
+        .add_plugins(bevy::transform::TransformPlugin)
+        .add_plugins(bevy::animation::AnimationPlugin)
+        .add_plugins(AnimationRuntimePlugin);
+
+    let handle: Handle<AnimationGraphAsset> =
+        app.world().resource::<AssetServer>().load("rigs/hero.bsn");
+    let mut loaded = None;
+    for _ in 0..200 {
+        app.update();
+        if let Some(asset) = app
+            .world()
+            .resource::<Assets<AnimationGraphAsset>>()
+            .get(&handle)
+        {
+            loaded = Some(asset.def.clone());
+            break;
+        }
+        std::thread::sleep(millis(5));
+    }
+
+    assert_eq!(loaded.expect("the graph file loads").entry, "idle");
+}

--- a/crates/jackdaw_bsn/src/header.rs
+++ b/crates/jackdaw_bsn/src/header.rs
@@ -7,6 +7,7 @@
 //! file before it parses; the first document root's type is the truth.
 
 use std::any::TypeId;
+use std::collections::BTreeMap;
 use std::path::{Path, PathBuf};
 
 use bevy::ecs::entity::Entity;
@@ -45,6 +46,94 @@ pub fn read_asset_header(text: &str) -> Option<String> {
         }
     }
     None
+}
+
+/// The bare name a path or a reference carries: the last segment's text
+/// before its first dot, so `materials/grass.material.bsn` and `grass` are
+/// both `grass`.
+pub fn asset_stem(reference: &str) -> &str {
+    let last = reference
+        .rsplit(['/', '\\'])
+        .next()
+        .unwrap_or(reference)
+        .trim_start_matches('.');
+    last.split_once('.').map_or(last, |(stem, _)| stem)
+}
+
+/// [`asset_stem`] of the file a path names.
+pub fn path_stem(path: &Path) -> String {
+    path.file_name()
+        .and_then(|name| name.to_str())
+        .map_or_else(String::new, |name| asset_stem(name).to_string())
+}
+
+/// What each bare name stands for, over the documents a walk saw.
+///
+/// A name one file carries stands for that file; a name two files carry stands
+/// for neither, and the two are there to be named in what says so. The editor
+/// and the runtime both count over every document their walk saw, so a name
+/// one calls ambiguous is ambiguous in the other.
+#[derive(Default, Debug, Clone)]
+pub struct StemIndex(BTreeMap<String, Vec<PathBuf>>);
+
+impl StemIndex {
+    /// The stems of every path given.
+    pub fn from_paths<I, P>(paths: I) -> Self
+    where
+        I: IntoIterator<Item = P>,
+        P: Into<PathBuf>,
+    {
+        let mut index = Self::default();
+        for path in paths {
+            index.insert(path);
+        }
+        index
+    }
+
+    pub fn insert(&mut self, path: impl Into<PathBuf>) {
+        let path = path.into();
+        let stem = path_stem(&path);
+        if stem.is_empty() {
+            return;
+        }
+        let held = self.0.entry(stem).or_default();
+        if !held.contains(&path) {
+            held.push(path);
+        }
+    }
+
+    /// Forget a file, for one that has left the walk.
+    pub fn remove(&mut self, path: &Path) {
+        let stem = path_stem(path);
+        let Some(held) = self.0.get_mut(&stem) else {
+            return;
+        };
+        held.retain(|held| held != path);
+        if held.is_empty() {
+            self.0.remove(&stem);
+        }
+    }
+
+    /// The one file this name stands for, or `None` when no file or several do.
+    pub fn unique(&self, stem: &str) -> Option<&Path> {
+        match self.0.get(stem)?.as_slice() {
+            [only] => Some(only),
+            _ => None,
+        }
+    }
+
+    /// The first two files a name several carry stands for, to name in a report.
+    pub fn shared(&self, stem: &str) -> Option<(&Path, &Path)> {
+        match self.0.get(stem)?.as_slice() {
+            [first, second, ..] => Some((first, second)),
+            _ => None,
+        }
+    }
+
+    /// Every file this name stands for.
+    pub fn paths(&self, stem: &str) -> &[PathBuf] {
+        self.0.get(stem).map_or(&[], Vec::as_slice)
+    }
 }
 
 /// The type path a document root names, or `None` when the root names none.
@@ -264,6 +353,47 @@ mod tests {
         let text =
             format!("my_game::content::ItemDef {{}}\n{ASSET_HEADER}my_game::content::Impostor\n");
         assert!(read_asset_header(&text).is_none());
+    }
+
+    #[test]
+    fn a_name_is_the_last_segment_before_its_first_dot() {
+        assert_eq!(asset_stem("materials/grass.material.bsn"), "grass");
+        assert_eq!(asset_stem("grass"), "grass");
+        assert_eq!(asset_stem("zones/hedgerow/grass.bsn"), "grass");
+        assert_eq!(
+            path_stem(Path::new("content/items/torch.item.bsn")),
+            "torch"
+        );
+    }
+
+    #[test]
+    fn a_name_two_documents_carry_stands_for_neither_and_names_both() {
+        let index = StemIndex::from_paths([
+            Path::new("zones/grass.bsn").to_path_buf(),
+            Path::new("materials/grass.material.bsn").to_path_buf(),
+        ]);
+
+        assert!(index.unique("grass").is_none());
+        assert_eq!(
+            index
+                .shared("grass")
+                .map(|(first, second)| (first.to_path_buf(), second.to_path_buf())),
+            Some((
+                PathBuf::from("zones/grass.bsn"),
+                PathBuf::from("materials/grass.material.bsn")
+            ))
+        );
+    }
+
+    #[test]
+    fn a_name_one_document_carries_stands_for_it() {
+        let index = StemIndex::from_paths([PathBuf::from("materials/grass.material.bsn")]);
+
+        assert_eq!(
+            index.unique("grass"),
+            Some(Path::new("materials/grass.material.bsn"))
+        );
+        assert!(index.unique("slate").is_none());
     }
 
     #[test]

--- a/crates/jackdaw_bsn/src/lib.rs
+++ b/crates/jackdaw_bsn/src/lib.rs
@@ -25,9 +25,10 @@ pub use catalog::{
 };
 
 pub use header::{
-    ASSET_HEADER, AssetFileError, PREFAB_TYPE, asset_file_type, asset_text_type,
-    document_type_path, read_asset_file, read_asset_header, root_type_path, walk_asset_files,
-    walk_document_files, walk_files_with_extensions, with_asset_header,
+    ASSET_HEADER, AssetFileError, PREFAB_TYPE, StemIndex, asset_file_type, asset_stem,
+    asset_text_type, document_type_path, path_stem, read_asset_file, read_asset_header,
+    root_type_path, walk_asset_files, walk_document_files, walk_files_with_extensions,
+    with_asset_header,
 };
 
 pub use parse::{ParseError, parse_bsn};

--- a/crates/jackdaw_runtime/src/lib.rs
+++ b/crates/jackdaw_runtime/src/lib.rs
@@ -63,7 +63,7 @@
 //! - `pie`: play-in-editor, streaming this world to a running editor.
 
 use std::any::TypeId;
-use std::collections::HashMap;
+use std::collections::{BTreeMap, HashMap};
 // Only the texture-format promotion pass gathers bound image ids, and that is
 // a rendering build's concern.
 #[cfg(feature = "render")]
@@ -1365,8 +1365,9 @@ fn load_asset_files(world: &mut World) {
 /// The walk costs one parse per `.bsn`, which is what telling a file that
 /// holds an asset from one that spawns a scene takes.
 fn load_walked_assets(world: &mut World, root: &Path, catalog_path: Option<&Path>) {
-    let mut stems: HashMap<String, Vec<(String, UntypedHandle)>> = HashMap::new();
-    let mut count = 0usize;
+    let mut stems = jackdaw_bsn::StemIndex::default();
+    let mut loaded: Vec<(String, String, UntypedHandle)> = Vec::new();
+    let mut skipped = SkippedTypes::default();
 
     for path in jackdaw_bsn::walk_document_files(root) {
         let is_bsn = path
@@ -1379,39 +1380,87 @@ fn load_walked_assets(world: &mut World, root: &Path, catalog_path: Option<&Path
         let Some(key) = assets_relative_key(root, &path) else {
             continue;
         };
-        let Some(handle) = load_asset_file(world, &path) else {
+        stems.insert(PathBuf::from(&key));
+        let Some(handle) = load_asset_file(world, &path, &mut skipped) else {
             continue;
         };
-        let stem = file_stem_name(&path);
         world
             .resource_mut::<JackdawCatalog>()
             .files
             .insert(key.clone(), handle.clone());
-        stems.entry(stem).or_default().push((key, handle));
-        count += 1;
+        loaded.push((jackdaw_bsn::path_stem(&path), key, handle));
     }
 
-    let mut catalog = world.resource_mut::<JackdawCatalog>();
-    for (stem, found) in stems {
-        match found.as_slice() {
-            [(_, handle)] => {
-                catalog.handles.insert(format!("@{stem}"), handle.clone());
+    let count = loaded.len();
+    let mut ambiguous: Vec<String> = Vec::new();
+    {
+        let mut catalog = world.resource_mut::<JackdawCatalog>();
+        for (stem, _, handle) in loaded {
+            if stems.unique(&stem).is_some() {
+                catalog.handles.insert(format!("@{stem}"), handle);
+            } else if !ambiguous.contains(&stem) {
+                ambiguous.push(stem);
             }
-            [(first, _), (second, _), ..] => {
-                warn!("'{stem}' names both {first} and {second}; spell the one you mean as a path");
-            }
-            [] => {}
+        }
+    }
+    for stem in ambiguous {
+        if let Some((first, second)) = stems.shared(&stem) {
+            warn!(
+                "'{stem}' names both {} and {}; spell the one you mean as a path",
+                first.display(),
+                second.display()
+            );
         }
     }
 
+    skipped.report();
     if count > 0 {
         info!("Loaded {count} asset files from {}", root.display());
     }
 }
 
+/// The types the walk passed over, so a project whose materials this app does
+/// not render costs one line rather than one per file.
+#[derive(Default)]
+struct SkippedTypes {
+    unregistered: BTreeMap<String, usize>,
+    unreflected: BTreeMap<String, usize>,
+}
+
+impl SkippedTypes {
+    fn report(&self) {
+        if !self.unregistered.is_empty() {
+            warn!(
+                "Skipped {} asset files holding types this app has not registered: {}",
+                self.unregistered.values().sum::<usize>(),
+                summarize(&self.unregistered)
+            );
+        }
+        if !self.unreflected.is_empty() {
+            warn!(
+                "Skipped {} asset files holding types this app registered without register_asset_reflect: {}",
+                self.unreflected.values().sum::<usize>(),
+                summarize(&self.unreflected)
+            );
+        }
+    }
+}
+
+fn summarize(counts: &BTreeMap<String, usize>) -> String {
+    counts
+        .iter()
+        .map(|(type_path, count)| format!("{type_path} ({count})"))
+        .collect::<Vec<_>>()
+        .join(", ")
+}
+
 /// Load the asset the file at `path` holds, or nothing when it holds a scene,
 /// a prefab, or a type this app has not registered as an asset.
-fn load_asset_file(world: &mut World, path: &Path) -> Option<UntypedHandle> {
+fn load_asset_file(
+    world: &mut World,
+    path: &Path,
+    skipped: &mut SkippedTypes,
+) -> Option<UntypedHandle> {
     let text = match std::fs::read_to_string(path) {
         Ok(text) => text,
         Err(err) => {
@@ -1445,18 +1494,12 @@ fn load_asset_file(world: &mut World, path: &Path) -> Option<UntypedHandle> {
     };
     match registered {
         None => {
-            warn!(
-                "{} holds a {type_path}, which this app has not registered; skipping it",
-                path.display()
-            );
+            *skipped.unregistered.entry(type_path).or_default() += 1;
             return None;
         }
         Some(false) => {
             if jackdaw_bsn::read_asset_header(&text).is_some() {
-                warn!(
-                    "{} holds a {type_path}, which this app registered without register_asset_reflect; skipping it",
-                    path.display()
-                );
+                *skipped.unreflected.entry(type_path).or_default() += 1;
             }
             return None;
         }
@@ -1490,18 +1533,6 @@ fn assets_relative_key(root: &Path, path: &Path) -> Option<String> {
         key.push_str(component.as_os_str().to_str()?);
     }
     (!key.is_empty()).then_some(key)
-}
-
-/// The bare name a file's stem gives it: everything before the first dot of its
-/// file name, so `grass.material.bsn` is `grass`.
-fn file_stem_name(path: &Path) -> String {
-    path.file_name()
-        .and_then(|name| name.to_str())
-        .map_or_else(String::new, |name| {
-            name.split_once('.')
-                .map_or(name, |(stem, _)| stem)
-                .to_owned()
-        })
 }
 
 /// The folder Bevy reads assets from, as this app's [`AssetPlugin`] was

--- a/crates/jackdaw_runtime/src/terrain.rs
+++ b/crates/jackdaw_runtime/src/terrain.rs
@@ -261,19 +261,12 @@ fn document_of(data: RegionTerrainData, terrain: &Terrain) -> TerrainDocument {
 /// [`resolve_with`] decides what a resolved material means: which of its slots
 /// is albedo, and that a vacated or unfound reference keeps its texture id.
 fn catalog_material(catalog: &JackdawCatalog, reference: &str) -> Option<Handle<StandardMaterial>> {
-    let name = material_name_of(reference);
+    let name = jackdaw_bsn::asset_stem(reference);
     catalog
         .get(reference)
         .or_else(|| catalog.get(&format!("@{name}")))
         .cloned()
         .and_then(|handle| handle.try_typed::<StandardMaterial>().ok())
-}
-
-/// The name a material reference carries: the part of its last path segment
-/// before the first dot, which is what a bare name already is.
-fn material_name_of(reference: &str) -> &str {
-    let file = reference.rsplit('/').next().unwrap_or(reference);
-    file.split_once('.').map_or(file, |(stem, _)| stem)
 }
 
 /// Keep every terrain's resolved set following its material list.

--- a/crates/jackdaw_runtime/tests/catalog_loading.rs
+++ b/crates/jackdaw_runtime/tests/catalog_loading.rs
@@ -160,3 +160,50 @@ fn a_scene_reaches_a_material_in_any_folder_by_the_path_of_its_file() {
 
     let _ = std::fs::remove_dir_all(&dir);
 }
+
+/// The name counts over every document the walk saw, scenes included, so a
+/// name the editor calls ambiguous is ambiguous here too.
+#[test]
+fn a_name_a_scene_and_an_asset_share_stands_for_neither() {
+    let type_path = <CatalogMaterial as TypePath>::type_path();
+
+    let dir = unique_temp_dir("catalog-loading-shared-name");
+    std::fs::create_dir_all(dir.join("materials")).unwrap();
+    std::fs::create_dir_all(dir.join("zones")).unwrap();
+    std::fs::write(
+        dir.join("materials/grass.bsn"),
+        format!("#grass\n{type_path}\n"),
+    )
+    .unwrap();
+    std::fs::write(
+        dir.join("zones/grass.bsn"),
+        "#Root\nbevy_transform::components::transform::Transform\n\
+         bevy_ecs::hierarchy::Children [\n    bevy_transform::components::transform::Transform\n]\n",
+    )
+    .unwrap();
+
+    let mut app = App::new();
+    app.add_plugins(MinimalPlugins);
+    app.add_plugins(bevy::transform::TransformPlugin);
+    app.add_plugins(bevy::asset::AssetPlugin::default());
+    app.add_plugins(bevy::world_serialization::WorldSerializationPlugin);
+    app.add_plugins(bevy::image::ImagePlugin::default());
+    app.init_asset::<CatalogMaterial>();
+    app.register_asset_reflect::<CatalogMaterial>();
+    app.insert_resource(JackdawCatalogPath(dir.join("catalog.bsn")));
+    app.add_plugins(JackdawPlugin);
+
+    app.update();
+
+    let catalog = app.world().resource::<JackdawCatalog>();
+    assert!(
+        catalog.get("@grass").is_none(),
+        "a name a scene also carries stands for neither file"
+    );
+    assert!(
+        catalog.get("materials/grass.bsn").is_some(),
+        "the file is there to be named by its path"
+    );
+
+    let _ = std::fs::remove_dir_all(&dir);
+}

--- a/src/animation/graph_doc.rs
+++ b/src/animation/graph_doc.rs
@@ -25,10 +25,11 @@ use jackdaw_node_graph::{
 
 use crate::project::ProjectRoot;
 
-/// Directory under `assets/` holding graph files.
+/// Directory a graph with no folder in mind is created in.
 pub const GRAPH_DIR: &str = "animation";
 
-/// Suffix identifying a graph file. The name is the stem before it.
+/// Suffix a graph created with no name in mind carries. A graph file is known
+/// by the type it holds, so a graph in any folder under any name is one too.
 pub const GRAPH_FILE_SUFFIX: &str = ".animgraph.bsn";
 
 /// Registry key of the node one state is drawn as.
@@ -147,11 +148,6 @@ pub struct GraphAnyStateNode;
 #[derive(Component, Debug)]
 pub struct GraphCanvasPart;
 
-/// `<project>/assets/animation`.
-pub fn graphs_dir(project: &ProjectRoot) -> PathBuf {
-    project.assets_dir().join(GRAPH_DIR)
-}
-
 /// The file an assets-relative graph path names, refusing one that climbs out
 /// of the project.
 pub fn graph_file_path(project: &ProjectRoot, path: &str) -> Option<PathBuf> {
@@ -192,28 +188,13 @@ pub fn sanitize_graph_name(name: &str) -> String {
     }
 }
 
-/// Every `assets/animation/*.animgraph.bsn` as an assets-relative path, sorted.
+/// Every graph file the project holds, wherever it sits, as an assets-relative
+/// path, sorted.
 pub fn graph_files(world: &World) -> Vec<String> {
-    let Some(project) = world.get_resource::<ProjectRoot>() else {
+    let Some(index) = world.get_resource::<crate::asset_index::AssetIndex>() else {
         return Vec::new();
     };
-    graph_files_in(project)
-}
-
-/// Every `assets/animation/*.animgraph.bsn` of a project, sorted.
-pub fn graph_files_in(project: &ProjectRoot) -> Vec<String> {
-    let Ok(entries) = std::fs::read_dir(graphs_dir(project)) else {
-        return Vec::new();
-    };
-    let mut paths: Vec<String> = entries
-        .flatten()
-        .map(|entry| entry.path())
-        .filter_map(|path| {
-            let name = path.file_name()?.to_str()?;
-            name.ends_with(GRAPH_FILE_SUFFIX)
-                .then(|| format!("{GRAPH_DIR}/{name}"))
-        })
-        .collect();
+    let mut paths = index.paths_of_kind(crate::definition_assets::ANIMATION_GRAPH_KIND);
     paths.sort();
     paths
 }
@@ -1026,6 +1007,46 @@ mod tests {
             "animation/Player_Locomotion.animgraph.bsn"
         );
         assert_eq!(graph_path_for_name("///"), "animation/graph.animgraph.bsn");
+    }
+
+    /// The Graph window lists what the index holds, so a graph filed anywhere
+    /// under the project is one it can open.
+    #[test]
+    fn a_graph_filed_outside_the_animation_folder_is_listed_and_reads_back() {
+        let tmp = tempfile::tempdir().expect("tempdir");
+        let mut app = bevy::app::App::new();
+        app.add_plugins((
+            bevy::app::TaskPoolPlugin::default(),
+            bevy::asset::AssetPlugin::default(),
+        ));
+        app.register_type::<AnimationGraphDef>();
+        app.insert_resource(ProjectRoot {
+            root: tmp.path().to_path_buf(),
+            config: crate::project::ProjectConfig::default(),
+        });
+        app.init_resource::<crate::asset_index::AssetIndex>();
+        app.init_resource::<crate::asset_files::AssetKindCache>();
+        app.init_resource::<jackdaw_api::prelude::AssetKinds>();
+        app.world_mut()
+            .resource_mut::<jackdaw_api::prelude::AssetKinds>()
+            .register(jackdaw_api::prelude::AssetKind::compiled(
+                crate::definition_assets::ANIMATION_GRAPH_KIND,
+                "Animation Graph",
+                <AnimationGraphDef as bevy::reflect::TypePath>::type_path(),
+            ));
+        let rigs = tmp.path().join("assets/rigs");
+        std::fs::create_dir_all(&rigs).expect("the folder is made");
+        std::fs::write(
+            rigs.join("hero.bsn"),
+            "#hero\njackdaw_animation_runtime::graph::AnimationGraphDef { entry: \"idle\" }\n",
+        )
+        .expect("the file is written");
+
+        crate::asset_index::rescan_asset_index(app.world_mut());
+
+        assert_eq!(graph_files(app.world()), vec!["rigs/hero.bsn".to_string()]);
+        let def = read_graph_file(app.world(), "rigs/hero.bsn").expect("the graph reads back");
+        assert_eq!(def.entry, "idle");
     }
 
     #[test]

--- a/src/animation/graph_ops.rs
+++ b/src/animation/graph_ops.rs
@@ -75,7 +75,7 @@ pub(crate) fn animation_graph_new(
 #[operator(
     id = "animation.graph.open",
     label = "Open Animation Graph",
-    description = "Show an existing .animgraph.bsn file in the Graph window.",
+    description = "Show a graph file the project holds in the Graph window.",
     allows_undo = false,
     params(path(String, doc = "Assets-relative path of the graph file to open."))
 )]

--- a/src/animation/panel.rs
+++ b/src/animation/panel.rs
@@ -796,13 +796,12 @@ fn spawn_graph_tab(commands: &mut Commands, body: Entity, state: &AnimationPanel
 
 /// Refill the list of graph files the project holds.
 ///
-/// The directory is read when the tab is built and when the open graph
-/// changes, rather than every frame: nothing else in the editor writes these
-/// files behind the panel's back.
+/// The index is read when the tab is built and when the open graph changes,
+/// rather than every frame.
 fn update_graph_list(
     mut commands: Commands,
     doc: Res<crate::animation::graph_doc::AnimationGraphDoc>,
-    project: Option<Res<crate::project::ProjectRoot>>,
+    index: Option<Res<crate::asset_index::AssetIndex>>,
     lists: Query<(Entity, Option<&Children>), With<AnimationGraphList>>,
     mut last: Local<Option<String>>,
 ) {
@@ -816,9 +815,10 @@ fn update_graph_list(
     }
     *last = Some(open.clone());
 
-    let files = project
-        .map(|project| crate::animation::graph_doc::graph_files_in(&project))
+    let mut files = index
+        .map(|index| index.paths_of_kind(crate::definition_assets::ANIMATION_GRAPH_KIND))
         .unwrap_or_default();
+    files.sort();
     for (list, children) in &lists {
         despawn_children(&mut commands, children);
         if files.is_empty() {

--- a/src/asset_catalog.rs
+++ b/src/asset_catalog.rs
@@ -10,39 +10,34 @@ use jackdaw_jsn::format::JsnCatalog;
 /// while scene-local inline assets use `#Name`. When multiple scenes reference
 /// the same `@Name`, they share the same handle (zero duplication).
 ///
-/// The map holds every named asset the editor has loaded, saved or not, so
-/// `@Name` references resolve while it runs. What *persists* is decided at save
-/// time: materials go to their own files (see [`crate::material_assets`]),
-/// everything else to `catalog.bsn`.
+/// The map holds every named asset the editor has loaded, so `@Name`
+/// references resolve while it runs. Nothing here is written back:
+/// `catalog.bsn` is read for what older projects put in it, and
+/// `project.migrate_asset_references` writes those entries out as files of
+/// their own.
 #[derive(Resource, Default)]
 pub struct AssetCatalog {
     /// `@Name` -> loaded `UntypedHandle` (populated at project open).
     pub handles: HashMap<String, UntypedHandle>,
-    /// Reverse lookup: asset ID -> `@Name` (used during save to emit catalog refs).
+    /// Reverse lookup: asset ID -> `@Name`, for the names a scene save falls
+    /// back to when no file holds the asset.
     pub id_to_name: HashMap<UntypedAssetId, String>,
-    /// Whether the catalog has unsaved changes.
-    pub dirty: bool,
     /// Names of material entries the catalog file still holds inline, which
-    /// the next save writes out as files of their own.
+    /// the migration writes out as files of their own.
     pub inline_materials: HashSet<String>,
-    /// Set when `catalog.bsn` existed but could not be read or parsed.
-    ///
-    /// The loaded map is then an unknown fraction of the file, so writing it
-    /// back would destroy whatever failed to load. While this is set, saving
-    /// does not touch the catalog file.
-    pub load_failed: bool,
-    /// Whether the quarantine refusal has already been reported this run.
-    quarantine_reported: bool,
 }
 
-/// What a catalog file with no entries holds. A blank file is indistinguishable
-/// from a truncated one, and deleting the file would un-shadow the older catalog
-/// locations and resurrect their contents.
-const EMPTY_CATALOG: &str = "// no catalog entries\n";
+/// What `catalog.bsn` held when the project opened.
+#[derive(Resource, Default)]
+pub struct CatalogImport {
+    /// How many entries the file holds, all of them without a file of their own.
+    pub entries: usize,
+    /// Whether the entries have already been reported this run.
+    reported: bool,
+}
 
 impl AssetCatalog {
-    /// Insert a runtime handle into the catalog. Does not mark dirty; the
-    /// caller sets `dirty` when the change should persist.
+    /// Insert a runtime handle into the catalog.
     pub fn insert(&mut self, name: String, handle: UntypedHandle) {
         self.id_to_name.insert(handle.id(), name.clone());
         self.handles.insert(name, handle);
@@ -52,12 +47,21 @@ impl AssetCatalog {
     pub fn contains_name(&self, name: &str) -> bool {
         self.handles.contains_key(name)
     }
+}
 
-    /// Refuse further writes to the catalog file: what is in memory may not be
-    /// the whole of what is on disk.
-    pub fn quarantine(&mut self) {
-        self.load_failed = true;
+/// Say once that the catalog file holds entries that belong in files of their
+/// own, and how to move them.
+fn report_catalog_entries(world: &mut World, count: usize) {
+    let mut import = world.get_resource_or_init::<CatalogImport>();
+    import.entries = count;
+    if count == 0 || import.reported {
+        return;
     }
+    import.reported = true;
+    warn!(
+        "catalog.bsn holds {count} entries, which is how assets were kept before each had a \
+         file of its own; run project.migrate_asset_references to write them out"
+    );
 }
 
 /// Whether a catalog entry is a `StandardMaterial`, and so belongs in a file
@@ -80,9 +84,8 @@ fn is_empty_catalog_text(text: &str) -> bool {
 /// their linear-space textures have claimed their paths and a filed material
 /// wins its name over an inline entry of the same name.
 ///
-/// Inline material entries in `catalog.bsn` load normally and are flagged
-/// dirty, so the next save writes them out as files of their own and drops them
-/// from the catalog file.
+/// Inline material entries load normally; `project.migrate_asset_references`
+/// writes them out as files of their own.
 pub fn load_catalog(world: &mut World) {
     let catalog_path = catalog_file_path(world);
     let Some(catalog_path) = catalog_path else {
@@ -99,7 +102,6 @@ pub fn load_catalog(world: &mut World) {
         Ok(json) => json,
         Err(err) => {
             warn!("Failed to read {}: {err}", catalog_path.display());
-            world.resource_mut::<AssetCatalog>().quarantine();
             return;
         }
     };
@@ -115,7 +117,6 @@ pub fn load_catalog(world: &mut World) {
         match jackdaw_bsn::load_bsn_assets(world, &json) {
             Ok(entries) => {
                 let count = entries.len();
-                let mut migratable = 0;
                 for entry in entries {
                     // Scenes reference catalog assets as `@Name`.
                     let name = format!("@{}", entry.name);
@@ -128,7 +129,6 @@ pub fn load_catalog(world: &mut World) {
                         // `@Name` scenes reference, so the entry stays inline.
                         if crate::material_assets::sanitize_material_name(&entry.name) == entry.name
                         {
-                            migratable += 1;
                             world
                                 .resource_mut::<AssetCatalog>()
                                 .inline_materials
@@ -144,14 +144,10 @@ pub fn load_catalog(world: &mut World) {
                     catalog.id_to_name.insert(entry.handle.id(), name.clone());
                     catalog.handles.insert(name, entry.handle);
                 }
-                // Migrate the inline materials out on the next save.
-                world.resource_mut::<AssetCatalog>().dirty = migratable > 0;
                 info!("Loaded asset catalog with {count} entries");
+                report_catalog_entries(world, count);
             }
-            Err(err) => {
-                warn!("Failed to parse {}: {err}", catalog_path.display());
-                world.resource_mut::<AssetCatalog>().quarantine();
-            }
+            Err(err) => warn!("Failed to parse {}: {err}", catalog_path.display()),
         }
         return;
     }
@@ -160,7 +156,6 @@ pub fn load_catalog(world: &mut World) {
         Ok(c) => c,
         Err(err) => {
             warn!("Failed to parse asset catalog: {err}");
-            world.resource_mut::<AssetCatalog>().quarantine();
             return;
         }
     };
@@ -171,98 +166,15 @@ pub fn load_catalog(world: &mut World) {
     // Use the same load_inline_assets function scenes use
     let loaded = crate::scene_io::load_inline_assets(world, &jsn_catalog.assets, &assets_dir);
 
-    // Populate the catalog resource
     let mut catalog = world.resource_mut::<AssetCatalog>();
     for (name, handle) in loaded {
         catalog.id_to_name.insert(handle.id(), name.clone());
         catalog.handles.insert(name, handle);
     }
-    catalog.dirty = false;
+    let count = catalog.handles.len();
 
-    info!(
-        "Loaded asset catalog with {} entries",
-        catalog.handles.len()
-    );
-}
-
-/// Persist the catalog: saved materials to their own files, everything else to
-/// `assets/catalog.bsn`.
-///
-/// A material written to `assets/materials` and an unsaved material (a detected
-/// set or a fresh `material.create`) are both left out of the catalog file: the
-/// first has its own file, the second is ephemeral and travels inline inside the
-/// scenes that use it. Any other entry (another asset type, or a material whose
-/// name is not a legal file stem) is written inline.
-///
-/// The file is never unlinked. With nothing left to write it holds an empty
-/// document, which keeps it shadowing the other catalog locations
-/// `catalog_file_path` reads.
-pub fn save_catalog(world: &mut World) {
-    let Some(catalog_path) = catalog_save_path(world) else {
-        return;
-    };
-
-    if !world.resource::<AssetCatalog>().dirty {
-        return;
-    }
-
-    if world.resource::<AssetCatalog>().load_failed {
-        let mut catalog = world.resource_mut::<AssetCatalog>();
-        if !catalog.quarantine_reported {
-            catalog.quarantine_reported = true;
-            warn!("Asset catalog failed to load; refusing to write over it");
-        }
-        return;
-    }
-
-    let in_files: HashSet<UntypedAssetId> = crate::material_assets::persist_materials(world)
-        .into_iter()
-        .collect();
-    let ephemeral = crate::material_assets::ephemeral_material_ids(world);
-
-    let catalog = world.resource::<AssetCatalog>();
-    let refs: Vec<jackdaw_bsn::CatalogAssetRef> = catalog
-        .id_to_name
-        .iter()
-        .filter(|(asset_id, _)| !in_files.contains(asset_id) && !ephemeral.contains(asset_id))
-        .map(|(&asset_id, name)| jackdaw_bsn::CatalogAssetRef {
-            name: name.trim_start_matches(['@', '#']).to_string(),
-            type_id: asset_id.type_id(),
-            asset_id,
-        })
-        .collect();
-
-    // Emptiness is decided from the entries, not the emitted text: the serializer drops
-    // entries it cannot express, which must not read as having nothing to keep.
-    let text = if refs.is_empty() {
-        EMPTY_CATALOG.to_string()
-    } else {
-        let (text, skipped) = jackdaw_bsn::serialize_assets_to_bsn_reporting(world, &refs);
-        if !skipped.is_empty() {
-            warn!(
-                "Catalog entries could not be serialized and are missing from {}: {}",
-                catalog_path.display(),
-                skipped.join(", ")
-            );
-        }
-        if is_empty_catalog_text(&text) {
-            EMPTY_CATALOG.to_string()
-        } else {
-            text
-        }
-    };
-
-    if let Some(parent) = catalog_path.parent() {
-        let _ = std::fs::create_dir_all(parent);
-    }
-
-    match crate::scene_io::save::write_atomic(&catalog_path, text.as_bytes()) {
-        Ok(()) => {
-            info!("Catalog saved to {}", catalog_path.display());
-            world.resource_mut::<AssetCatalog>().dirty = false;
-        }
-        Err(err) => warn!("Failed to write catalog: {err}"),
-    }
+    info!("Loaded asset catalog with {count} entries");
+    report_catalog_entries(world, count);
 }
 
 /// Resolve the catalog file path for loading.
@@ -286,15 +198,6 @@ fn catalog_file_path(world: &World) -> Option<std::path::PathBuf> {
         }
     }
     // No catalog exists yet
-    Some(project.assets_dir().join("catalog.bsn"))
-}
-
-/// Always returns `assets/catalog.bsn`. The catalog is committed project
-/// data (scenes reference its `@Name` entries), so it lives with the assets,
-/// not in the gitignored `.jackdaw/`. Materials are not among those entries;
-/// they live one per file under `assets/materials`.
-fn catalog_save_path(world: &World) -> Option<std::path::PathBuf> {
-    let project = world.get_resource::<crate::project::ProjectRoot>()?;
     Some(project.assets_dir().join("catalog.bsn"))
 }
 
@@ -330,114 +233,66 @@ mod tests {
         tmp.path().join("assets/catalog.bsn")
     }
 
+    /// The catalog file is an import, not a store: the editor reads what an
+    /// older project put there and never writes it, so what is on disk stays
+    /// as the project committed it until the migration moves it.
     #[test]
-    fn a_catalog_that_failed_to_load_is_never_written_over() {
+    fn nothing_the_editor_does_writes_the_catalog_file() {
         let (mut app, tmp) = catalog_app();
         let path = catalog_file(&tmp);
-        std::fs::write(&path, "this is not $$ valid bsn {{{").expect("write");
+        let held = "#slate\nbevy_pbr::pbr_material::StandardMaterial {}\n";
+        std::fs::write(&path, held).expect("write");
 
         load_catalog(app.world_mut());
-        assert!(
-            app.world().resource::<AssetCatalog>().load_failed,
-            "a parse failure must quarantine the catalog"
-        );
-
-        app.world_mut().resource_mut::<AssetCatalog>().dirty = true;
-        save_catalog(app.world_mut());
+        app.update();
+        app.update();
 
         assert_eq!(
             std::fs::read_to_string(&path).expect("still there"),
-            "this is not $$ valid bsn {{{",
-            "the unreadable file must survive untouched"
+            held,
+            "the file must survive an editor run untouched"
         );
     }
 
+    /// The entries belong in files of their own, and the user is told once
+    /// where to put them.
     #[test]
-    fn an_emptied_catalog_is_written_empty_rather_than_unlinked() {
+    fn opening_a_project_whose_catalog_holds_entries_reports_them_once() {
         let (mut app, tmp) = catalog_app();
-        let path = catalog_file(&tmp);
-        std::fs::write(&path, "// placeholder\n").expect("write");
+        std::fs::write(
+            catalog_file(&tmp),
+            "#slate\nbevy_pbr::pbr_material::StandardMaterial {}\n",
+        )
+        .expect("write");
 
-        app.world_mut().resource_mut::<AssetCatalog>().dirty = true;
-        save_catalog(app.world_mut());
+        load_catalog(app.world_mut());
 
-        assert!(
-            path.is_file(),
-            "unlinking would un-shadow the legacy catalog locations"
-        );
-        assert!(is_empty_catalog_text(
-            &std::fs::read_to_string(&path).expect("read")
-        ));
-    }
+        let import = app.world().resource::<CatalogImport>();
+        assert_eq!(import.entries, 1);
+        assert!(import.reported, "the count is said once");
 
-    #[test]
-    fn a_non_material_entry_sharing_a_materials_name_is_kept() {
-        let (mut app, tmp) = catalog_app();
-        let material = app
-            .world_mut()
-            .resource_mut::<Assets<StandardMaterial>>()
-            .add(StandardMaterial::default());
-        let mesh = app
-            .world_mut()
-            .resource_mut::<Assets<Mesh>>()
-            .add(Mesh::from(bevy::math::primitives::Cuboid::default()));
-        {
-            let mut catalog = app.world_mut().resource_mut::<AssetCatalog>();
-            catalog.insert("@shared".into(), mesh.clone().untyped());
-            catalog.dirty = true;
-        }
-        // The material carries the same display name but is ephemeral, so only its own id
-        // is filtered out of the catalog file.
-        app.world_mut()
-            .resource_mut::<MaterialRegistry>()
-            .add("shared".into(), material);
-
-        save_catalog(app.world_mut());
-
-        let text = std::fs::read_to_string(catalog_file(&tmp)).expect("read");
-        assert!(
-            text.contains("#shared"),
-            "the mesh entry must survive a same-named material, got:\n{text}"
-        );
-    }
-
-    #[test]
-    fn a_material_that_could_not_be_written_stays_in_the_catalog() {
-        let (mut app, tmp) = catalog_app();
-        let handle = app
-            .world_mut()
-            .resource_mut::<Assets<StandardMaterial>>()
-            .add(StandardMaterial::default());
-        {
-            let mut catalog = app.world_mut().resource_mut::<AssetCatalog>();
-            catalog.insert("@blocked".into(), handle.clone().untyped());
-            catalog.dirty = true;
-        }
-        app.world_mut()
-            .resource_mut::<MaterialRegistry>()
-            .add_saved("blocked".into(), handle);
-
-        // A file where the materials directory belongs, so the write cannot land.
-        std::fs::write(tmp.path().join("assets/materials"), "not a directory").expect("write");
-
-        save_catalog(app.world_mut());
-
-        let text = std::fs::read_to_string(catalog_file(&tmp)).expect("read");
-        assert!(
-            text.contains("#blocked"),
-            "a failed migration must leave the entry inline, got:\n{text}"
+        load_catalog(app.world_mut());
+        assert_eq!(
+            app.world().resource::<CatalogImport>().entries,
+            1,
+            "a second read says the same thing and no more"
         );
     }
 
     #[test]
     fn comment_only_and_blank_catalogs_load_as_empty_not_as_failures() {
-        for text in ["", "   \n", EMPTY_CATALOG] {
+        for text in ["", "   \n", "// no catalog entries\n"] {
             let (mut app, tmp) = catalog_app();
             std::fs::write(catalog_file(&tmp), text).expect("write");
             load_catalog(app.world_mut());
-            let catalog = app.world().resource::<AssetCatalog>();
-            assert!(!catalog.load_failed, "{text:?} must not quarantine");
-            assert!(catalog.handles.is_empty());
+            assert!(app.world().resource::<AssetCatalog>().handles.is_empty());
+            assert_eq!(
+                app.world()
+                    .get_resource::<CatalogImport>()
+                    .map_or(0, |import| import.entries),
+                0,
+                "{text:?} holds nothing to migrate"
+            );
         }
     }
 }

--- a/src/asset_index.rs
+++ b/src/asset_index.rs
@@ -21,11 +21,11 @@ use std::time::SystemTime;
 use bevy::asset::{ReflectAsset, UntypedAssetId, UntypedHandle};
 use bevy::prelude::*;
 use jackdaw_api::prelude::{AssetKind, AssetKinds};
-use jackdaw_bsn::BsnStructData;
+use jackdaw_bsn::{BsnStructData, StemIndex};
 use path_slash::PathExt as _;
 
 use crate::asset_files::{AssetFileKind, AssetKindCache, walk_document_files};
-use crate::definition_assets::{MATERIAL_KIND, definition_name_of};
+use crate::definition_assets::MATERIAL_KIND;
 use crate::project::ProjectRoot;
 
 /// What the editor loaded out of an asset file.
@@ -72,7 +72,7 @@ impl AssetEntry {
     /// The bare name the file's stem gives it: everything before the first dot
     /// of its file name, so `torch.item.bsn` is `torch`.
     pub fn name(&self) -> String {
-        definition_name_of(&self.path)
+        jackdaw_bsn::path_stem(&self.path)
     }
 }
 
@@ -81,6 +81,7 @@ impl AssetEntry {
 pub struct AssetIndex {
     entries: BTreeMap<PathBuf, AssetEntry>,
     by_id: HashMap<UntypedAssetId, PathBuf>,
+    stems: StemIndex,
     warned_stems: Mutex<HashSet<String>>,
 }
 
@@ -120,30 +121,36 @@ impl AssetIndex {
         self.entries.get(self.by_id.get(&handle.id())?)
     }
 
-    /// Every file whose stem is `stem`.
+    /// Every document whose stem is `stem`, asset file or not.
     pub fn stem_paths(&self, stem: &str) -> Vec<PathBuf> {
-        self.entries
-            .values()
-            .filter(|entry| entry.name() == stem)
-            .map(|entry| entry.path.clone())
-            .collect()
+        self.stems.paths(stem).to_vec()
+    }
+
+    /// The names every document the walk saw counts towards, so a name this
+    /// editor calls ambiguous is ambiguous in the runtime too.
+    pub fn stems(&self) -> &StemIndex {
+        &self.stems
+    }
+
+    /// Take the documents a walk saw as the set names are counted over.
+    pub fn set_documents<I: IntoIterator<Item = PathBuf>>(&mut self, paths: I) {
+        self.stems = StemIndex::from_paths(paths);
     }
 
     /// The file a bare name stands for, for the references written before
-    /// paths. A stem two files share stands for neither, and says so once.
+    /// paths. A stem two documents share stands for neither, and says so once.
     pub fn by_stem(&self, stem: &str) -> Option<&AssetEntry> {
-        let mut matching = self.entries.values().filter(|entry| entry.name() == stem);
-        let first = matching.next()?;
-        let Some(second) = matching.next() else {
-            return Some(first);
-        };
-        if let Ok(mut warned) = self.warned_stems.lock()
+        if let Some(path) = self.stems.unique(stem) {
+            return self.entries.get(path);
+        }
+        if let Some((first, second)) = self.stems.shared(stem)
+            && let Ok(mut warned) = self.warned_stems.lock()
             && warned.insert(stem.to_string())
         {
             warn!(
                 "'{stem}' names both {} and {}; spell the one you mean as a path",
-                first.path.display(),
-                second.path.display()
+                first.display(),
+                second.display()
             );
         }
         None
@@ -160,6 +167,7 @@ impl AssetIndex {
         if let Some(handle) = entry.value.handle() {
             self.by_id.insert(handle.id(), entry.path.clone());
         }
+        self.stems.insert(entry.path.clone());
         self.entries.insert(entry.path.clone(), entry);
     }
 
@@ -168,6 +176,7 @@ impl AssetIndex {
         if let Some(handle) = entry.value.handle() {
             self.by_id.remove(&handle.id());
         }
+        self.stems.remove(path);
         Some(entry)
     }
 
@@ -264,10 +273,9 @@ pub fn load_asset_value(world: &mut World, kind: &AssetKind, path: &Path) -> Opt
 }
 
 /// The handle a material's name already answers to, when no file of its own
-/// has claimed it: a set detected from its textures, or one created and saved
-/// in this session.
+/// has claimed it: one created and saved in this session.
 fn material_handle_in_use(world: &World, path: &Path) -> Option<UntypedHandle> {
-    let name = definition_name_of(path);
+    let name = jackdaw_bsn::path_stem(path);
     let listed = world
         .get_resource::<crate::material_assets::MaterialRegistry>()
         .and_then(|registry| registry.get_by_name(&name))
@@ -347,17 +355,25 @@ pub fn rescan_asset_index(world: &mut World) -> AssetRescan {
         world.init_resource::<AssetIndex>();
     }
 
+    let documents: Vec<PathBuf> = walk_document_files(&assets)
+        .into_iter()
+        .filter_map(|path| {
+            let relative = path.strip_prefix(&assets).ok()?.to_path_buf();
+            (!is_catalog_file(&relative)).then_some(relative)
+        })
+        .collect();
+    world
+        .resource_mut::<AssetIndex>()
+        .set_documents(documents.clone());
+
     let found = world.resource_scope(|world, mut cache: Mut<AssetKindCache>| {
         let Some(kinds) = world.get_resource::<AssetKinds>() else {
             return Vec::new();
         };
-        walk_document_files(&assets)
+        documents
             .into_iter()
-            .filter_map(|path| {
-                let relative = path.strip_prefix(&assets).ok()?.to_path_buf();
-                if is_catalog_file(&relative) {
-                    return None;
-                }
+            .filter_map(|relative| {
+                let path = assets.join(&relative);
                 let kind = kind_of_file(&path, kinds, &mut cache)?;
                 let mtime = std::fs::metadata(&path)
                     .and_then(|meta| meta.modified())
@@ -447,7 +463,7 @@ fn publish_name(world: &mut World, path: &Path, kind: &AssetKind, value: &AssetV
     let Some(handle) = value.handle() else {
         return;
     };
-    let name = definition_name_of(path);
+    let name = jackdaw_bsn::path_stem(path);
     world
         .resource_mut::<crate::asset_catalog::AssetCatalog>()
         .insert(format!("@{name}"), handle.clone());
@@ -466,11 +482,7 @@ pub fn publish_reference_map(world: &mut World) {
         bevy::platform::collections::HashMap::default();
     let mut paths: bevy::platform::collections::HashMap<UntypedAssetId, String> =
         bevy::platform::collections::HashMap::default();
-    let mut stems: HashMap<String, usize> = HashMap::new();
     let index = world.resource::<AssetIndex>();
-    for entry in index.iter() {
-        *stems.entry(entry.name()).or_default() += 1;
-    }
     for entry in index.iter() {
         let Some(handle) = entry.value.handle() else {
             continue;
@@ -479,7 +491,7 @@ pub fn publish_reference_map(world: &mut World) {
         paths.insert(handle.id(), path.clone());
         references.insert(path, handle.clone());
         let name = entry.name();
-        if stems.get(&name) == Some(&1) {
+        if index.stems().unique(&name).is_some() {
             references.insert(format!("@{name}"), handle.clone());
             references.entry(name).or_insert_with(|| handle.clone());
         }
@@ -691,6 +703,68 @@ mod tests {
         assert_eq!(
             index.by_stem("torch").map(|entry| entry.path.clone()),
             Some(PathBuf::from("anywhere/torch.item.bsn"))
+        );
+    }
+
+    /// The runtime counts a name over every document its walk saw, and so does
+    /// this: a scene sharing a stem with an asset makes the name ambiguous in
+    /// both.
+    #[test]
+    fn a_name_a_scene_and_an_asset_share_stands_for_neither() {
+        let tmp = tempfile::tempdir().expect("tempdir");
+        let mut app = App::new();
+        app.add_plugins((
+            bevy::app::TaskPoolPlugin::default(),
+            bevy::asset::AssetPlugin::default(),
+        ));
+        app.init_asset::<Image>();
+        app.init_asset::<StandardMaterial>();
+        app.register_asset_reflect::<Image>();
+        app.register_asset_reflect::<StandardMaterial>();
+        app.register_type::<StandardMaterial>();
+        app.insert_resource(ProjectRoot {
+            root: tmp.path().to_path_buf(),
+            config: crate::project::ProjectConfig::default(),
+        });
+        app.init_resource::<AssetIndex>();
+        app.init_resource::<AssetKindCache>();
+        app.init_resource::<crate::asset_catalog::AssetCatalog>();
+        app.init_resource::<crate::material_assets::MaterialRegistry>();
+        app.init_resource::<AssetKinds>();
+        app.world_mut()
+            .resource_mut::<AssetKinds>()
+            .register(AssetKind::compiled(
+                MATERIAL_KIND,
+                "Material",
+                <StandardMaterial as bevy::reflect::TypePath>::type_path(),
+            ));
+        for (relative, text) in [
+            (
+                "materials/grass.bsn",
+                "#grass\nbevy_pbr::pbr_material::StandardMaterial {}\n",
+            ),
+            (
+                "zones/grass.bsn",
+                "#Root\nbevy_transform::components::transform::Transform\n\
+                 bevy_ecs::hierarchy::Children [\n    \
+                 bevy_transform::components::transform::Transform\n]\n",
+            ),
+        ] {
+            let path = tmp.path().join("assets").join(relative);
+            std::fs::create_dir_all(path.parent().expect("a parent")).expect("the folder is made");
+            std::fs::write(path, text).expect("the file is written");
+        }
+
+        rescan_asset_index(app.world_mut());
+
+        let index = app.world().resource::<AssetIndex>();
+        assert!(
+            index.by_stem("grass").is_none(),
+            "a name a scene also carries stands for neither file"
+        );
+        assert!(
+            index.get(Path::new("materials/grass.bsn")).is_some(),
+            "the file is there to be named by its path"
         );
     }
 

--- a/src/asset_migration.rs
+++ b/src/asset_migration.rs
@@ -1,0 +1,882 @@
+//! Bringing a project written before assets were files at paths up to date.
+//!
+//! Everything here is already what the editor does as it reads such a
+//! project: a bare name resolves through the file whose stem it is, a file
+//! with no header is known by its first root, a sidecar older than version 8
+//! reads its slots as paths. The operator writes that reading back to disk,
+//! once, so the files spell what the editor understands.
+
+use std::path::{Path, PathBuf};
+
+use bevy::prelude::*;
+use jackdaw_api::prelude::*;
+use jackdaw_api_internal::operator::report_to_caller;
+use jackdaw_bsn::{BsnPatch, BsnValue, SceneBsnAst};
+use path_slash::PathExt as _;
+
+use crate::asset_index::{AssetIndex, AssetValue, assets_dir, rescan_asset_index};
+
+/// What one run changed, and what it could not.
+#[derive(Default)]
+struct MigrationReport {
+    rewritten: Vec<String>,
+    headers: Vec<String>,
+    catalog: Vec<String>,
+    sidecars: Vec<String>,
+    unresolved: Vec<String>,
+}
+
+impl MigrationReport {
+    fn did_nothing(&self) -> bool {
+        self.rewritten.is_empty()
+            && self.headers.is_empty()
+            && self.catalog.is_empty()
+            && self.sidecars.is_empty()
+    }
+
+    fn lines(&self) -> Vec<String> {
+        let mut lines = Vec::new();
+        for (what, items) in [
+            ("rewrote", &self.rewritten),
+            ("wrote out", &self.catalog),
+            ("added a header to", &self.headers),
+            ("re-encoded", &self.sidecars),
+        ] {
+            if !items.is_empty() {
+                lines.push(format!("{what} {}: {}", items.len(), items.join(", ")));
+            }
+        }
+        if !self.unresolved.is_empty() {
+            lines.push(format!(
+                "left alone {}: {}",
+                self.unresolved.len(),
+                self.unresolved.join(", ")
+            ));
+        }
+        if lines.is_empty() {
+            lines.insert(0, "nothing to migrate".to_string());
+        }
+        lines
+    }
+}
+
+pub(crate) fn add_to_extension(ctx: &mut ExtensionContext) {
+    ctx.register_operator::<ProjectMigrateAssetReferencesOp>();
+}
+
+/// Rewrite a project's references, headers and sidecars as the current model
+/// spells them.
+#[operator(
+    id = "project.migrate_asset_references",
+    label = "Migrate Asset References",
+    description = "Rewrite every name reference as a path, write the catalog's entries out as \
+                   files, head every asset file and re-encode every terrain sidecar. Writes \
+                   over the project's files and cannot be undone; save what is open first.",
+    allows_undo = false
+)]
+pub fn project_migrate_asset_references(
+    _: In<OperatorParameters>,
+    mut commands: Commands,
+) -> OperatorResult {
+    commands.queue(migrate);
+    OperatorResult::Finished
+}
+
+/// The edit that would be written over by a migration, if there is one.
+fn open_edit(world: &World) -> Option<&'static str> {
+    if crate::scene_io::is_scene_dirty(world) {
+        return Some("the open scene has edits that are not saved");
+    }
+    if crate::definition_assets::open_card_has_unsaved_edits(world) {
+        return Some("an open asset has edits that are not saved");
+    }
+    if world
+        .get_resource::<crate::animation::graph_doc::AnimationGraphDoc>()
+        .is_some_and(|doc| doc.dirty)
+    {
+        return Some("the open animation graph has edits that are not saved");
+    }
+    None
+}
+
+fn migrate(world: &mut World) {
+    let Some(assets) = assets_dir(world) else {
+        report_to_caller(world, "migrate: no project is open");
+        return;
+    };
+    if !assets.is_dir() {
+        report_to_caller(
+            world,
+            format!("migrate: {} is not a directory", assets.display()),
+        );
+        return;
+    }
+    if let Some(reason) = open_edit(world) {
+        report_to_caller(world, format!("migrate: refused, {reason}"));
+        return;
+    }
+
+    let mut report = MigrationReport::default();
+    rescan_asset_index(world);
+    write_catalog_out(world, &assets, &mut report);
+    rescan_asset_index(world);
+    head_asset_files(world, &assets, &mut report);
+    rewrite_documents(world, &assets, &mut report);
+    reencode_sidecars(world, &assets, &mut report);
+    rescan_asset_index(world);
+
+    let did_nothing = report.did_nothing();
+    for line in report.lines() {
+        report_to_caller(world, format!("migrate: {line}"));
+    }
+    if !did_nothing {
+        report_to_caller(world, "migrate: undo does not reach these files");
+    }
+}
+
+// -- The catalog ------------------------------------------------------------
+
+/// The folder a catalog entry's kind keeps its files in.
+fn folder_for_kind(kind: &AssetKind) -> &str {
+    if kind.kind == crate::definition_assets::MATERIAL_KIND {
+        crate::material_assets::MATERIALS_DIR
+    } else {
+        kind.kind.as_str()
+    }
+}
+
+/// Write every entry `catalog.bsn` holds out as a file of its own, and leave
+/// the file holding none.
+///
+/// The file is read again rather than taken from [`AssetCatalog`], which also
+/// holds what the editor named for itself this run.
+fn write_catalog_out(world: &mut World, assets: &Path, report: &mut MigrationReport) {
+    let catalog_file = assets.join("catalog.bsn");
+    let Ok(text) = std::fs::read_to_string(&catalog_file) else {
+        return;
+    };
+    let entries = match jackdaw_bsn::load_bsn_assets(world, &text) {
+        Ok(entries) => entries,
+        Err(err) => {
+            report.unresolved.push(format!("catalog.bsn ({err})"));
+            return;
+        }
+    };
+    if entries.is_empty() {
+        return;
+    }
+
+    for entry in entries {
+        let kind = kind_of_handle(world, entry.handle.type_id());
+        let Some(kind) = kind else {
+            report.unresolved.push(format!(
+                "catalog entry '{}' holds a type no kind claims",
+                entry.name
+            ));
+            continue;
+        };
+        let name = crate::material_assets::sanitize_material_name(&entry.name);
+        let relative = PathBuf::from(folder_for_kind(&kind)).join(format!("{name}.bsn"));
+        let file = assets.join(&relative);
+        if file.exists() {
+            report.unresolved.push(format!(
+                "catalog entry '{}' already has {}, which wins the name",
+                entry.name,
+                relative.to_slash_lossy()
+            ));
+            continue;
+        }
+        let value = AssetValue::Handle(entry.handle.clone());
+        match crate::definition_assets::write_asset_file(world, &name, &value, &file) {
+            Ok(_) => {
+                crate::asset_index::index_written(world, &file, &kind, value);
+                note_written(world, &file);
+                world
+                    .resource_mut::<crate::asset_catalog::AssetCatalog>()
+                    .inline_materials
+                    .remove(&entry.name);
+                report.catalog.push(relative.to_slash_lossy().into_owned());
+            }
+            Err(err) => report
+                .unresolved
+                .push(format!("catalog entry '{}' ({err})", entry.name)),
+        }
+    }
+
+    if report.catalog.is_empty() {
+        return;
+    }
+    let emptied = "// no catalog entries\n";
+    match crate::scene_io::save::write_atomic(&catalog_file, emptied.as_bytes()) {
+        Ok(()) => {
+            note_written(world, &catalog_file);
+            report.catalog.push("catalog.bsn".to_string());
+        }
+        Err(err) => report.unresolved.push(format!("catalog.bsn ({err})")),
+    }
+}
+
+/// Record a file the migration itself wrote, so neither the asset index nor
+/// the open document reads it back as a change made behind the editor's back.
+fn note_written(world: &mut World, file: &Path) {
+    crate::asset_index::note_written(world, file);
+    if let Ok(bytes) = std::fs::read(file) {
+        crate::scenes::external_watch::note_known_content(world, file, &bytes);
+    }
+}
+
+/// The kind that claims the type an asset id holds.
+fn kind_of_handle(world: &World, type_id: std::any::TypeId) -> Option<AssetKind> {
+    let registry = world.get_resource::<AppTypeRegistry>()?.read();
+    let type_path = registry.get(type_id)?.type_info().type_path();
+    world
+        .get_resource::<AssetKinds>()?
+        .by_type_path(type_path)
+        .cloned()
+}
+
+// -- Headers ----------------------------------------------------------------
+
+/// Put the header naming its type on every asset file that carries none.
+fn head_asset_files(world: &mut World, assets: &Path, report: &mut MigrationReport) {
+    let headless: Vec<(PathBuf, String)> = world
+        .resource::<AssetIndex>()
+        .iter()
+        .map(|entry| (entry.path.clone(), entry.type_path.clone()))
+        .filter(|(path, _)| {
+            std::fs::read_to_string(assets.join(path))
+                .is_ok_and(|text| jackdaw_bsn::read_asset_header(&text).is_none())
+        })
+        .collect();
+
+    for (path, type_path) in headless {
+        let file = assets.join(&path);
+        let Ok(text) = std::fs::read_to_string(&file) else {
+            continue;
+        };
+        let headed = with_header_below_the_stamp(&text, &type_path);
+        match crate::scene_io::save::write_atomic(&file, headed.as_bytes()) {
+            Ok(()) => {
+                note_written(world, &file);
+                report.headers.push(path.to_slash_lossy().into_owned());
+            }
+            Err(err) => report
+                .unresolved
+                .push(format!("{} ({err})", path.to_slash_lossy())),
+        }
+    }
+}
+
+/// Put the header after the version stamp, where a file the editor writes
+/// carries it, and at the top of a file that has no stamp.
+fn with_header_below_the_stamp(text: &str, type_path: &str) -> String {
+    let Some(rest) = text
+        .split_once('\n')
+        .filter(|(first, _)| crate::scene_io::stamp::read_stamp(&format!("{first}\n")).is_some())
+    else {
+        return jackdaw_bsn::with_asset_header(type_path, text);
+    };
+    format!(
+        "{}\n{}",
+        rest.0,
+        jackdaw_bsn::with_asset_header(type_path, rest.1)
+    )
+}
+
+// -- References -------------------------------------------------------------
+
+/// Rewrite every name a scene or a prefab spells for an asset as the path of
+/// the file that answers to it.
+fn rewrite_documents(world: &mut World, assets: &Path, report: &mut MigrationReport) {
+    let documents: Vec<PathBuf> = jackdaw_bsn::walk_document_files(assets)
+        .into_iter()
+        .filter_map(|file| Some(file.strip_prefix(assets).ok()?.to_path_buf()))
+        .filter(|path| !crate::asset_index::is_catalog_file(path))
+        .filter(|path| world.resource::<AssetIndex>().get(path).is_none())
+        .collect();
+
+    for path in documents {
+        let file = assets.join(&path);
+        let Ok(text) = std::fs::read_to_string(&file) else {
+            continue;
+        };
+        let Ok(ast) = jackdaw_bsn::parse_bsn_text(&text) else {
+            continue;
+        };
+        let named = name_references(world, &ast);
+        if named.is_empty() {
+            continue;
+        }
+        let mut rewritten = text.clone();
+        let mut count = 0usize;
+        for (field, reference) in named {
+            match resolve_reference(world, &reference) {
+                Resolved::Path(target) if target == reference => {}
+                Resolved::Path(target) => {
+                    let was = format!("{field}: \"{reference}\"");
+                    let now = format!("{field}: \"{target}\"");
+                    if rewritten.contains(&was) {
+                        rewritten = rewritten.replace(&was, &now);
+                        count += 1;
+                    }
+                }
+                Resolved::Ambiguous(first, second) => report.unresolved.push(format!(
+                    "{} names '{reference}', which is both {first} and {second}",
+                    path.to_slash_lossy()
+                )),
+                Resolved::Missing => report.unresolved.push(format!(
+                    "{} names '{reference}', which no file holds",
+                    path.to_slash_lossy()
+                )),
+                Resolved::AlreadyAPath => {}
+            }
+        }
+        if count == 0 {
+            continue;
+        }
+        match crate::scene_io::save::write_atomic(&file, rewritten.as_bytes()) {
+            Ok(()) => {
+                note_written(world, &file);
+                report
+                    .rewritten
+                    .push(format!("{} ({count})", path.to_slash_lossy()));
+            }
+            Err(err) => report
+                .unresolved
+                .push(format!("{} ({err})", path.to_slash_lossy())),
+        }
+    }
+}
+
+/// What a document spells for an asset, as the field holding it and the text
+/// it holds.
+///
+/// Only a field whose type names an asset by path counts, so a string that
+/// happens to read like a name is left alone; a string under the `@` sigil
+/// counts wherever it sits, since nothing else spells one. Nested values name
+/// their own type, so a reference inside a brush face is found the same way as
+/// one on a component.
+fn name_references(world: &World, ast: &SceneBsnAst) -> Vec<(String, String)> {
+    let Some(registry) = world.get_resource::<AppTypeRegistry>() else {
+        return Vec::new();
+    };
+    let registry = registry.read();
+    let mut found: Vec<(String, String)> = Vec::new();
+    for patch in ast.world.iter_entities() {
+        let Some(BsnPatch::Struct(data)) = patch.get::<BsnPatch>() else {
+            continue;
+        };
+        scan_struct(&registry, data, &mut found);
+    }
+    found
+}
+
+/// Read the fields of one struct, by the type it names.
+fn scan_struct(
+    registry: &bevy::reflect::TypeRegistry,
+    data: &jackdaw_bsn::BsnStructData,
+    found: &mut Vec<(String, String)>,
+) {
+    let info = registry
+        .get_with_type_path(&data.type_path)
+        .map(bevy::reflect::TypeRegistration::type_info);
+    for field in &data.fields.0 {
+        let field_type = match info {
+            Some(bevy::reflect::TypeInfo::Struct(info)) => info
+                .field(&field.name)
+                .map(bevy::reflect::NamedField::type_id),
+            _ => None,
+        };
+        scan_value(registry, field_type, &field.name, &field.value, found);
+    }
+}
+
+/// The type the items of a list or an array hold.
+fn item_type(
+    registry: &bevy::reflect::TypeRegistry,
+    type_id: std::any::TypeId,
+) -> Option<std::any::TypeId> {
+    match registry.get(type_id)?.type_info() {
+        bevy::reflect::TypeInfo::List(info) => Some(info.item_ty().id()),
+        bevy::reflect::TypeInfo::Array(info) => Some(info.item_ty().id()),
+        _ => None,
+    }
+}
+
+fn scan_value(
+    registry: &bevy::reflect::TypeRegistry,
+    field_type: Option<std::any::TypeId>,
+    field_name: &str,
+    value: &BsnValue,
+    found: &mut Vec<(String, String)>,
+) {
+    match value {
+        BsnValue::String(reference) => {
+            let takes_path = field_type
+                .is_some_and(|type_id| crate::typed_values::takes_asset_path(registry, type_id));
+            let pair = (field_name.to_string(), reference.clone());
+            if (takes_path || reference.starts_with('@'))
+                && !reference.is_empty()
+                && !found.contains(&pair)
+            {
+                found.push(pair);
+            }
+        }
+        BsnValue::Struct(data) => scan_struct(registry, data, found),
+        BsnValue::TupleStruct(data) => {
+            for value in &data.values {
+                scan_value(registry, None, field_name, value, found);
+            }
+        }
+        BsnValue::List(values) => {
+            let item = field_type.and_then(|type_id| item_type(registry, type_id));
+            for value in values {
+                scan_value(registry, item, field_name, value, found);
+            }
+        }
+        BsnValue::Map(pairs) => {
+            for (_, value) in pairs {
+                scan_value(registry, field_type, field_name, value, found);
+            }
+        }
+        _ => {}
+    }
+}
+
+enum Resolved {
+    Path(String),
+    Ambiguous(String, String),
+    Missing,
+    AlreadyAPath,
+}
+
+/// The file a reference stands for: the one whose stem it is, when exactly one
+/// document carries that stem and it is an asset file.
+fn resolve_reference(world: &World, reference: &str) -> Resolved {
+    let bare = reference.trim_start_matches('@');
+    if reference.starts_with('#') {
+        return Resolved::AlreadyAPath;
+    }
+    if !reference.starts_with('@') && bare.contains('/') {
+        return Resolved::AlreadyAPath;
+    }
+    let index = world.resource::<AssetIndex>();
+    let stem = jackdaw_bsn::asset_stem(bare);
+    if let Some(path) = index.stems().unique(stem) {
+        if index.get(path).is_some() {
+            return Resolved::Path(path.to_slash_lossy().into_owned());
+        }
+        return Resolved::Missing;
+    }
+    match index.stems().shared(stem) {
+        Some((first, second)) => Resolved::Ambiguous(
+            first.to_slash_lossy().into_owned(),
+            second.to_slash_lossy().into_owned(),
+        ),
+        None => Resolved::Missing,
+    }
+}
+
+// -- Sidecars ---------------------------------------------------------------
+
+/// Read every terrain sidecar and write it back at the current version, with
+/// its material slots spelling paths.
+fn reencode_sidecars(world: &mut World, assets: &Path, report: &mut MigrationReport) {
+    let sidecars =
+        jackdaw_bsn::walk_files_with_extensions(assets, &[jackdaw_terrain::sidecar::EXTENSION]);
+    for file in sidecars {
+        let Ok(bytes) = std::fs::read(&file) else {
+            continue;
+        };
+        let relative = file
+            .strip_prefix(assets)
+            .unwrap_or(&file)
+            .to_slash_lossy()
+            .into_owned();
+        if version_of(&bytes) == Some(jackdaw_terrain::sidecar::VERSION_8) {
+            continue;
+        }
+        let loaded = match jackdaw_terrain::sidecar::load_from(&bytes, Some(assets)) {
+            Ok(loaded) => loaded,
+            Err(err) => {
+                report.unresolved.push(format!("{relative} ({err})"));
+                continue;
+            }
+        };
+        let mut data = loaded.data;
+        for (slot, name) in loaded.kept_names {
+            match resolve_reference(world, &name) {
+                Resolved::Path(path) => data.materials[slot].material = path,
+                Resolved::Ambiguous(first, second) => report.unresolved.push(format!(
+                    "{relative} slot {slot} names '{name}', which is both {first} and {second}"
+                )),
+                _ => report.unresolved.push(format!(
+                    "{relative} slot {slot} names '{name}', which no file holds"
+                )),
+            }
+        }
+        let encoded = match jackdaw_terrain::sidecar::save(&data) {
+            Ok(encoded) => encoded,
+            Err(err) => {
+                report.unresolved.push(format!("{relative} ({err})"));
+                continue;
+            }
+        };
+        match crate::scene_io::save::write_atomic(&file, &encoded) {
+            Ok(()) => {
+                note_written(world, &file);
+                report.sidecars.push(relative);
+            }
+            Err(err) => report.unresolved.push(format!("{relative} ({err})")),
+        }
+    }
+}
+
+/// The format version a sidecar's header states.
+fn version_of(bytes: &[u8]) -> Option<u16> {
+    let magic = jackdaw_terrain::sidecar::MAGIC.len();
+    let stated = bytes.get(magic..magic + 2)?;
+    Some(u16::from_le_bytes([stated[0], stated[1]]))
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use bevy::asset::AssetPlugin;
+    use jackdaw_api_internal::operator::OperatorReports;
+
+    const STANDARD_MATERIAL: &str = "bevy_pbr::pbr_material::StandardMaterial";
+
+    /// A component naming a material, of the shape a scene spells one in.
+    #[derive(Component, Reflect, Default)]
+    #[reflect(Component, Default)]
+    struct Signpost {
+        board: Handle<StandardMaterial>,
+    }
+
+    fn migration_app() -> (App, tempfile::TempDir) {
+        let tmp = tempfile::tempdir().expect("tempdir");
+        let mut app = App::new();
+        app.add_plugins((bevy::app::TaskPoolPlugin::default(), AssetPlugin::default()));
+        app.init_asset::<Image>();
+        app.init_asset::<StandardMaterial>();
+        app.register_asset_reflect::<Image>();
+        app.register_asset_reflect::<StandardMaterial>();
+        app.register_type::<StandardMaterial>();
+        app.register_type::<Signpost>();
+        app.insert_resource(crate::project::ProjectRoot {
+            root: tmp.path().to_path_buf(),
+            config: crate::project::ProjectConfig::default(),
+        });
+        app.init_resource::<crate::asset_index::AssetIndex>();
+        app.init_resource::<crate::asset_files::AssetKindCache>();
+        app.init_resource::<crate::asset_catalog::AssetCatalog>();
+        app.init_resource::<crate::material_assets::MaterialRegistry>();
+        app.init_resource::<jackdaw_commands::CommandHistory>();
+        app.init_resource::<crate::scene_io::SceneDirtyState>();
+        app.init_resource::<AssetKinds>();
+        app.world_mut()
+            .resource_mut::<AssetKinds>()
+            .register(AssetKind::compiled(
+                crate::definition_assets::MATERIAL_KIND,
+                "Material",
+                STANDARD_MATERIAL,
+            ));
+        std::fs::create_dir_all(tmp.path().join("assets")).expect("the assets directory is made");
+        (app, tmp)
+    }
+
+    fn write(tmp: &tempfile::TempDir, relative: &str, text: &str) {
+        let path = tmp.path().join("assets").join(relative);
+        std::fs::create_dir_all(path.parent().expect("a parent")).expect("the folder is made");
+        std::fs::write(path, text).expect("the file is written");
+    }
+
+    fn read(tmp: &tempfile::TempDir, relative: &str) -> String {
+        std::fs::read_to_string(tmp.path().join("assets").join(relative)).expect("the file is read")
+    }
+
+    /// A material file of the shape written before headers, so the migration
+    /// has something to head.
+    fn headerless_material(tmp: &tempfile::TempDir, relative: &str, name: &str) {
+        write(
+            tmp,
+            relative,
+            &format!("#{name}\n{STANDARD_MATERIAL} {{ metallic: 0.25 }}\n"),
+        );
+    }
+
+    fn run(app: &mut App) -> Vec<String> {
+        app.world_mut()
+            .get_resource_or_init::<OperatorReports>()
+            .0
+            .clear();
+        crate::asset_index::rescan_asset_index(app.world_mut());
+        migrate(app.world_mut());
+        app.world().resource::<OperatorReports>().0.to_vec()
+    }
+
+    fn said(reports: &[String], fragment: &str) -> bool {
+        reports.iter().any(|line| line.contains(fragment))
+    }
+
+    #[test]
+    fn a_name_a_scene_spells_becomes_the_path_of_the_file_it_names() {
+        let (mut app, tmp) = migration_app();
+        headerless_material(&tmp, "materials/slate.material.bsn", "slate");
+        write(
+            &tmp,
+            "zones/hedgerow.bsn",
+            "#Sign\njackdaw::asset_migration::tests::Signpost { board: \"@slate\" }\n",
+        );
+
+        run(&mut app);
+
+        assert!(
+            read(&tmp, "zones/hedgerow.bsn").contains("materials/slate.material.bsn"),
+            "got {}",
+            read(&tmp, "zones/hedgerow.bsn")
+        );
+    }
+
+    #[test]
+    fn a_name_a_prefab_spells_becomes_a_path_too() {
+        let (mut app, tmp) = migration_app();
+        headerless_material(&tmp, "materials/slate.material.bsn", "slate");
+        write(
+            &tmp,
+            "prefabs/post.bsn",
+            "#post\njackdaw::prefab::components::Prefab\n\
+             jackdaw::asset_migration::tests::Signpost { board: \"slate\" }\n",
+        );
+
+        run(&mut app);
+
+        assert!(read(&tmp, "prefabs/post.bsn").contains("materials/slate.material.bsn"));
+    }
+
+    #[test]
+    fn a_file_with_no_header_is_given_one() {
+        let (mut app, tmp) = migration_app();
+        headerless_material(&tmp, "materials/slate.material.bsn", "slate");
+
+        run(&mut app);
+
+        let text = read(&tmp, "materials/slate.material.bsn");
+        assert_eq!(
+            jackdaw_bsn::read_asset_header(&text).as_deref(),
+            Some(STANDARD_MATERIAL),
+            "got {text}"
+        );
+        assert!(text.contains("metallic: 0.25"), "got {text}");
+    }
+
+    #[test]
+    fn a_catalog_entry_is_written_out_as_a_file_of_its_own() {
+        let (mut app, tmp) = migration_app();
+        write(
+            &tmp,
+            "catalog.bsn",
+            &format!("#steel\n{STANDARD_MATERIAL} {{ metallic: 0.75 }}\n"),
+        );
+
+        run(&mut app);
+
+        let written = read(&tmp, "materials/steel.bsn");
+        assert!(written.contains("metallic"), "got {written}");
+        assert!(
+            !read(&tmp, "catalog.bsn").contains("steel"),
+            "the catalog keeps nothing it has written out"
+        );
+    }
+
+    /// A catalog entry whose name a file already carries would be written over
+    /// the file; it is left where it is and named in the report.
+    #[test]
+    fn a_catalog_entry_that_would_land_on_a_file_is_left_alone() {
+        let (mut app, tmp) = migration_app();
+        headerless_material(&tmp, "materials/steel.bsn", "steel");
+        write(
+            &tmp,
+            "catalog.bsn",
+            &format!("#steel\n{STANDARD_MATERIAL} {{ metallic: 0.75 }}\n"),
+        );
+
+        let reports = run(&mut app);
+
+        assert!(
+            said(&reports, "already has materials/steel.bsn"),
+            "got {reports:?}"
+        );
+        assert!(read(&tmp, "materials/steel.bsn").contains("metallic: 0.25"));
+        assert!(read(&tmp, "catalog.bsn").contains("steel"));
+    }
+
+    #[test]
+    fn a_name_two_files_carry_is_left_alone_and_both_are_named() {
+        let (mut app, tmp) = migration_app();
+        headerless_material(&tmp, "materials/slate.material.bsn", "slate");
+        headerless_material(&tmp, "zones/slate.bsn", "slate");
+        write(
+            &tmp,
+            "zones/hedgerow.bsn",
+            "#Sign\njackdaw::asset_migration::tests::Signpost { board: \"@slate\" }\n",
+        );
+
+        let reports = run(&mut app);
+
+        assert!(
+            said(&reports, "materials/slate.material.bsn")
+                && said(&reports, "zones/slate.bsn")
+                && said(&reports, "which is both"),
+            "got {reports:?}"
+        );
+        assert!(
+            read(&tmp, "zones/hedgerow.bsn").contains("\"@slate\""),
+            "an ambiguous name is left as the file spells it"
+        );
+    }
+
+    #[test]
+    fn a_name_no_file_carries_is_left_alone_and_reported() {
+        let (mut app, tmp) = migration_app();
+        write(
+            &tmp,
+            "zones/hedgerow.bsn",
+            "#Sign\njackdaw::asset_migration::tests::Signpost { board: \"@ephemeral\" }\n",
+        );
+
+        let reports = run(&mut app);
+
+        assert!(
+            said(&reports, "'@ephemeral', which no file holds"),
+            "got {reports:?}"
+        );
+        assert!(read(&tmp, "zones/hedgerow.bsn").contains("\"@ephemeral\""));
+    }
+
+    /// Version 7 and version 8 lay the same bytes out, so a version-7 file is
+    /// this build's bytes under the older version word.
+    fn write_version_7_sidecar(tmp: &tempfile::TempDir, relative: &str, slot: &str) {
+        let data = jackdaw_terrain::sidecar::RegionTerrainData {
+            materials: vec![jackdaw_terrain::sidecar::TerrainMaterialSlot::new(slot)],
+            ..Default::default()
+        };
+        let mut bytes = jackdaw_terrain::sidecar::encode_regions(&data).expect("it encodes");
+        bytes[8..10].copy_from_slice(&jackdaw_terrain::sidecar::VERSION_7.to_le_bytes());
+        let path = tmp.path().join("assets").join(relative);
+        std::fs::create_dir_all(path.parent().expect("a parent")).expect("the folder is made");
+        std::fs::write(path, bytes).expect("the sidecar is written");
+    }
+
+    fn sidecar_slot(tmp: &tempfile::TempDir, relative: &str) -> (u16, String) {
+        let bytes = std::fs::read(tmp.path().join("assets").join(relative)).expect("read");
+        let data = jackdaw_terrain::sidecar::load(&bytes).expect("it loads");
+        (
+            version_of(&bytes).expect("a version"),
+            data.materials[0].material.clone(),
+        )
+    }
+
+    #[test]
+    fn a_sidecar_written_before_paths_is_re_encoded_with_its_slots_as_paths() {
+        let (mut app, tmp) = migration_app();
+        headerless_material(&tmp, "materials/slate.material.bsn", "slate");
+        write_version_7_sidecar(&tmp, "zones/hedgerow.terrain-0.jdterrain", "slate");
+
+        run(&mut app);
+
+        assert_eq!(
+            sidecar_slot(&tmp, "zones/hedgerow.terrain-0.jdterrain"),
+            (
+                jackdaw_terrain::sidecar::VERSION_8,
+                "materials/slate.material.bsn".to_string()
+            )
+        );
+    }
+
+    #[test]
+    fn a_sidecar_slot_naming_no_file_keeps_its_name_and_is_reported() {
+        let (mut app, tmp) = migration_app();
+        write_version_7_sidecar(&tmp, "zones/hedgerow.terrain-0.jdterrain", "gone");
+
+        let reports = run(&mut app);
+
+        assert!(
+            said(&reports, "slot 0 names 'gone', which no file holds"),
+            "got {reports:?}"
+        );
+        assert_eq!(
+            sidecar_slot(&tmp, "zones/hedgerow.terrain-0.jdterrain").1,
+            "gone",
+            "a name with no file behind it still draws what it drew"
+        );
+    }
+
+    /// A file at the top of the assets is already at the path its name spells,
+    /// so a reference to it is finished and a run that rewrote it would never
+    /// settle.
+    #[test]
+    fn a_reference_that_already_spells_its_file_is_left_as_it_is() {
+        let (mut app, tmp) = migration_app();
+        headerless_material(&tmp, "slate.bsn", "slate");
+        write(
+            &tmp,
+            "zones/hedgerow.bsn",
+            "#Sign\njackdaw::asset_migration::tests::Signpost { board: \"slate.bsn\" }\n",
+        );
+
+        run(&mut app);
+        let again = run(&mut app);
+
+        assert!(said(&again, "nothing to migrate"), "got {again:?}");
+    }
+
+    #[test]
+    fn a_second_run_has_nothing_to_do() {
+        let (mut app, tmp) = migration_app();
+        headerless_material(&tmp, "materials/slate.material.bsn", "slate");
+        write(
+            &tmp,
+            "zones/hedgerow.bsn",
+            "#Sign\njackdaw::asset_migration::tests::Signpost { board: \"@slate\" }\n",
+        );
+
+        run(&mut app);
+        let again = run(&mut app);
+
+        assert!(said(&again, "nothing to migrate"), "got {again:?}");
+    }
+
+    #[test]
+    fn a_project_with_unsaved_edits_open_is_refused() {
+        let (mut app, tmp) = migration_app();
+        headerless_material(&tmp, "materials/slate.material.bsn", "slate");
+        app.world_mut()
+            .resource_mut::<crate::scene_io::SceneDirtyState>()
+            .undo_len_at_save = 1;
+
+        let reports = run(&mut app);
+
+        assert!(said(&reports, "refused"), "got {reports:?}");
+        assert!(
+            jackdaw_bsn::read_asset_header(&read(&tmp, "materials/slate.material.bsn")).is_none(),
+            "nothing is written while an edit is open"
+        );
+    }
+
+    #[test]
+    fn a_project_with_no_assets_directory_is_said_so_rather_than_walked() {
+        let tmp = tempfile::tempdir().expect("tempdir");
+        let (mut app, _held) = migration_app();
+        app.world_mut()
+            .insert_resource(crate::project::ProjectRoot {
+                root: tmp.path().to_path_buf(),
+                config: crate::project::ProjectConfig::default(),
+            });
+
+        let reports = run(&mut app);
+
+        assert!(said(&reports, "is not a directory"), "got {reports:?}");
+    }
+}

--- a/src/asset_migration.rs
+++ b/src/asset_migration.rs
@@ -148,7 +148,7 @@ fn folder_for_kind(kind: &AssetKind) -> &str {
 /// Write every entry `catalog.bsn` holds out as a file of its own, and leave
 /// the file holding none.
 ///
-/// The file is read again rather than taken from [`AssetCatalog`], which also
+/// The file is read again rather than taken from [`AssetCatalog`](crate::asset_catalog::AssetCatalog), which also
 /// holds what the editor named for itself this run.
 fn write_catalog_out(world: &mut World, assets: &Path, report: &mut MigrationReport) {
     let catalog_file = assets.join("catalog.bsn");

--- a/src/core_extension.rs
+++ b/src/core_extension.rs
@@ -258,6 +258,7 @@ impl JackdawExtension for JackdawCoreExtension {
         crate::file_ops::add_to_extension(ctx);
         crate::material_assets::add_to_extension(ctx);
         crate::definition_assets::add_to_extension(ctx);
+        crate::asset_migration::add_to_extension(ctx);
         crate::viewport_select::add_to_extension(ctx);
         crate::clip_ops::add_to_extension(ctx);
         crate::brush_element_ops::add_to_extension(ctx);

--- a/src/definition_assets.rs
+++ b/src/definition_assets.rs
@@ -107,17 +107,6 @@ pub fn definition_file_path(dir: &Path, name: &str) -> PathBuf {
     dir.join(format!("{}.bsn", sanitize_definition_name(name)))
 }
 
-/// The name a file gives what it holds: everything before the first dot of its
-/// file name, so `torch.item.bsn` holds `torch`.
-pub fn definition_name_of(path: &Path) -> String {
-    let file = path
-        .file_name()
-        .and_then(|name| name.to_str())
-        .unwrap_or_default()
-        .trim_start_matches('.');
-    file.split('.').next().unwrap_or(file).to_string()
-}
-
 /// The folder a new asset lands in: the one the browser is showing when it is
 /// under the project's assets, and the assets directory otherwise.
 pub fn new_definition_dir(world: &World) -> Option<PathBuf> {
@@ -670,6 +659,15 @@ fn open_card_for(world: &mut World, path: &Path) -> Option<Entity> {
         .iter(world)
         .find(|(_, edit)| edit.path == path)
         .map(|(entity, _)| entity)
+}
+
+/// Whether an open card holds edits that are not on disk.
+pub fn open_card_has_unsaved_edits(world: &World) -> bool {
+    world
+        .get_resource::<OpenDefinition>()
+        .and_then(|open| open.0)
+        .and_then(|entity| world.get::<DefinitionAssetEdit>(entity))
+        .is_some_and(|edit| edit.dirty)
 }
 
 /// Whether the card editing this file holds edits that are not on disk.
@@ -1314,7 +1312,7 @@ pub(crate) fn create_definition(
         .filter(|asked| asked.contains('.'))
         .map(|asked| dir.join(bsn_file_name(asked)));
     let file = file.or_else(|| named_file.clone());
-    let named_by_path = file.as_deref().map(definition_name_of);
+    let named_by_path = file.as_deref().map(jackdaw_bsn::path_stem);
     let name = match named_by_path.or_else(|| asked_for.clone()) {
         Some(name) => sanitize_definition_name(&name),
         None => next_free_name(world, kind, &dir),
@@ -1658,7 +1656,7 @@ mod tests {
             (".torch.item.bsn", "torch"),
         ] {
             assert_eq!(
-                definition_name_of(Path::new(file)),
+                jackdaw_bsn::path_stem(Path::new(file)),
                 expected,
                 "{file} names an asset"
             );

--- a/src/inspector/animation_graph_card.rs
+++ b/src/inspector/animation_graph_card.rs
@@ -33,7 +33,7 @@ pub(super) fn fill_graph_reference_picker(world: &mut World, entity: Entity, bod
         .id();
     if files.is_empty() {
         world.spawn((
-            Text::new("No graph file in assets/animation yet."),
+            Text::new("No graph file in this project yet."),
             TextFont {
                 font_size: tokens::TEXT_SIZE_SM,
                 ..default()

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -16,6 +16,7 @@ pub mod asset_catalog;
 pub mod asset_files;
 pub mod asset_index;
 pub mod asset_ingest;
+pub mod asset_migration;
 pub mod authored_widgets;
 pub mod boot_ops;
 pub mod brush;

--- a/src/material_assets.rs
+++ b/src/material_assets.rs
@@ -8,21 +8,21 @@
 //!
 //! # Saved vs unsaved
 //!
-//! Detected texture sets and freshly created materials are *unsaved*: they
-//! live in the running editor's `Assets<StandardMaterial>` and in the shared
+//! A detected texture set and a freshly created material are *unsaved*: they
+//! live in the running editor's
+//! `Assets<StandardMaterial>` and in the shared
 //! [`crate::asset_catalog::AssetCatalog`] (so `@Name` references resolve and
-//! scene saves emit them), but nothing is written for them. `material.save`
-//! writes the file and promotes the entry. Detected sets are reproducible
-//! from the same texture files on the next open; a saved material takes over its
-//! detected base name on rescan so the two never sit side by side.
+//! scene saves emit them), but no file holds them. `material.save` writes the
+//! file and promotes the entry, and a detected set is reproducible from the
+//! same textures on the next open. A material whose file has gone reads as
+//! unsaved again, so nothing writes the file back on its own.
 //!
 //! # The catalog file
 //!
 //! The index *is* the material list: a file's stem is the `@Name` older scenes
-//! spell. `assets/catalog.bsn` holds only what has no file of its own: catalog
-//! entries of other asset types, and inline material entries. Inline material
-//! entries load normally and are rewritten as files on the next save, which
-//! removes them from `catalog.bsn`.
+//! spell. `assets/catalog.bsn` is read for what a project kept there before
+//! each asset had a file of its own; nothing writes it, and
+//! `project.migrate_asset_references` moves its entries into files.
 
 use std::path::{Path, PathBuf};
 
@@ -37,9 +37,6 @@ use crate::project::ProjectRoot;
 
 /// Directory under `assets/` holding saved material files.
 pub const MATERIALS_DIR: &str = "materials";
-
-/// Suffix identifying a saved material file. The name is the stem before it.
-pub const MATERIAL_FILE_SUFFIX: &str = ".material.bsn";
 
 const STANDARD_MATERIAL: &str = "bevy_pbr::pbr_material::StandardMaterial";
 
@@ -65,8 +62,8 @@ pub struct MaterialRegistry {
 pub struct MaterialRegistryEntry {
     pub name: String,
     pub handle: Handle<StandardMaterial>,
-    /// Whether a `.material.bsn` file backs this entry. Unsaved entries are
-    /// usable while the editor runs but are not written by [`persist_materials`].
+    /// Whether a file backs this entry. An unsaved entry is usable while the
+    /// editor runs, and travels inline in the scenes that use it.
     pub saved: bool,
 }
 
@@ -140,13 +137,6 @@ impl MaterialRegistry {
     }
 }
 
-/// The name a material reference carries: the part of its last path segment
-/// before the first dot, which is what a bare name already is.
-pub fn material_name_of(reference: &str) -> &str {
-    let file = reference.rsplit('/').next().unwrap_or(reference);
-    file.split_once('.').map_or(file, |(stem, _)| stem)
-}
-
 /// The file a material reference names, if one holds it: the file at that
 /// path, or, for the references written before paths, the file whose stem is
 /// that bare name.
@@ -161,7 +151,7 @@ pub fn material_file_of<'a>(
     index
         .get(&path)
         .filter(|entry| entry.kind == crate::definition_assets::MATERIAL_KIND)
-        .or_else(|| index.material_named(material_name_of(reference)))
+        .or_else(|| index.material_named(jackdaw_bsn::asset_stem(reference)))
 }
 
 /// The material a reference names: the file it spells the path of, or, for the
@@ -182,7 +172,7 @@ pub fn material_of_reference(
         return Some(typed);
     }
     registry
-        .get_by_name(material_name_of(reference))
+        .get_by_name(jackdaw_bsn::asset_stem(reference))
         .map(|entry| entry.handle.clone())
 }
 
@@ -212,12 +202,42 @@ pub fn materials_dir(project: &ProjectRoot) -> PathBuf {
     project.assets_dir().join(MATERIALS_DIR)
 }
 
-/// The file a material of this name saves to.
+/// The file a material of this name saves to with no folder in mind.
 pub fn material_file_path(project: &ProjectRoot, name: &str) -> PathBuf {
-    materials_dir(project).join(format!(
-        "{}{MATERIAL_FILE_SUFFIX}",
-        sanitize_material_name(name)
-    ))
+    materials_dir(project).join(material_file_name(name))
+}
+
+/// The file name a material of this name saves under.
+pub fn material_file_name(name: &str) -> String {
+    format!("{}.bsn", sanitize_material_name(name))
+}
+
+/// The file a save writes: the one chosen, else the file the material is
+/// already filed at, else `materials/<name>.bsn`.
+///
+/// A chosen folder takes the default file name, whether or not it is there
+/// yet; a chosen file is written as it stands, under a `.bsn` extension.
+pub fn material_save_path(
+    world: &World,
+    name: &str,
+    handle: &Handle<StandardMaterial>,
+    chosen: Option<&Path>,
+) -> Option<PathBuf> {
+    let project = world.get_resource::<ProjectRoot>()?;
+    if let Some(chosen) = chosen {
+        let chosen = crate::definition_assets::resolve_project_path(world, chosen);
+        if chosen.is_dir() || chosen.extension().is_none() {
+            return Some(chosen.join(material_file_name(name)));
+        }
+        return Some(chosen.with_extension("bsn"));
+    }
+    let stem = sanitize_material_name(name);
+    let filed = world
+        .get_resource::<crate::asset_index::AssetIndex>()
+        .and_then(|index| index.by_handle(&handle.clone().untyped()))
+        .filter(|entry| entry.name() == stem)
+        .map(|entry| project.assets_dir().join(&entry.path));
+    Some(filed.unwrap_or_else(|| material_file_path(project, name)))
 }
 
 /// Reflect one material out of its `Assets` store as a single-entry `.bsn`
@@ -234,25 +254,28 @@ pub fn material_to_bsn(world: &World, name: &str, asset_id: UntypedAssetId) -> S
 }
 
 /// Write a live material back to the file the index holds it at, or to
-/// `assets/materials/<name>.material.bsn` when it has none yet.
+/// `assets/materials/<name>.bsn` when it has none yet.
 pub fn write_material_file(
     world: &World,
     name: &str,
     handle: &Handle<StandardMaterial>,
 ) -> std::io::Result<PathBuf> {
-    let project = world
-        .get_resource::<ProjectRoot>()
+    write_material_file_at(world, name, handle, None)
+}
+
+/// Write a live material to `chosen`, or to the file [`material_save_path`]
+/// picks for it.
+pub fn write_material_file_at(
+    world: &World,
+    name: &str,
+    handle: &Handle<StandardMaterial>,
+    chosen: Option<&Path>,
+) -> std::io::Result<PathBuf> {
+    let path = material_save_path(world, name, handle, chosen)
         .ok_or_else(|| std::io::Error::other("no project root"))?;
-    let stem = sanitize_material_name(name);
-    let filed = world
-        .get_resource::<crate::asset_index::AssetIndex>()
-        .and_then(|index| index.by_handle(&handle.clone().untyped()))
-        .filter(|entry| entry.name() == stem)
-        .map(|entry| project.assets_dir().join(&entry.path));
-    let path = filed.unwrap_or_else(|| material_file_path(project, name));
     crate::definition_assets::write_asset_file(
         world,
-        &stem,
+        &sanitize_material_name(name),
         &crate::asset_index::AssetValue::Handle(handle.clone().untyped()),
         &path,
     )
@@ -383,37 +406,51 @@ fn linear_texture_paths(ast: &SceneBsnAst) -> Vec<String> {
     paths
 }
 
-/// Write a `.material.bsn` for every saved registry entry. Unsaved entries are
-/// skipped; they stay ephemeral until `material.save` runs.
+/// The materials a panel has edited since the last frame wrote them back.
 ///
-/// Returns the asset ids that have files, so the catalog writer knows which
-/// entries it need not hold inline. Keyed by id, not name, so an entry of
-/// another type sharing a material's name is never mistaken for it.
-///
-/// A name that would change under [`sanitize_material_name`] cannot become a
-/// file stem without changing the `@Name` scenes reference, so it is reported
-/// and left inline.
-pub fn persist_materials(world: &mut World) -> Vec<UntypedAssetId> {
-    let saved: Vec<(String, Handle<StandardMaterial>)> = world
-        .resource::<MaterialRegistry>()
-        .entries
-        .iter()
-        .filter(|e| e.saved && e.handle != Handle::default())
-        .map(|e| (e.name.clone(), e.handle.clone()))
-        .collect();
+/// An edit to a material that has a file of its own belongs in that file; one
+/// to a material with none stays in memory until `material.save` files it.
+#[derive(Resource, Default)]
+pub struct EditedMaterials(Vec<Handle<StandardMaterial>>);
 
-    let mut written = Vec::new();
-    for (name, handle) in saved {
-        if sanitize_material_name(&name) != name {
-            warn!("Material '{name}' has no valid file name; keeping it in the catalog");
-            continue;
-        }
-        match write_material_file(world, &name, &handle) {
-            Ok(_) => written.push(handle.id().untyped()),
-            Err(err) => warn!("Failed to write material '{name}': {err}"),
+impl EditedMaterials {
+    pub fn edited(&mut self, handle: &Handle<StandardMaterial>) {
+        if !self.0.contains(handle) {
+            self.0.push(handle.clone());
         }
     }
-    written
+
+    pub fn is_empty(&self) -> bool {
+        self.0.is_empty()
+    }
+
+    pub fn clear(&mut self) {
+        self.0.clear();
+    }
+}
+
+/// Write back every material a panel edited, for the ones with a file behind
+/// them.
+pub fn write_edited_materials(world: &mut World) {
+    let edited = std::mem::take(&mut world.get_resource_or_init::<EditedMaterials>().0);
+    for handle in edited {
+        let Some(name) = world
+            .resource::<MaterialRegistry>()
+            .entries
+            .iter()
+            .find(|entry| entry.handle == handle && entry.saved)
+            .map(|entry| entry.name.clone())
+        else {
+            continue;
+        };
+        if sanitize_material_name(&name) != name {
+            warn!("Material '{name}' has no valid file name; it is not written out");
+            continue;
+        }
+        if let Err(err) = write_material_file(world, &name, &handle) {
+            warn!("Failed to write material '{name}': {err}");
+        }
+    }
 }
 
 /// Asset ids of materials with no file behind them. A scene that references
@@ -578,6 +615,11 @@ pub(crate) fn plugin(app: &mut App) {
     // the built game agree on it.
     app.add_plugins(jackdaw_runtime::MaterialTextureFormatPlugin)
         .init_resource::<PendingMaterialDelete>()
+        .init_resource::<EditedMaterials>()
+        .add_systems(
+            Update,
+            write_edited_materials.run_if(in_state(crate::AppState::Editor)),
+        )
         .add_observer(on_delete_dialog_opened)
         .add_observer(on_delete_dialog_closed)
         .add_observer(on_material_delete_confirmed);
@@ -593,8 +635,8 @@ fn a_material_is_selected(
     })
 }
 
-/// Write the target material to `assets/materials` and promote it to a saved
-/// asset. Both parameters are optional so a surface can dispatch this with no
+/// Write the target material to a file of its own and promote it to a saved
+/// asset. Every parameter is optional so a surface can dispatch this with no
 /// arguments for the previewed material.
 ///
 /// Registry key, file stem and `@Name` are the same string, so a call naming a
@@ -602,22 +644,28 @@ fn a_material_is_selected(
 #[operator(
     id = "material.save",
     label = "Save Material",
-    description = "Write the material to assets/materials as a reusable asset.",
+    description = "Write the material to a file of its own as a reusable asset.",
     allows_undo = false,
     is_available = a_material_is_selected,
     params(
-        material(String, doc = "Name of the material to save. Defaults to the previewed one."),
-        name(String, doc = "Name to save under. Defaults to the material's current name.")
+        material(String, doc = "Path or name of the material to save. Defaults to the previewed one."),
+        name(String, doc = "Name to save under. Defaults to the material's current name."),
+        path(
+            String,
+            doc = "Folder or file to write it to. Defaults to the file it is \
+                   already filed at, else assets/materials."
+        )
     )
 )]
 pub fn material_save(
     params: In<OperatorParameters>,
     registry: Res<MaterialRegistry>,
+    index: Option<Res<crate::asset_index::AssetIndex>>,
     preview: Option<Res<crate::material_preview::MaterialPreviewState>>,
     mut commands: Commands,
 ) -> OperatorResult {
     let handle = match params.as_str("material") {
-        Some(name) => registry.get_by_name(name).map(|e| e.handle.clone()),
+        Some(reference) => material_of_reference(index.as_deref(), &registry, reference),
         None => preview.and_then(|p| p.active_material.clone()),
     };
     let Some(handle) = handle.filter(|h| *h != Handle::default()) else {
@@ -632,6 +680,7 @@ pub fn material_save(
             .or(current.as_deref())
             .unwrap_or("material"),
     );
+    let chosen = params.as_str("path").map(PathBuf::from);
 
     if let Some(owner) = name_owner(&registry, &handle, &name) {
         warn!("material.save: '{name}' already belongs to material '{owner}'");
@@ -639,9 +688,51 @@ pub fn material_save(
     }
 
     commands.queue(move |world: &mut World| {
-        write_and_promote(world, &handle, current.as_deref(), &name);
+        write_and_promote(world, &handle, current.as_deref(), &name, chosen.as_deref());
     });
     OperatorResult::Finished
+}
+
+/// The folder and file name a Save As dialog opens on for the previewed
+/// material: where a save with no folder in mind would put it.
+pub fn previewed_material_target(world: &World) -> Option<(PathBuf, String)> {
+    let handle = world
+        .get_resource::<crate::material_preview::MaterialPreviewState>()?
+        .active_material
+        .clone()
+        .filter(|handle| *handle != Handle::default())?;
+    let name = world
+        .get_resource::<MaterialRegistry>()?
+        .name_of(&handle)
+        .unwrap_or("material")
+        .to_string();
+    let path = material_save_path(world, &name, &handle, None)?;
+    let folder = path.parent()?.to_path_buf();
+    let file_name = path.file_name()?.to_string_lossy().into_owned();
+    Some((folder, file_name))
+}
+
+/// Write the previewed material to a file the user chose, taking its name
+/// from that file.
+pub fn save_previewed_material_to(world: &mut World, file: &Path) {
+    let Some(handle) = world
+        .get_resource::<crate::material_preview::MaterialPreviewState>()
+        .and_then(|preview| preview.active_material.clone())
+        .filter(|handle| *handle != Handle::default())
+    else {
+        warn!("material.save_as: no material to save");
+        return;
+    };
+    let current = world
+        .resource::<MaterialRegistry>()
+        .name_of(&handle)
+        .map(str::to_owned);
+    let name = sanitize_material_name(&jackdaw_bsn::path_stem(file));
+    if let Some(owner) = name_owner(world.resource::<MaterialRegistry>(), &handle, &name) {
+        warn!("material.save_as: '{name}' already belongs to material '{owner}'");
+        return;
+    }
+    write_and_promote(world, &handle, current.as_deref(), &name, Some(file));
 }
 
 /// The material already answering to `name`, if it is not `handle` itself.
@@ -670,6 +761,7 @@ fn write_and_promote(
     handle: &Handle<StandardMaterial>,
     current: Option<&str>,
     name: &str,
+    chosen: Option<&Path>,
 ) {
     // The dispatching check ran before this command was queued, so a second save aimed at
     // the same name may have landed in between; re-check at the point of claiming it.
@@ -678,7 +770,7 @@ fn write_and_promote(
         return;
     }
 
-    let file = match write_material_file(world, name, handle) {
+    let file = match write_material_file_at(world, name, handle, chosen) {
         Ok(file) => file,
         Err(err) => {
             warn!("material.save: failed to write '{name}': {err}");
@@ -706,7 +798,6 @@ fn write_and_promote(
     world
         .resource_mut::<AssetCatalog>()
         .insert(format!("@{name}"), handle.clone().untyped());
-    world.resource_mut::<AssetCatalog>().dirty = true;
     world
         .resource_mut::<AssetCatalog>()
         .inline_materials
@@ -898,7 +989,6 @@ fn delete_material(world: &mut World, name: &str) {
         catalog.id_to_name.remove(&id);
         catalog.handles.retain(|_, handle| handle.id() != id);
     }
-    catalog.dirty = true;
 
     if let Some(entry) = removed
         && let Some(mut preview) =
@@ -1127,6 +1217,14 @@ mod tests {
             .typed::<StandardMaterial>()
     }
 
+    /// Queue an edit to `handle` and let the writeback run.
+    fn edit_and_write(app: &mut App, handle: &Handle<StandardMaterial>) {
+        app.world_mut()
+            .get_resource_or_init::<EditedMaterials>()
+            .edited(handle);
+        write_edited_materials(app.world_mut());
+    }
+
     /// Where the index holds a material, if it holds one.
     fn filed_at(app: &App, name: &str) -> Option<PathBuf> {
         app.world()
@@ -1135,8 +1233,99 @@ mod tests {
             .map(|entry| entry.path.clone())
     }
 
+    /// `materials/` is only where a save with no folder in mind puts a file.
     #[test]
-    fn saving_a_detected_material_writes_a_file_and_promotes_it() {
+    fn a_save_with_a_folder_chosen_writes_there() {
+        let (mut app, tmp) = project_app();
+        let handle = app
+            .world_mut()
+            .resource_mut::<Assets<StandardMaterial>>()
+            .add(StandardMaterial::default());
+        app.world_mut()
+            .resource_mut::<MaterialRegistry>()
+            .add("bramble".into(), handle.clone());
+        let chosen = tmp.path().join("assets/zones/hedgerow");
+        std::fs::create_dir_all(&chosen).expect("the folder is made");
+
+        let result = app
+            .world_mut()
+            .run_system_cached_with(
+                material_save,
+                params(&[("material", "bramble"), ("path", "zones/hedgerow")]),
+            )
+            .expect("the operator runs");
+        app.world_mut().flush();
+
+        assert!(result.is_finished());
+        assert!(
+            chosen.join("bramble.bsn").is_file(),
+            "the chosen folder is where it goes"
+        );
+        assert!(
+            !tmp.path().join("assets/materials/bramble.bsn").exists(),
+            "the default folder is a default, not a rule"
+        );
+        assert_eq!(
+            filed_at(&app, "bramble"),
+            Some(PathBuf::from("zones/hedgerow/bramble.bsn"))
+        );
+    }
+
+    /// A folder is named the same way whether or not it is there yet, so a
+    /// save into a new one makes it rather than filing a material under its
+    /// name.
+    #[test]
+    fn a_save_into_a_folder_that_is_not_there_yet_writes_inside_it() {
+        let (mut app, tmp) = project_app();
+        let handle = app
+            .world_mut()
+            .resource_mut::<Assets<StandardMaterial>>()
+            .add(StandardMaterial::default());
+        app.world_mut()
+            .resource_mut::<MaterialRegistry>()
+            .add("bramble".into(), handle.clone());
+
+        write_and_promote(
+            app.world_mut(),
+            &handle,
+            Some("bramble"),
+            "bramble",
+            Some(Path::new("zones/hedgerow")),
+        );
+
+        assert!(
+            tmp.path()
+                .join("assets/zones/hedgerow/bramble.bsn")
+                .is_file()
+        );
+        assert!(!tmp.path().join("assets/zones/hedgerow.bsn").exists());
+    }
+
+    /// A save aimed at one file keeps writing that file.
+    #[test]
+    fn a_save_with_a_file_chosen_writes_that_file() {
+        let (mut app, tmp) = project_app();
+        let handle = app
+            .world_mut()
+            .resource_mut::<Assets<StandardMaterial>>()
+            .add(StandardMaterial::default());
+        app.world_mut()
+            .resource_mut::<MaterialRegistry>()
+            .add("bramble".into(), handle.clone());
+
+        write_and_promote(
+            app.world_mut(),
+            &handle,
+            Some("bramble"),
+            "bramble",
+            Some(&tmp.path().join("assets/props/thorns.bsn")),
+        );
+
+        assert!(tmp.path().join("assets/props/thorns.bsn").is_file());
+    }
+
+    #[test]
+    fn saving_a_material_writes_a_file_and_promotes_it() {
         let (mut app, tmp) = project_app();
         let handle = {
             let base = textured(&mut app, "t/grass_basecolor.png", true);
@@ -1151,9 +1340,9 @@ mod tests {
             .resource_mut::<MaterialRegistry>()
             .add("grass".into(), handle.clone());
 
-        write_and_promote(app.world_mut(), &handle, Some("grass"), "grass");
+        write_and_promote(app.world_mut(), &handle, Some("grass"), "grass", None);
 
-        let path = tmp.path().join("assets/materials/grass.material.bsn");
+        let path = tmp.path().join("assets/materials/grass.bsn");
         assert!(path.is_file(), "the material file must exist at {path:?}");
         assert!(
             std::fs::read_to_string(&path)
@@ -1163,7 +1352,7 @@ mod tests {
         assert!(app.world().resource::<MaterialRegistry>().is_saved("grass"));
         assert_eq!(
             filed_at(&app, "grass"),
-            Some(PathBuf::from("materials/grass.material.bsn")),
+            Some(PathBuf::from("materials/grass.bsn")),
             "the index must hold the file the save wrote"
         );
         assert!(
@@ -1203,9 +1392,7 @@ mod tests {
             "a name another material answers to must not be taken"
         );
         assert!(
-            !tmp.path()
-                .join("assets/materials/GRASS.material.bsn")
-                .exists(),
+            !tmp.path().join("assets/materials/GRASS.bsn").exists(),
             "a refused save must not leave a file behind"
         );
         assert!(!app.world().resource::<MaterialRegistry>().is_saved("grass"));
@@ -1229,8 +1416,8 @@ mod tests {
 
         // Both dispatches cleared the name against the same registry; only the first may
         // take it.
-        write_and_promote(app.world_mut(), &first, Some("Material_1"), "grass");
-        write_and_promote(app.world_mut(), &second, Some("Material_2"), "grass");
+        write_and_promote(app.world_mut(), &first, Some("Material_1"), "grass", None);
+        write_and_promote(app.world_mut(), &second, Some("Material_2"), "grass", None);
 
         let registry = app.world().resource::<MaterialRegistry>();
         assert_eq!(
@@ -1258,26 +1445,16 @@ mod tests {
             .resource_mut::<MaterialRegistry>()
             .add("grass".into(), handle.clone());
 
-        write_and_promote(app.world_mut(), &handle, Some("grass"), "grass");
-        assert!(
-            tmp.path()
-                .join("assets/materials/grass.material.bsn")
-                .is_file()
-        );
+        write_and_promote(app.world_mut(), &handle, Some("grass"), "grass", None);
+        assert!(tmp.path().join("assets/materials/grass.bsn").is_file());
 
-        write_and_promote(app.world_mut(), &handle, Some("grass"), "meadow");
+        write_and_promote(app.world_mut(), &handle, Some("grass"), "meadow", None);
 
         assert!(
-            !tmp.path()
-                .join("assets/materials/grass.material.bsn")
-                .exists(),
+            !tmp.path().join("assets/materials/grass.bsn").exists(),
             "the file the old name held must go with the name"
         );
-        assert!(
-            tmp.path()
-                .join("assets/materials/meadow.material.bsn")
-                .is_file()
-        );
+        assert!(tmp.path().join("assets/materials/meadow.bsn").is_file());
 
         let catalog = app.world().resource::<AssetCatalog>();
         assert_eq!(
@@ -1298,13 +1475,13 @@ mod tests {
         );
         assert_eq!(
             filed_at(&app, "meadow"),
-            Some(PathBuf::from("materials/meadow.material.bsn"))
+            Some(PathBuf::from("materials/meadow.bsn"))
         );
         assert_eq!(filed_at(&app, "grass"), None);
     }
 
     #[test]
-    fn a_name_that_is_not_a_legal_file_stem_stays_in_the_catalog() {
+    fn a_name_that_is_not_a_legal_file_stem_is_not_written_out() {
         let (mut app, tmp) = project_app();
         let handle = app
             .world_mut()
@@ -1312,13 +1489,14 @@ mod tests {
             .add(StandardMaterial::default());
         app.world_mut()
             .resource_mut::<MaterialRegistry>()
-            .add_saved("my material".into(), handle);
+            .add_saved("my material".into(), handle.clone());
+
+        edit_and_write(&mut app, &handle);
 
         assert!(
-            persist_materials(app.world_mut()).is_empty(),
-            "migrating would silently rename the material"
+            !tmp.path().join("assets/materials").exists(),
+            "writing it out would silently rename the material"
         );
-        assert!(!tmp.path().join("assets/materials").exists());
     }
 
     #[test]
@@ -1360,10 +1538,7 @@ mod tests {
         write_material_file(app.world(), "rock", &handle).expect("write");
 
         let scan = crate::asset_index::rescan_asset_index(app.world_mut());
-        assert_eq!(
-            scan.added,
-            vec![PathBuf::from("materials/rock.material.bsn")]
-        );
+        assert_eq!(scan.added, vec![PathBuf::from("materials/rock.bsn")]);
         let reloaded = filed_handle(&app, "rock");
         let material = app
             .world()
@@ -1388,14 +1563,11 @@ mod tests {
             .add(StandardMaterial::default());
         app.world_mut()
             .resource_mut::<MaterialRegistry>()
-            .add("detected".into(), handle);
+            .add("unfiled".into(), handle.clone());
 
-        assert!(persist_materials(app.world_mut()).is_empty());
-        assert!(
-            !tmp.path()
-                .join("assets/materials/detected.material.bsn")
-                .exists()
-        );
+        edit_and_write(&mut app, &handle);
+
+        assert!(!tmp.path().join("assets/materials/unfiled.bsn").exists());
     }
 
     /// Without a rescan a file written while the editor is up stays invisible until the
@@ -1415,10 +1587,7 @@ mod tests {
 
         let scan = crate::asset_index::rescan_asset_index(app.world_mut());
 
-        assert_eq!(
-            scan.added,
-            vec![PathBuf::from("materials/slate.material.bsn")]
-        );
+        assert_eq!(scan.added, vec![PathBuf::from("materials/slate.bsn")]);
         assert!(scan.removed.is_empty());
         let loaded = app
             .world()
@@ -1503,9 +1672,7 @@ mod tests {
         let filed = filed_handle(&app, "slate");
         write_material_file(app.world(), "slate", &filed).expect("write");
         assert!(
-            !tmp.path()
-                .join("assets/materials/slate.material.bsn")
-                .exists(),
+            !tmp.path().join("assets/materials/slate.bsn").exists(),
             "a save goes back to the file the material came from"
         );
     }
@@ -1523,11 +1690,8 @@ mod tests {
             .resource_mut::<MaterialRegistry>()
             .add_saved(name.to_string(), handle);
 
-        std::fs::remove_file(
-            tmp.path()
-                .join(format!("assets/materials/{name}{MATERIAL_FILE_SUFFIX}")),
-        )
-        .expect("remove");
+        std::fs::remove_file(tmp.path().join(format!("assets/materials/{name}.bsn")))
+            .expect("remove");
         (app, tmp)
     }
 
@@ -1539,10 +1703,7 @@ mod tests {
 
         let scan = crate::asset_index::rescan_asset_index(app.world_mut());
 
-        assert_eq!(
-            scan.removed,
-            vec![PathBuf::from("materials/slate.material.bsn")]
-        );
+        assert_eq!(scan.removed, vec![PathBuf::from("materials/slate.bsn")]);
         assert!(scan.added.is_empty());
         assert!(
             app.world()
@@ -1578,25 +1739,19 @@ mod tests {
             .resource_mut::<MaterialRegistry>()
             .add("slate".to_string(), handle.clone());
 
-        assert!(persist_materials(app.world_mut()).is_empty());
+        edit_and_write(&mut app, &handle);
         assert!(
-            !tmp.path()
-                .join("assets/materials/slate.material.bsn")
-                .exists(),
+            !tmp.path().join("assets/materials/slate.bsn").exists(),
             "the deletion stands",
         );
 
         // An explicit save writes the file again.
-        write_and_promote(app.world_mut(), &handle, Some("slate"), "slate");
+        write_and_promote(app.world_mut(), &handle, Some("slate"), "slate", None);
         assert_eq!(
             filed_at(&app, "slate"),
-            Some(PathBuf::from("materials/slate.material.bsn"))
+            Some(PathBuf::from("materials/slate.bsn"))
         );
-        assert!(
-            tmp.path()
-                .join("assets/materials/slate.material.bsn")
-                .exists()
-        );
+        assert!(tmp.path().join("assets/materials/slate.bsn").exists());
     }
 
     /// Deleting leaves nothing that could still resolve: the file, the durable-name set, the
@@ -1612,17 +1767,13 @@ mod tests {
         app.world_mut()
             .resource_mut::<MaterialRegistry>()
             .add("grass".into(), handle.clone());
-        write_and_promote(app.world_mut(), &handle, Some("grass"), "grass");
+        write_and_promote(app.world_mut(), &handle, Some("grass"), "grass", None);
         // A rename leaves the old name behind as an alias; both keys have to go.
-        write_and_promote(app.world_mut(), &handle, Some("grass"), "meadow");
+        write_and_promote(app.world_mut(), &handle, Some("grass"), "meadow", None);
 
         delete_material(app.world_mut(), "meadow");
 
-        assert!(
-            !tmp.path()
-                .join("assets/materials/meadow.material.bsn")
-                .exists()
-        );
+        assert!(!tmp.path().join("assets/materials/meadow.bsn").exists());
         assert_eq!(filed_at(&app, "meadow"), None);
         assert!(
             app.world()

--- a/src/material_browser.rs
+++ b/src/material_browser.rs
@@ -1,19 +1,4 @@
-use std::path::{Path, PathBuf};
-
-use bevy::{
-    feathers::theme::ThemedText,
-    image::ImageLoaderSettings,
-    prelude::*,
-    tasks::{AsyncComputeTaskPool, Task, futures_lite::future},
-};
-use jackdaw_feathers::{
-    button::{ButtonOperatorCall, ButtonVariant, IconButtonProps, icon_button},
-    icons::{self, Icon},
-    panel_card::PanelCardCollapseState,
-    text_edit::{self, TextEditProps, TextEditValue},
-    tokens,
-};
-use path_slash::PathExt as _;
+use std::path::Path;
 
 use crate::brush::LastUsedMaterial;
 use crate::material_ui::{
@@ -28,7 +13,21 @@ use crate::{
     prelude::*,
     selection::Selection,
 };
+use bevy::{
+    feathers::theme::ThemedText,
+    image::ImageLoaderSettings,
+    prelude::*,
+    tasks::{AsyncComputeTaskPool, Task, futures_lite::future},
+};
 use jackdaw_commands::{CommandGroup, EditorCommand};
+use jackdaw_feathers::{
+    button::{ButtonOperatorCall, ButtonVariant, IconButtonProps, icon_button},
+    icons::{self, Icon},
+    panel_card::PanelCardCollapseState,
+    text_edit::{self, TextEditProps, TextEditValue},
+    tokens,
+};
+use path_slash::PathExt as _;
 
 pub struct MaterialBrowserPlugin;
 
@@ -43,7 +42,6 @@ impl Plugin for MaterialBrowserPlugin {
                 (
                     |world: &mut World| crate::asset_catalog::load_catalog(world),
                     rebuild_material_registry,
-                    |world: &mut World| crate::asset_catalog::save_catalog(world),
                 )
                     .chain()
                     .after(crate::asset_index::open_asset_index),
@@ -55,11 +53,10 @@ impl Plugin for MaterialBrowserPlugin {
                         .run_if(resource_changed::<crate::asset_index::AssetIndex>)
                         .before(rescan_material_definitions),
                     rescan_material_definitions,
-                    save_catalog_if_dirty,
                     apply_material_filter,
                     update_material_browser_ui.after(rescan_material_definitions),
                     update_preview_area,
-                    poll_material_browser_folder,
+                    poll_material_save_folder,
                 )
                     .run_if(in_state(crate::AppState::Editor)),
             )
@@ -75,7 +72,6 @@ pub use crate::material_assets::{MaterialRegistry, MaterialRegistryEntry};
 pub struct MaterialBrowserState {
     pub filter: String,
     pub needs_rescan: bool,
-    pub scan_directory: PathBuf,
 }
 
 #[derive(Event, Clone)]
@@ -97,11 +93,8 @@ pub struct MaterialBrowserGrid;
 #[derive(Component)]
 pub struct MaterialBrowserFilter;
 
-#[derive(Component)]
-struct MaterialBrowserRootLabel;
-
 #[derive(Resource)]
-struct MaterialBrowserFolderTask(Task<Option<rfd::FileHandle>>);
+struct MaterialSaveFolderTask(Task<Option<rfd::FileHandle>>);
 
 /// Fixed bar under the panel title holding the material action header. Outside the
 /// scrolling body, so the actions stay put.
@@ -111,6 +104,10 @@ struct MaterialActionBar;
 /// Container for the editing sections shown for the selected material.
 #[derive(Component)]
 struct PreviewAreaContainer;
+
+/// The file extensions the filename pattern behind [`detect_material_sets`]
+/// can match.
+const TEXTURE_EXTENSIONS: &[&str] = &["png", "jpg", "jpeg", "ktx2", "bmp", "tga", "webp"];
 
 /// Load a texture path into an `Image` handle for the given role, choosing the
 /// color space from `role.is_srgb()`.
@@ -133,12 +130,27 @@ fn load_role_image(
     }
 }
 
-/// Scan a directory for PBR texture sets. `group_texture_sets` already returns
-/// them sorted by base name.
-fn detect_material_sets(dir: &Path) -> Vec<jackdaw_material::MaterialSet> {
-    let mut paths = Vec::new();
-    collect_texture_paths(dir, &mut paths);
+/// Every PBR texture set the project's assets hold, sorted by base name.
+///
+/// The walk is the one the asset index uses, so it skips hidden directories
+/// and follows no symlink out of the tree, and it reads only the extensions
+/// the filename pattern can match.
+fn detect_material_sets(assets: &Path) -> Vec<jackdaw_material::MaterialSet> {
+    let paths: Vec<String> = jackdaw_bsn::walk_files_with_extensions(assets, TEXTURE_EXTENSIONS)
+        .into_iter()
+        .filter(|path| !is_non_2d_ktx2(path))
+        .map(|path| path.to_slash_lossy().into_owned())
+        .collect();
     jackdaw_material::group_texture_sets(&paths)
+}
+
+/// Whether a file is a KTX2 cubemap or array, which cannot bind to a
+/// `StandardMaterial` slot. The bytes the answer is read from say nothing in
+/// any other format, so only a KTX2 file is asked.
+fn is_non_2d_ktx2(path: &Path) -> bool {
+    path.extension()
+        .is_some_and(|extension| extension.eq_ignore_ascii_case("ktx2"))
+        && crate::asset_browser::is_ktx2_non_2d(path)
 }
 
 /// Bind a detected set's files to a fresh `StandardMaterial`.
@@ -193,47 +205,20 @@ fn material_from_set(
     })
 }
 
-/// Recursively walk a directory, collecting candidate texture file paths as
-/// forward-slash strings. The crate's regex is the authority on which of these
-/// actually parse into material sets; this walk only filters out non-2D KTX2
-/// files (cubemaps, texture arrays) that can't bind to a `StandardMaterial`
-/// texture slot.
-fn collect_texture_paths(dir: &Path, paths: &mut Vec<String>) {
-    let Ok(read_dir) = std::fs::read_dir(dir) else {
-        return;
-    };
-    for entry in read_dir.flatten() {
-        let path = entry.path();
-        if path.is_dir() {
-            collect_texture_paths(&path, paths);
-        } else {
-            if path
-                .extension()
-                .is_some_and(|e| e.eq_ignore_ascii_case("ktx2"))
-                && crate::asset_browser::is_ktx2_non_2d(&path)
-            {
-                continue;
-            }
-
-            paths.push(path.to_slash_lossy().into_owned());
-        }
-    }
-}
-
-/// Rebuild [`MaterialRegistry`] from the asset index plus a fresh scan of the
-/// texture sets under `assets/`.
+/// Rebuild [`MaterialRegistry`] from the asset index plus the materials that
+/// have no file behind them.
 ///
 /// Materials with a file of their own are listed first and win their base name,
-/// wherever their file sits: a detected set whose name already belongs to one is
-/// skipped. Detected sets enter the in-memory catalog (so `@Name` face
-/// references resolve and scene saves emit them) but stay unsaved until
-/// `material.save` writes a file.
+/// wherever their file sits. What is left is ephemeral: a texture set detected
+/// under the project's assets, a material created this run and never saved, or
+/// one whose file has gone. It is in memory and references to it resolve, so it
+/// is listed, marked unsaved. A detected set whose name a file already claims is
+/// left out, so saving one moves it from the detected list to the index without
+/// the two sitting side by side.
 fn rebuild_material_registry(world: &mut World) {
-    let assets_dir = world
+    let assets = world
         .get_resource::<crate::project::ProjectRoot>()
-        .map(super::project::ProjectRoot::assets_dir)
-        .unwrap_or_else(|| std::env::current_dir().unwrap_or_default().join("assets"));
-    world.resource_mut::<MaterialBrowserState>().scan_directory = assets_dir.clone();
+        .map(crate::project::ProjectRoot::assets_dir);
     world.resource_mut::<MaterialRegistry>().entries.clear();
 
     let mut saved: Vec<(String, Handle<StandardMaterial>)> = world
@@ -273,52 +258,10 @@ fn rebuild_material_registry(world: &mut World) {
             .add_saved(name, handle);
     }
 
-    let sets = detect_material_sets(&assets_dir);
-    info!(
-        "Material scan: {} detected sets in {}",
-        sets.len(),
-        assets_dir.display()
-    );
-    for set in sets {
-        // The registry key, the file stem a save would use and the `@Name` scenes reference
-        // are one string, so detection commits to the file-safe spelling up front.
-        let name = crate::material_assets::sanitize_material_name(&set.base_name);
-        if world
-            .resource::<MaterialRegistry>()
-            .get_by_name(&name)
-            .is_some()
-        {
-            continue;
-        }
-        let catalog_name = format!("@{name}");
-        // Reuse the handle a previous scan published under this name, so a rescan does not
-        // orphan the material on faces that reference it.
-        let existing = world
-            .resource::<crate::asset_catalog::AssetCatalog>()
-            .handles
-            .get(&catalog_name)
-            .filter(|handle| handle.type_id() == std::any::TypeId::of::<StandardMaterial>())
-            .map(|handle| handle.clone().typed::<StandardMaterial>());
-        let handle = match existing {
-            Some(handle) => handle,
-            None => {
-                let handle = {
-                    let asset_server = world.resource::<AssetServer>().clone();
-                    let mut materials = world.resource_mut::<Assets<StandardMaterial>>();
-                    material_from_set(&set, &asset_server, &mut materials)
-                };
-                world
-                    .resource_mut::<crate::asset_catalog::AssetCatalog>()
-                    .insert(catalog_name, handle.clone().untyped());
-                handle
-            }
-        };
-        world.resource_mut::<MaterialRegistry>().add(name, handle);
+    if let Some(assets) = assets {
+        add_detected_sets(world, &assets);
     }
 
-    // Whatever the catalog holds that neither pass claimed: a material created this run and
-    // never saved, or one whose file is gone. It is in memory and references to it resolve,
-    // so it is listed as unsaved.
     let mut orphans: Vec<(String, Handle<StandardMaterial>)> = world
         .resource::<crate::asset_catalog::AssetCatalog>()
         .handles
@@ -346,6 +289,51 @@ fn rebuild_material_registry(world: &mut World) {
     world.resource_mut::<MaterialRegistry>().ensure_none_entry();
 }
 
+/// List every texture set the project's assets hold that no material file
+/// already answers for.
+///
+/// A detected set is unsaved: it lives in `Assets<StandardMaterial>` and in the
+/// shared catalog, so a face can reference it and a scene save embeds it, until
+/// `material.save` writes it a file. The handle a previous scan published under
+/// the same name is reused, so a rescan does not orphan the material on the
+/// faces holding it.
+fn add_detected_sets(world: &mut World, assets: &Path) {
+    for set in detect_material_sets(assets) {
+        // The registry key, the file stem a save would use and the `@Name` scenes reference
+        // are one string, so detection commits to the file-safe spelling up front.
+        let name = crate::material_assets::sanitize_material_name(&set.base_name);
+        if world
+            .resource::<MaterialRegistry>()
+            .get_by_name(&name)
+            .is_some()
+        {
+            continue;
+        }
+        let catalog_name = format!("@{name}");
+        let existing = world
+            .resource::<crate::asset_catalog::AssetCatalog>()
+            .handles
+            .get(&catalog_name)
+            .filter(|handle| handle.type_id() == std::any::TypeId::of::<StandardMaterial>())
+            .map(|handle| handle.clone().typed::<StandardMaterial>());
+        let handle = match existing {
+            Some(handle) => handle,
+            None => {
+                let handle = {
+                    let asset_server = world.resource::<AssetServer>().clone();
+                    let mut materials = world.resource_mut::<Assets<StandardMaterial>>();
+                    material_from_set(&set, &asset_server, &mut materials)
+                };
+                world
+                    .resource_mut::<crate::asset_catalog::AssetCatalog>()
+                    .insert(catalog_name, handle.clone().untyped());
+                handle
+            }
+        };
+        world.resource_mut::<MaterialRegistry>().add(name, handle);
+    }
+}
+
 fn on_material_grid_added(
     _trigger: On<Add, MaterialBrowserGrid>,
     mut state: ResMut<MaterialBrowserState>,
@@ -368,17 +356,6 @@ fn rescan_material_definitions(world: &mut World) {
     rebuild_material_registry(world);
 }
 
-fn save_catalog_if_dirty(world: &mut World) {
-    let is_dirty = world
-        .get_resource::<crate::asset_catalog::AssetCatalog>()
-        .is_some_and(|c| c.dirty);
-    if !is_dirty {
-        return;
-    }
-
-    crate::asset_catalog::save_catalog(world);
-}
-
 fn apply_material_filter(
     filter_input: Query<&TextEditValue, (With<MaterialBrowserFilter>, Changed<TextEditValue>)>,
     mut state: ResMut<MaterialBrowserState>,
@@ -399,13 +376,9 @@ fn handle_apply_material(
     mut history: ResMut<CommandHistory>,
     children_query: Query<&Children>,
     mut last_material: ResMut<LastUsedMaterial>,
-    mut catalog: ResMut<crate::asset_catalog::AssetCatalog>,
     mut commands: Commands,
 ) {
     last_material.material = Some(event.material.clone());
-    // The assignment is durable in the scene, so the catalog is rewritten; an unsaved
-    // material stays flagged as needing its own save.
-    catalog.dirty = true;
 
     let active_faces: Vec<usize> = brush_selection
         .active_sub()
@@ -680,26 +653,22 @@ fn browser_actions() -> Vec<HeaderAction> {
     actions
 }
 
-fn poll_material_browser_folder(world: &mut World) {
-    let Some(mut task_res) = world.get_resource_mut::<MaterialBrowserFolderTask>() else {
+/// Take the file the Save As dialog came back with and write the previewed
+/// material there. A dismissed dialog writes nothing.
+fn poll_material_save_folder(world: &mut World) {
+    let Some(mut task_res) = world.get_resource_mut::<MaterialSaveFolderTask>() else {
         return;
     };
     let Some(result) = future::block_on(future::poll_once(&mut task_res.0)) else {
         return;
     };
-    world.remove_resource::<MaterialBrowserFolderTask>();
+    world.remove_resource::<MaterialSaveFolderTask>();
 
-    if let Some(handle) = result {
-        let path = handle.path().to_path_buf();
-        let mut state = world.resource_mut::<MaterialBrowserState>();
-        state.scan_directory = path.clone();
-        state.needs_rescan = true;
-
-        let mut label_query = world.query_filtered::<&mut Text, With<MaterialBrowserRootLabel>>();
-        for mut text in label_query.iter_mut(world) {
-            **text = path.to_string_lossy().to_string();
-        }
-    }
+    let Some(picked) = result else {
+        return;
+    };
+    let picked = picked.path().to_path_buf();
+    crate::material_assets::save_previewed_material_to(world, &picked);
 }
 
 fn update_material_browser_ui(
@@ -707,22 +676,13 @@ fn update_material_browser_ui(
     registry: Res<MaterialRegistry>,
     state: Res<MaterialBrowserState>,
     materials: Res<Assets<StandardMaterial>>,
-    project_root: Res<crate::project::ProjectRoot>,
     italic_font: Res<icons::EditorFontItalic>,
     grid_query: Query<(Entity, Option<&Children>), With<MaterialBrowserGrid>>,
-    mut root_label_query: Query<&mut Text, With<MaterialBrowserRootLabel>>,
 ) {
     let italic_font = italic_font.0.clone();
     let needs_rebuild = registry.is_changed() || state.is_changed();
     if !needs_rebuild {
         return;
-    }
-
-    for mut text in root_label_query.iter_mut() {
-        **text = project_root
-            .to_relative(&state.scan_directory)
-            .to_string_lossy()
-            .to_string();
     }
 
     let Ok((grid_entity, grid_children)) = grid_query.single() else {
@@ -804,53 +764,15 @@ pub fn material_browser_panel(icon_font: Handle<Font>) -> impl Bundle {
                 },
                 BackgroundColor(tokens::PANEL_HEADER_BG),
                 children![
-                    // Left side: title + path
                     (
-                        Node {
-                            flex_direction: FlexDirection::Row,
-                            align_items: AlignItems::Center,
-                            column_gap: Val::Px(tokens::SPACING_MD),
-                            overflow: Overflow::clip(),
-                            flex_shrink: 1.0,
+                        Text::new("Materials"),
+                        TextFont {
+                            font_size: tokens::TEXT_SIZE,
                             ..Default::default()
                         },
-                        children![
-                            (
-                                Text::new("Materials"),
-                                TextFont {
-                                    font_size: tokens::TEXT_SIZE,
-                                    ..Default::default()
-                                },
-                                ThemedText,
-                            ),
-                            (
-                                MaterialBrowserRootLabel,
-                                Node {
-                                    margin: UiRect::vertical(Val::Px(tokens::SPACING_MD)),
-                                    ..Default::default()
-                                },
-                                Text::default(),
-                                TextFont {
-                                    font_size: tokens::TEXT_SIZE_SM,
-                                    ..Default::default()
-                                },
-                                TextColor(tokens::TEXT_SECONDARY),
-                            ),
-                        ],
+                        ThemedText,
                     ),
-                    // Right side: folder picker + rescan
-                    (
-                        Node {
-                            flex_direction: FlexDirection::Row,
-                            align_items: AlignItems::Center,
-                            column_gap: Val::Px(tokens::SPACING_XS),
-                            ..Default::default()
-                        },
-                        children![
-                            material_folder_button(icon_font.clone()),
-                            rescan_button(icon_font),
-                        ],
-                    ),
+                    rescan_button(icon_font),
                 ],
             ),
             // Action header.
@@ -918,16 +840,6 @@ pub fn material_browser_panel(icon_font: Handle<Font>) -> impl Bundle {
     )
 }
 
-fn material_folder_button(icon_font: Handle<Font>) -> impl Bundle {
-    (
-        icon_button(
-            IconButtonProps::new(Icon::FolderOpen).variant(ButtonVariant::Ghost),
-            &icon_font,
-        ),
-        ButtonOperatorCall::new(MaterialSelectFolderOp::ID),
-    )
-}
-
 fn rescan_button(icon_font: Handle<Font>) -> impl Bundle {
     (
         icon_button(
@@ -945,7 +857,7 @@ pub(crate) fn add_to_extension(ctx: &mut ExtensionContext) {
         .register_operator::<MaterialSelectOp>()
         .register_operator::<MaterialApplyOp>()
         .register_operator::<MaterialRescanOp>()
-        .register_operator::<MaterialSelectFolderOp>();
+        .register_operator::<MaterialSaveAsOp>();
 }
 
 /// Create a fresh empty material and select it for preview. It stays unsaved
@@ -982,19 +894,26 @@ pub(crate) fn material_create(
     label = "Select Material",
     description = "Load a material into the material preview.",
     allows_undo = false,
-    params(material(String, doc = "Name of the material to preview."))
+    params(material(
+        String,
+        doc = "Path of the material file to preview, such as \
+               materials/slate.bsn. A bare name still resolves for one release."
+    ))
 )]
 pub(crate) fn material_select(
     params: In<OperatorParameters>,
     registry: Res<MaterialRegistry>,
+    index: Option<Res<crate::asset_index::AssetIndex>>,
     mut preview_state: ResMut<MaterialPreviewState>,
 ) -> OperatorResult {
-    let name = params.as_str("material")?;
-    let Some(entry) = registry.get_by_name(name) else {
-        warn!("material.select: no material named '{name}'");
+    let reference = params.as_str("material")?;
+    let Some(handle) =
+        crate::material_assets::material_of_reference(index.as_deref(), &registry, reference)
+    else {
+        warn!("material.select: no material at '{reference}'");
         return OperatorResult::Cancelled;
     };
-    preview_state.active_material = Some(entry.handle.clone());
+    preview_state.active_material = Some(handle);
     preview_state.orbit_yaw = 0.5;
     preview_state.orbit_pitch = -0.3;
     preview_state.zoom_distance = 3.0;
@@ -1037,11 +956,11 @@ pub(crate) fn material_apply(
     OperatorResult::Finished
 }
 
-/// Refresh the material browser from disk.
+/// Refresh the material browser from what the project holds.
 #[operator(
     id = "material.rescan",
     label = "Rescan Materials",
-    description = "Refresh the material browser from disk."
+    description = "Refresh the material browser from the project's asset files."
 )]
 pub(crate) fn material_rescan(
     _: In<OperatorParameters>,
@@ -1051,24 +970,29 @@ pub(crate) fn material_rescan(
     OperatorResult::Finished
 }
 
-/// Choose a different folder as the materials directory.
+/// Choose the file the previewed material saves to, starting where a save
+/// with no folder in mind would put it.
 #[operator(
-    id = "material.select_folder",
-    label = "Select Materials Folder",
-    description = "Choose a different folder as the materials directory."
+    id = "material.save_as",
+    label = "Save Material As",
+    description = "Choose the file to write this material to.",
+    allows_undo = false
 )]
-pub fn material_select_folder(_: In<OperatorParameters>, mut commands: Commands) -> OperatorResult {
+pub fn material_save_as(_: In<OperatorParameters>, mut commands: Commands) -> OperatorResult {
     commands.queue(|world: &mut World| {
-        if world.contains_resource::<MaterialBrowserFolderTask>() {
+        if world.contains_resource::<MaterialSaveFolderTask>() {
             return;
         }
-        let current = world
-            .get_resource::<MaterialBrowserState>()
-            .map(|state| state.scan_directory.clone());
-        let dialog = crate::native_dialog::dialog_starting_at(world, current)
-            .set_title("Select materials directory");
-        let task = AsyncComputeTaskPool::get().spawn(async move { dialog.pick_folder().await });
-        world.insert_resource(MaterialBrowserFolderTask(task));
+        let Some((folder, file_name)) = crate::material_assets::previewed_material_target(world)
+        else {
+            warn!("material.save_as: no material to save");
+            return;
+        };
+        let dialog = crate::native_dialog::dialog_starting_at(world, Some(folder))
+            .set_title("Save material")
+            .set_file_name(file_name);
+        let task = AsyncComputeTaskPool::get().spawn(async move { dialog.save_file().await });
+        world.insert_resource(MaterialSaveFolderTask(task));
     });
     OperatorResult::Finished
 }
@@ -1123,6 +1047,16 @@ mod tests {
             scalars.max_parallax_layer_count
         );
         assert!(material.parallax_depth_scale > 0.0);
+    }
+
+    #[test]
+    fn a_detected_set_with_no_height_map_leaves_parallax_off() {
+        let mut app = browser_app();
+        let material = built(&mut app, &detected(&["pack/rock_albedo.png"]));
+
+        assert!(material.depth_map.is_none());
+        assert_eq!(material.parallax_depth_scale, 0.0);
+        assert_eq!(material.max_parallax_layer_count, 0.0);
     }
 
     /// The preview's drag observer lives inside the subtree a rebuild despawns, and the
@@ -1204,16 +1138,6 @@ mod tests {
         );
     }
 
-    #[test]
-    fn a_detected_set_with_no_height_map_leaves_parallax_off() {
-        let mut app = browser_app();
-        let material = built(&mut app, &detected(&["pack/rock_albedo.png"]));
-
-        assert!(material.depth_map.is_none());
-        assert_eq!(material.parallax_depth_scale, 0.0);
-        assert_eq!(material.max_parallax_layer_count, 0.0);
-    }
-
     fn project_browser_app() -> (App, tempfile::TempDir) {
         let tmp = tempfile::tempdir().expect("tempdir");
         let mut app = browser_app();
@@ -1240,6 +1164,72 @@ mod tests {
                 StandardMaterial::type_path(),
             ));
         (app, tmp)
+    }
+
+    /// A PNG's bytes are not a KTX2 header, and the fields that say a KTX2
+    /// holds a cubemap land on picture data in one.
+    #[test]
+    fn a_texture_that_is_not_a_ktx2_is_never_read_as_a_cubemap() {
+        let (mut app, tmp) = project_browser_app();
+        let textures = tmp.path().join("assets/textures");
+        std::fs::create_dir_all(&textures).expect("the folder is made");
+        for file in ["moss_albedo.png", "moss_normal.png"] {
+            std::fs::write(textures.join(file), [0xffu8; 64]).expect("the texture is written");
+        }
+
+        rebuild_material_registry(app.world_mut());
+
+        assert!(
+            app.world()
+                .resource::<MaterialRegistry>()
+                .get_by_name("moss")
+                .is_some(),
+            "the set is offered whatever its picture data reads as"
+        );
+    }
+
+    /// Drop a folder of consistently named textures anywhere under the assets
+    /// and the panel offers it as a material to save; once it has a file of its
+    /// own the index carries it and the detected entry goes.
+    #[test]
+    fn a_texture_set_in_any_folder_is_offered_unsaved_until_it_has_a_file() {
+        let (mut app, tmp) = project_browser_app();
+        let textures = tmp.path().join("assets/models/kit/bark");
+        std::fs::create_dir_all(&textures).expect("the folder is made");
+        for file in ["bark_albedo.png", "bark_normal.png", "bark_roughness.png"] {
+            std::fs::write(textures.join(file), [0xffu8; 64]).expect("the texture is written");
+        }
+
+        crate::asset_index::rescan_asset_index(app.world_mut());
+        rebuild_material_registry(app.world_mut());
+
+        let entry = app
+            .world()
+            .resource::<MaterialRegistry>()
+            .get_by_name("bark")
+            .expect("the set is offered as a material");
+        assert!(!entry.saved, "a detected set has no file behind it yet");
+        let handle = entry.handle.clone();
+
+        crate::material_assets::write_material_file(app.world(), "bark", &handle)
+            .expect("the material file is written");
+        crate::asset_index::rescan_asset_index(app.world_mut());
+        rebuild_material_registry(app.world_mut());
+
+        let registry = app.world().resource::<MaterialRegistry>();
+        assert!(
+            registry.is_saved("bark"),
+            "the file the save wrote is what the panel lists now",
+        );
+        assert_eq!(
+            registry
+                .entries
+                .iter()
+                .filter(|entry| entry.name == "bark")
+                .count(),
+            1,
+            "the detected set must not sit beside the file it became",
+        );
     }
 
     /// The panel lists what the index holds, so a material filed anywhere under
@@ -1290,8 +1280,7 @@ mod tests {
             "a material with a file behind it is saved",
         );
 
-        std::fs::remove_file(tmp.path().join("assets/materials/slate.material.bsn"))
-            .expect("remove");
+        std::fs::remove_file(tmp.path().join("assets/materials/slate.bsn")).expect("remove");
         crate::asset_index::rescan_asset_index(app.world_mut());
         rebuild_material_registry(app.world_mut());
 

--- a/src/material_ui.rs
+++ b/src/material_ui.rs
@@ -314,8 +314,8 @@ fn bind_texture_slot(
         slot.set_on(&mut value, image);
     }
     world
-        .resource_mut::<crate::asset_catalog::AssetCatalog>()
-        .dirty = true;
+        .get_resource_or_init::<crate::material_assets::EditedMaterials>()
+        .edited(material);
     world.resource_mut::<MaterialPreviewState>().set_changed();
     true
 }
@@ -409,7 +409,7 @@ pub(crate) fn on_material_slider_commit(
     event: On<ValueChange<f32>>,
     mut bindings: Query<&mut MaterialFieldBinding>,
     mut materials: ResMut<Assets<StandardMaterial>>,
-    catalog: Option<ResMut<crate::asset_catalog::AssetCatalog>>,
+    edited: Option<ResMut<crate::material_assets::EditedMaterials>>,
     mut commands: Commands,
 ) {
     let slider = event.source;
@@ -423,7 +423,7 @@ pub(crate) fn on_material_slider_commit(
     }
     binding.shown = value;
     if event.is_final {
-        mark_catalog_dirty(catalog);
+        material_edited(edited, &binding.material_handle);
     }
 }
 
@@ -503,35 +503,38 @@ fn holds_focus(entity: Entity, focus: &InputFocus, child_of: &Query<&ChildOf>) -
             .any(|ancestor| ancestor == entity)
 }
 
-/// Flag the catalog once a material slider's drag has ended, however it ended.
+/// Write a material back once a slider's drag has ended, however it ended.
 ///
-/// [`on_material_slider_commit`] persists on the final `ValueChange` that closes an ordinary
+/// [`on_material_slider_commit`] writes on the final `ValueChange` that closes an ordinary
 /// drag. A drag that ends any other way (the pointer leaving the window, the widget disabled
 /// mid-gesture, the gesture cancelled) emits no final event, so the edit would sit in memory
-/// until something else dirties the catalog. The end is detected from the drag state, since
+/// until something else wrote the material. The end is detected from the drag state, since
 /// there is no event to read.
 fn flush_material_slider_drag(
     mut fields: Query<(&mut MaterialFieldBinding, Option<&SliderDragState>)>,
-    catalog: Option<ResMut<crate::asset_catalog::AssetCatalog>>,
+    mut edited: Option<ResMut<crate::material_assets::EditedMaterials>>,
 ) {
-    let mut ended = false;
     for (mut binding, drag) in &mut fields {
         let dragging = drag.is_some_and(|drag| drag.dragging);
         if binding.dragging == dragging {
             continue;
         }
-        ended |= binding.dragging;
+        if binding.dragging
+            && let Some(edited) = edited.as_mut()
+        {
+            edited.edited(&binding.material_handle);
+        }
         binding.dragging = dragging;
-    }
-    if ended {
-        mark_catalog_dirty(catalog);
     }
 }
 
-/// Schedule the catalog and the edited material's file to be rewritten.
-fn mark_catalog_dirty(catalog: Option<ResMut<crate::asset_catalog::AssetCatalog>>) {
-    if let Some(mut catalog) = catalog {
-        catalog.dirty = true;
+/// Schedule the edited material's file to be rewritten.
+fn material_edited(
+    edited: Option<ResMut<crate::material_assets::EditedMaterials>>,
+    handle: &Handle<StandardMaterial>,
+) {
+    if let Some(mut edited) = edited {
+        edited.edited(handle);
     }
 }
 
@@ -579,7 +582,7 @@ pub(crate) fn on_material_checkbox_commit(
     event: On<ValueChange<bool>>,
     bindings: Query<&MaterialCheckboxBinding>,
     mut materials: ResMut<Assets<StandardMaterial>>,
-    catalog: Option<ResMut<crate::asset_catalog::AssetCatalog>>,
+    edited: Option<ResMut<crate::material_assets::EditedMaterials>>,
     mut commands: Commands,
 ) {
     let target = event.source;
@@ -591,7 +594,7 @@ pub(crate) fn on_material_checkbox_commit(
     if let Some(mut material) = materials.get_mut(&binding.material_handle) {
         (binding.apply_fn)(&mut material, checked);
     }
-    mark_catalog_dirty(catalog);
+    material_edited(edited, &binding.material_handle);
 }
 
 // ---------------------------------------------------------------------------
@@ -967,8 +970,14 @@ pub(crate) fn library_actions() -> Vec<HeaderAction> {
         HeaderAction::new(
             Icon::Save,
             "Save Material",
-            "Write this material to assets/materials as a reusable asset.",
+            "Write this material to a file of its own as a reusable asset.",
             ButtonOperatorCall::new(crate::material_assets::MaterialSaveOp::ID),
+        ),
+        HeaderAction::new(
+            Icon::FolderOpen,
+            "Save Material As",
+            "Choose the file to write this material to.",
+            ButtonOperatorCall::new(crate::material_browser::MaterialSaveAsOp::ID),
         ),
         HeaderAction::new(
             Icon::Trash2,
@@ -1554,15 +1563,22 @@ mod scalar_commit_tests {
         let mut app = App::new();
         app.add_plugins((bevy::app::TaskPoolPlugin::default(), AssetPlugin::default()));
         app.init_asset::<StandardMaterial>();
-        app.init_resource::<crate::asset_catalog::AssetCatalog>();
+        app.init_resource::<crate::material_assets::EditedMaterials>();
         app.add_observer(on_material_slider_commit);
         app
     }
 
-    fn catalog_is_dirty(app: &App) -> bool {
-        app.world()
-            .resource::<crate::asset_catalog::AssetCatalog>()
-            .dirty
+    /// Whether the material is queued to be written back to its file.
+    fn is_queued_for_writing(app: &App) -> bool {
+        !app.world()
+            .resource::<crate::material_assets::EditedMaterials>()
+            .is_empty()
+    }
+
+    fn clear_queue(app: &mut App) {
+        app.world_mut()
+            .resource_mut::<crate::material_assets::EditedMaterials>()
+            .clear();
     }
 
     /// A slider entity carrying the binding a spawned row would have.
@@ -1657,10 +1673,10 @@ mod scalar_commit_tests {
         assert!((metallic - 0.4).abs() < 1e-5, "got {metallic}");
     }
 
-    /// Dirtying the catalog schedules the material's file and `catalog.bsn` to be rewritten,
-    /// and a drag emits an event per frame.
+    /// Queueing a material schedules its file to be rewritten, and a drag emits an
+    /// event per frame.
     #[test]
-    fn a_value_mid_drag_leaves_the_catalog_clean() {
+    fn a_value_mid_drag_queues_no_write() {
         let mut app = commit_app();
         let handle = app
             .world_mut()
@@ -1673,7 +1689,7 @@ mod scalar_commit_tests {
         }
 
         assert!(
-            !catalog_is_dirty(&app),
+            !is_queued_for_writing(&app),
             "an unfinished drag schedules no write",
         );
         let metallic = app
@@ -1689,7 +1705,7 @@ mod scalar_commit_tests {
     }
 
     #[test]
-    fn the_end_of_a_drag_dirties_the_catalog() {
+    fn the_end_of_a_drag_queues_the_write() {
         let mut app = commit_app();
         let handle = app
             .world_mut()
@@ -1698,16 +1714,16 @@ mod scalar_commit_tests {
         let slider = bound_slider(&mut app, handle);
 
         drag_to(&mut app, slider, 0.4, false);
-        assert!(!catalog_is_dirty(&app));
+        assert!(!is_queued_for_writing(&app));
 
         drag_to(&mut app, slider, 0.5, true);
-        assert!(catalog_is_dirty(&app), "the finished edit persists");
+        assert!(is_queued_for_writing(&app), "the finished edit persists");
     }
 
     /// A drag can end without the final event that normally persists it: the pointer leaves
     /// the window, the widget is disabled mid-gesture, the gesture is cancelled.
     #[test]
-    fn a_drag_that_ends_without_a_final_event_still_flags_the_catalog() {
+    fn a_drag_that_ends_without_a_final_event_still_queues_the_write() {
         let mut app = commit_app();
         app.add_systems(Update, flush_material_slider_drag);
         let handle = app
@@ -1724,21 +1740,19 @@ mod scalar_commit_tests {
         drag_to(&mut app, slider, 0.6, false);
         app.update();
         assert!(
-            !catalog_is_dirty(&app),
+            !is_queued_for_writing(&app),
             "a drag in progress is not worth a pair of disk writes a frame",
         );
 
         set_dragging(&mut app, slider, false);
         app.update();
-        assert!(catalog_is_dirty(&app), "the abandoned edit persists");
+        assert!(is_queued_for_writing(&app), "the abandoned edit persists");
 
-        app.world_mut()
-            .resource_mut::<crate::asset_catalog::AssetCatalog>()
-            .dirty = false;
+        clear_queue(&mut app);
         app.update();
         app.update();
         assert!(
-            !catalog_is_dirty(&app),
+            !is_queued_for_writing(&app),
             "the flush fires once per drag, not every frame after one",
         );
     }

--- a/src/scene_io/save.rs
+++ b/src/scene_io/save.rs
@@ -363,9 +363,6 @@ pub(crate) fn save_scene_inner(world: &mut World) -> Result<(), BevyError> {
         }
     }
 
-    // Save catalog alongside scene if dirty
-    crate::asset_catalog::save_catalog(world);
-
     // Persist current editor layout to project.jsn
     save_layout_to_project(world);
 

--- a/src/terrain/panel.rs
+++ b/src/terrain/panel.rs
@@ -1408,7 +1408,7 @@ fn spawn_slot_editor(
     refs: &TexturesTabRefs,
 ) {
     let icon_font = refs.icon_font.0.clone();
-    let name = crate::material_assets::material_name_of(&slot.material);
+    let name = jackdaw_bsn::asset_stem(&slot.material);
     let handle = crate::material_assets::material_of_reference(
         refs.index.as_deref(),
         &refs.registry,

--- a/src/terrain/texture_ops.rs
+++ b/src/terrain/texture_ops.rs
@@ -176,7 +176,7 @@ fn slot_reference(
     registry: &MaterialRegistry,
     named: &str,
 ) -> Result<String, TerrainMaterialError> {
-    let name = crate::material_assets::material_name_of(named);
+    let name = jackdaw_bsn::asset_stem(named);
     if let Some(entry) =
         index.and_then(|index| crate::material_assets::material_file_of(index, named))
     {

--- a/tests/operators/operator_smoke.rs
+++ b/tests/operators/operator_smoke.rs
@@ -7,7 +7,7 @@ use crate::util;
 
 use jackdaw::asset_browser::AssetSelectFolderOp;
 use jackdaw::entity_ops::{EntityAddImageOp, EntityAddPrefabOp};
-use jackdaw::material_browser::MaterialSelectFolderOp;
+use jackdaw::material_browser::MaterialSaveAsOp;
 use jackdaw::scene_ops::{SceneSaveAsOp, SceneSaveOp};
 use jackdaw::scenes::operators::SceneOpenOp;
 use jackdaw_api::prelude::*;
@@ -37,7 +37,7 @@ const SMOKE_SKIP_LIST: &[SkipOp] = &[
         "falls through to scene.save_as (native dialog) when no SceneFilePath is set",
     ),
     SkipOp::new::<AssetSelectFolderOp>("spawns native folder picker"),
-    SkipOp::new::<MaterialSelectFolderOp>("spawns native folder picker"),
+    SkipOp::new::<MaterialSaveAsOp>("spawns native file-save dialog"),
     SkipOp::new::<EntityAddImageOp>("spawns native image-file picker"),
     SkipOp::new::<EntityAddPrefabOp>("spawns native prefab-file picker"),
 ];

--- a/tests/scenes/jsn_to_bsn.rs
+++ b/tests/scenes/jsn_to_bsn.rs
@@ -694,56 +694,42 @@ fn editor_opens_and_saves_bsn_scenes() {
     assert!(find_by_name(app2.world_mut(), "Hero").is_some());
 }
 
+/// The catalog file is only read now, so what an older build wrote has to keep
+/// loading as the assets it names.
 #[test]
-fn catalog_round_trips_as_bsn() {
-    use jackdaw::asset_catalog::{AssetCatalog, load_catalog, save_catalog};
+fn a_catalog_written_before_assets_had_files_still_loads() {
+    use jackdaw::asset_catalog::{AssetCatalog, load_catalog};
     use jackdaw::project::ProjectRoot;
 
     let dir = tempfile::tempdir().expect("tempdir");
-    std::fs::create_dir_all(dir.path().join(".jsn")).unwrap();
+    std::fs::create_dir_all(dir.path().join("assets")).unwrap();
+    std::fs::write(
+        dir.path().join("assets/catalog.bsn"),
+        "#Steel\nbevy_pbr::pbr_material::StandardMaterial { metallic: 0.75 }\n",
+    )
+    .unwrap();
 
-    fn project_app(root: &std::path::Path) -> App {
-        let mut app = headless_app();
-        app.init_resource::<AssetCatalog>();
-        // Saving and loading a catalog both go through the material files,
-        // which this minimal app has to supply the bookkeeping for.
-        app.init_resource::<jackdaw::material_assets::MaterialRegistry>();
-        app.world_mut().insert_resource(ProjectRoot::new(
-            root.to_path_buf(),
-            jackdaw::project::ProjectConfig::default(),
-        ));
-        app
-    }
+    let mut app = headless_app();
+    app.init_resource::<AssetCatalog>();
+    app.init_resource::<jackdaw::material_assets::MaterialRegistry>();
+    app.world_mut().insert_resource(ProjectRoot::new(
+        dir.path().to_path_buf(),
+        jackdaw::project::ProjectConfig::default(),
+    ));
 
-    let mut app = project_app(dir.path());
-    let handle = app
-        .world_mut()
-        .resource_mut::<Assets<StandardMaterial>>()
-        .add(StandardMaterial {
-            metallic: 0.75,
-            ..Default::default()
-        })
-        .untyped();
-    {
-        let mut catalog = app.world_mut().resource_mut::<AssetCatalog>();
-        catalog.insert("@Steel".to_string(), handle);
-        catalog.dirty = true;
-    }
-    save_catalog(app.world_mut());
+    load_catalog(app.world_mut());
 
-    let catalog_path = dir.path().join("assets/catalog.bsn");
-    let text = std::fs::read_to_string(&catalog_path).expect("catalog.bsn written");
-    assert!(text.contains("#Steel"), "{text}");
-    assert!(text.contains("metallic"), "{text}");
-
-    let mut app2 = project_app(dir.path());
-    load_catalog(app2.world_mut());
-    let catalog = app2.world().resource::<AssetCatalog>();
-    let loaded = catalog.handles.get("@Steel").expect("catalog entry loaded");
-    let material = app2
+    let loaded = app
+        .world()
+        .resource::<AssetCatalog>()
+        .handles
+        .get("@Steel")
+        .expect("catalog entry loaded")
+        .clone();
+    let material = app
         .world()
         .resource::<Assets<StandardMaterial>>()
-        .get(&loaded.clone().typed::<StandardMaterial>())
+        .get(&loaded.typed::<StandardMaterial>())
         .expect("material in store");
     assert!((material.metallic - 0.75).abs() < 1e-6);
 }

--- a/tests/stage/definition_assets.rs
+++ b/tests/stage/definition_assets.rs
@@ -598,7 +598,7 @@ fn a_material_file_is_not_deleted_through_the_definition_operator() {
         .add(StandardMaterial::default());
     jackdaw::material_assets::write_material_file(app.world(), "slate", &handle)
         .expect("the material file is written");
-    let path = tmp.path().join("assets/materials/slate.material.bsn");
+    let path = tmp.path().join("assets/materials/slate.bsn");
 
     call(
         &mut app,
@@ -656,16 +656,12 @@ fn a_material_file_is_indexed_alongside_every_other_kind() {
         });
     jackdaw::material_assets::write_material_file(app.world(), "slate", &handle)
         .expect("the material file is written");
-    assert!(
-        tmp.path()
-            .join("assets/materials/slate.material.bsn")
-            .is_file()
-    );
+    assert!(tmp.path().join("assets/materials/slate.bsn").is_file());
 
     let scan = jackdaw::asset_index::rescan_asset_index(app.world_mut());
     assert_eq!(
         scan.added,
-        vec![std::path::PathBuf::from("materials/slate.material.bsn")]
+        vec![std::path::PathBuf::from("materials/slate.bsn")]
     );
 
     let entry_path = app
@@ -675,10 +671,7 @@ fn a_material_file_is_indexed_alongside_every_other_kind() {
         .map(|entry| entry.path.clone())
         .next()
         .expect("the material lists like any other asset");
-    assert_eq!(
-        entry_path,
-        std::path::PathBuf::from("materials/slate.material.bsn")
-    );
+    assert_eq!(entry_path, std::path::PathBuf::from("materials/slate.bsn"));
 }
 
 #[test]
@@ -693,7 +686,7 @@ fn a_material_saved_by_its_own_operator_carries_what_asset_set_wrote() {
     call(
         &mut app,
         "asset.open",
-        &[("path", "assets/materials/slate.material.bsn".into())],
+        &[("path", "assets/materials/slate.bsn".into())],
     );
     call(
         &mut app,
@@ -703,7 +696,7 @@ fn a_material_saved_by_its_own_operator_carries_what_asset_set_wrote() {
     call(&mut app, "material.save", &[("material", "slate".into())]);
     app.update();
 
-    let written = std::fs::read_to_string(tmp.path().join("assets/materials/slate.material.bsn"))
+    let written = std::fs::read_to_string(tmp.path().join("assets/materials/slate.bsn"))
         .expect("the file reads");
     assert!(written.contains("metallic: 0.75"), "got:\n{written}");
 }
@@ -722,7 +715,7 @@ fn a_material_is_opened_and_its_fields_set_through_the_definition_operators() {
     call(
         &mut app,
         "asset.open",
-        &[("path", "assets/materials/slate.material.bsn".into())],
+        &[("path", "assets/materials/slate.bsn".into())],
     );
     call(
         &mut app,
@@ -744,7 +737,7 @@ fn a_material_is_opened_and_its_fields_set_through_the_definition_operators() {
         (roughness - 0.25).abs() < f32::EPSILON,
         "the edit lands on the loaded material, not on a copy"
     );
-    let written = std::fs::read_to_string(tmp.path().join("assets/materials/slate.material.bsn"))
+    let written = std::fs::read_to_string(tmp.path().join("assets/materials/slate.bsn"))
         .expect("the file reads");
     assert!(
         written.contains("perceptual_roughness: 0.25"),
@@ -766,7 +759,7 @@ fn asset_set_fills_a_texture_slot_from_a_path_and_the_save_keeps_it() {
     call(
         &mut app,
         "asset.open",
-        &[("path", "assets/materials/slate.material.bsn".into())],
+        &[("path", "assets/materials/slate.bsn".into())],
     );
     call(
         &mut app,
@@ -795,7 +788,7 @@ fn asset_set_fills_a_texture_slot_from_a_path_and_the_save_keeps_it() {
         Some("textures/slate_base.png".to_string()),
         "the slot names the image the caller asked for, whether or not it is there yet"
     );
-    let written = std::fs::read_to_string(tmp.path().join("assets/materials/slate.material.bsn"))
+    let written = std::fs::read_to_string(tmp.path().join("assets/materials/slate.bsn"))
         .expect("the file reads");
     assert!(
         written.contains("textures/slate_base.png"),
@@ -817,7 +810,7 @@ fn asset_set_takes_a_colour_as_channels_and_undo_puts_the_old_one_back() {
     call(
         &mut app,
         "asset.open",
-        &[("path", "assets/materials/slate.material.bsn".into())],
+        &[("path", "assets/materials/slate.bsn".into())],
     );
     call(
         &mut app,


### PR DESCRIPTION
Materials, animation graphs and catalog.bsn were still handled outside the asset model, so a project carried three different ideas of where an asset lives.

The Materials panel and the Graph window now list what the asset index holds, catalog.bsn is read but never written, and project.migrate_asset_references brings an existing project's references, headers and terrain sidecars up to date.

LLM disclaimer: Claude Code was used to help plan and implement this change, but all code was human reviewed by myself!
