### PR TITLE
Add a binary form for BSN files

### DIFF
--- a/book/src/developer-guide/bsn-format.md
+++ b/book/src/developer-guide/bsn-format.md
@@ -5,12 +5,47 @@ scenes. It is a reflection-based notation: each entity lists
 its components by full type path, with values in a compact
 struct / enum / tuple syntax that round-trips through Bevy's
 reflect system. Scene files are human-readable and
-line-diffable in git.
+line-diffable in git, and every document has a binary twin
+for the cases where that does not matter (see
+[Binary form](#binary-form)).
 
 The parser and scene document live in `crates/jackdaw_bsn`.
 The live in-editor document is the BSN AST (`SceneBsnAst`);
 saving writes it back out as `.bsn` text. Source of truth for
 the grammar is that crate; this page is the orientation.
+
+## Binary form
+
+The same document also writes as `.bsb`, a binary encoding of the
+roots, patches and values the text holds, with the comment lines it
+opens with carried as a field. It exists for two cases: a shipped
+game, where nobody reads the assets, and a file so large that nobody
+diffs it. Text stays the form a repository keeps.
+
+Readers never go by the extension. A document is binary when its first
+four bytes are the magic, whose leading byte is a UTF-8 continuation
+byte that no text file can start with, so the two forms can never be
+mistaken for each other. `jackdaw_bsn::read_document` sniffs and
+returns either; `read_document_text` hands back `.bsn` text whichever
+form the file was in. The comment lines a document opens with travel in
+the binary form verbatim, so the asset header and the version stamp come
+back on the text a conversion writes.
+
+Writers go the other way: the extension picks the form, which is how a
+save keeps a file in the form it was opened in. The editor's file
+context menus offer Convert to Binary and Convert to Text on one
+document, each removing the other form once the new one is written and
+refusing outright when a file already sits where it would write, and
+`project.export_binary` writes a whole tree out as binary beside the
+source, copying every other file through untouched. An export into the
+source tree, or into a folder inside it, is refused rather than left to
+walk over what it just wrote.
+
+A pair is one asset. `foo.bsn` and `foo.bsb` are keyed by the `.bsn`
+path, the text file wins when both exist, and a reference to
+`materials/grass.bsn` resolves to `grass.bsb` when that is the only
+form on disk. References are never rewritten by an export; the readers
+that follow them resolve either form instead.
 
 ## Legacy JSN import
 
@@ -140,11 +175,12 @@ with no folder in mind puts one.
 ## Asset files in a game
 
 The runtime reads the project's asset files itself: at startup it walks
-every `.bsn` under the asset folder, takes the type each file holds
-from its header or its first root, and loads the ones whose type the
-game registered as a reflected asset into that type's store. A file is
-reachable by the path it sits at, and, while a project still spells
-references by name, by its stem where only one file carries that stem.
+every document under the asset folder, in either form, takes the type
+each file holds from its header or its first root, and loads the ones
+whose type the game registered as a reflected asset into that type's
+store. A file is reachable by the path it sits at, and, while a project
+still spells references by name, by its stem where only one file
+carries that stem.
 A file naming a type the game has not registered is skipped with a
 warning; scenes and prefabs are left to the loaders that own them.
 

--- a/crates/jackdaw_animation_runtime/src/graph.rs
+++ b/crates/jackdaw_animation_runtime/src/graph.rs
@@ -476,21 +476,21 @@ impl AssetLoader for AnimationGraphLoader {
         &self,
         reader: &mut dyn Reader,
         _settings: &Self::Settings,
-        _load_context: &mut LoadContext<'_>,
+        load_context: &mut LoadContext<'_>,
     ) -> Result<Self::Asset, Self::Error> {
         let mut bytes = Vec::new();
         reader
             .read_to_end(&mut bytes)
             .await
             .map_err(|err| AnimationGraphLoadError::Io(err.to_string()))?;
-        let text = std::str::from_utf8(&bytes)
+        let text = jackdaw_bsn::document_text_from_bytes(&bytes, load_context.path().path())
             .map_err(|err| AnimationGraphLoadError::Parse(err.to_string()))?;
-        let def = parse_animation_graph(text, &self.registry.read())?;
+        let def = parse_animation_graph(&text, &self.registry.read())?;
         Ok(AnimationGraphAsset { def })
     }
 
     fn extensions(&self) -> &[&str] {
-        &["animgraph.bsn"]
+        &["animgraph.bsn", "animgraph.bsb"]
     }
 }
 

--- a/crates/jackdaw_animation_runtime/tests/animation_graphs.rs
+++ b/crates/jackdaw_animation_runtime/tests/animation_graphs.rs
@@ -499,6 +499,63 @@ fn an_any_state_transition_fires_from_every_state() {
 }
 
 #[test]
+fn a_graph_file_saved_in_the_binary_form_reads_back_through_the_loader() {
+    let dir = tempfile::tempdir().expect("a directory to save into");
+    let text = "\
+jackdaw_animation_runtime::graph::AnimationGraphDef {
+    entry: \"idle\",
+    states: [
+        jackdaw_animation_runtime::graph::AnimationGraphState {
+            name: \"idle\",
+            motion: jackdaw_animation_runtime::graph::AnimationMotion::Clip(
+                jackdaw_animation_runtime::graph::AnimationClipRef {
+                    source: \"rig.glb\",
+                    clip: \"Idle\",
+                },
+            ),
+        },
+    ],
+}
+";
+    jackdaw_bsn::write_document_text(&dir.path().join("rig.animgraph.bsb"), text)
+        .expect("the file is written");
+
+    let mut app = App::new();
+    app.add_plugins(MinimalPlugins)
+        .add_plugins(AssetPlugin {
+            file_path: dir.path().to_string_lossy().into_owned(),
+            ..AssetPlugin::default()
+        })
+        .add_plugins(bevy::transform::TransformPlugin)
+        .add_plugins(bevy::animation::AnimationPlugin)
+        .add_plugins(AnimationRuntimePlugin);
+
+    let handle: Handle<AnimationGraphAsset> = app
+        .world()
+        .resource::<AssetServer>()
+        .load("rig.animgraph.bsb");
+    let mut loaded = None;
+    for _ in 0..200 {
+        app.update();
+        if let Some(asset) = app
+            .world()
+            .resource::<Assets<AnimationGraphAsset>>()
+            .get(&handle)
+        {
+            loaded = Some(asset.def.clone());
+            break;
+        }
+        std::thread::sleep(millis(5));
+    }
+
+    assert_eq!(
+        loaded.expect("the binary graph file loads").entry,
+        "idle",
+        "the loader that owns .animgraph.bsn owns its binary twin too"
+    );
+}
+
+#[test]
 fn a_saved_graph_file_reads_back_through_the_loader() {
     let dir = tempfile::tempdir().expect("a directory to save into");
     let text = r#"

--- a/crates/jackdaw_bsn/src/binary.rs
+++ b/crates/jackdaw_bsn/src/binary.rs
@@ -1,0 +1,466 @@
+//! Binary form of a BSN document: the same document the text parser builds,
+//! written as a compact self-describing byte stream.
+//!
+//! Text stays the form a repository keeps. The binary form is for a shipped
+//! game's export and for large files nobody diffs, so it holds exactly what
+//! the text holds: the leading comment lines that carry the asset header and
+//! the version stamp, the document roots, their patches and their values.
+//! [`is_binary`] tells the two apart from the first four bytes, which lets
+//! every reader sniff rather than trust an extension.
+
+use bevy::ecs::entity::Entity;
+
+use crate::document::{
+    BsnField, BsnPatch, BsnStructData, BsnStructFields, BsnTupleStructData, BsnValue,
+    MAX_AST_DEPTH, SceneBsnAst,
+};
+
+/// The four bytes every binary BSN document starts with.
+///
+/// The first byte is a UTF-8 continuation byte, which no text document can
+/// begin with, so sniffing never mistakes one form for the other.
+pub const MAGIC: [u8; 4] = [0x89, b'B', b'S', b'B'];
+
+/// The format version this build writes.
+pub const VERSION: u16 = 1;
+
+const PATCH_NAME: u8 = 0;
+const PATCH_BASE: u8 = 1;
+const PATCH_TYPE: u8 = 2;
+const PATCH_STRUCT: u8 = 3;
+const PATCH_TUPLE_STRUCT: u8 = 4;
+const PATCH_TEMPLATE: u8 = 5;
+const PATCH_CHILDREN: u8 = 6;
+
+const VALUE_FLOAT: u8 = 0;
+const VALUE_INT: u8 = 1;
+const VALUE_BOOL: u8 = 2;
+const VALUE_STRING: u8 = 3;
+const VALUE_TYPE: u8 = 4;
+const VALUE_STRUCT: u8 = 5;
+const VALUE_TUPLE_STRUCT: u8 = 6;
+const VALUE_LIST: u8 = 7;
+const VALUE_MAP: u8 = 8;
+
+/// A document read back out of its binary form.
+#[derive(Default)]
+pub struct DecodedDocument {
+    /// The document itself.
+    pub ast: SceneBsnAst,
+    /// The comment lines the text form opens with, verbatim.
+    pub preamble: Option<String>,
+}
+
+/// Why a run of bytes did not read as a binary BSN document.
+#[derive(Debug, thiserror::Error)]
+pub enum BinaryError {
+    /// The first bytes are not [`MAGIC`].
+    #[error("not a binary BSN document: the first bytes are not {:?}", MAGIC)]
+    BadMagic,
+    /// The document was written by a later format than this build reads.
+    #[error("binary BSN version {0} is newer than the supported {VERSION}")]
+    UnsupportedVersion(u16),
+    /// The bytes ran out mid-value.
+    #[error("binary BSN document ends early")]
+    Truncated,
+    /// A tag byte named no patch or value this format has.
+    #[error("binary BSN document holds an unknown {kind} tag {tag}")]
+    UnknownTag {
+        /// Whether the tag was read as a patch or as a value.
+        kind: &'static str,
+        /// The byte that named nothing.
+        tag: u8,
+    },
+    /// A string field held bytes that are not UTF-8.
+    #[error("binary BSN document holds text that is not UTF-8")]
+    NotUtf8,
+    /// The document's `Children` nesting ran past the walk's cap.
+    #[error("binary BSN document nests deeper than {MAX_AST_DEPTH}")]
+    TooDeep,
+}
+
+/// Whether these bytes open with [`MAGIC`].
+pub fn is_binary(bytes: &[u8]) -> bool {
+    bytes.starts_with(&MAGIC)
+}
+
+/// Write a document and the comment lines it opens with as binary.
+pub fn encode(ast: &SceneBsnAst, preamble: Option<&str>) -> Vec<u8> {
+    let mut out = Vec::new();
+    out.extend_from_slice(&MAGIC);
+    out.extend_from_slice(&VERSION.to_le_bytes());
+    write_option_str(preamble, &mut out);
+    write_len(ast.roots.len(), &mut out);
+    for &root in &ast.roots {
+        write_node(ast, root, 0, &mut out);
+    }
+    out
+}
+
+/// Read a document and the comment lines it opens with back from binary.
+pub fn decode(bytes: &[u8]) -> Result<DecodedDocument, BinaryError> {
+    let mut reader = Reader::new(bytes);
+    if reader.take(MAGIC.len())? != MAGIC {
+        return Err(BinaryError::BadMagic);
+    }
+    let version = reader.u16()?;
+    if version > VERSION {
+        return Err(BinaryError::UnsupportedVersion(version));
+    }
+    let preamble = reader.option_str()?;
+
+    let mut ast = SceneBsnAst::default();
+    let roots = reader.len()?;
+    let mut root_nodes = Vec::new();
+    for _ in 0..roots {
+        root_nodes.push(read_node(&mut reader, &mut ast, 0)?);
+    }
+    for root in root_nodes {
+        ast.add_to_roots(root);
+    }
+    Ok(DecodedDocument { ast, preamble })
+}
+
+fn write_node(ast: &SceneBsnAst, node: Entity, depth: usize, out: &mut Vec<u8>) {
+    if depth >= MAX_AST_DEPTH {
+        log::warn!("document node {node} is deeper than {MAX_AST_DEPTH}; it was not written");
+        write_len(0, out);
+        return;
+    }
+    let patches = ast
+        .get_patches(node)
+        .map(|p| p.0.clone())
+        .unwrap_or_default();
+    let written: Vec<&BsnPatch> = patches
+        .iter()
+        .filter_map(|&patch| ast.get_patch(patch))
+        .collect();
+    write_len(written.len(), out);
+    for patch in written {
+        write_patch(ast, patch, depth, out);
+    }
+}
+
+fn write_patch(ast: &SceneBsnAst, patch: &BsnPatch, depth: usize, out: &mut Vec<u8>) {
+    match patch {
+        BsnPatch::Name(name) => {
+            out.push(PATCH_NAME);
+            write_str(name, out);
+        }
+        BsnPatch::Base(path) => {
+            out.push(PATCH_BASE);
+            write_str(path, out);
+        }
+        BsnPatch::Type(type_path) => {
+            out.push(PATCH_TYPE);
+            write_str(type_path, out);
+        }
+        BsnPatch::Struct(data) => {
+            out.push(PATCH_STRUCT);
+            write_struct(data, out);
+        }
+        BsnPatch::TupleStruct(data) => {
+            out.push(PATCH_TUPLE_STRUCT);
+            write_tuple_struct(data, out);
+        }
+        BsnPatch::Template(type_path, fields) => {
+            out.push(PATCH_TEMPLATE);
+            write_str(type_path, out);
+            match fields {
+                Some(fields) => {
+                    out.push(1);
+                    write_fields(fields, out);
+                }
+                None => out.push(0),
+            }
+        }
+        BsnPatch::Children(children) => {
+            out.push(PATCH_CHILDREN);
+            write_len(children.len(), out);
+            for &child in children {
+                write_node(ast, child, depth + 1, out);
+            }
+        }
+    }
+}
+
+fn write_struct(data: &BsnStructData, out: &mut Vec<u8>) {
+    write_str(&data.type_path, out);
+    write_fields(&data.fields, out);
+}
+
+fn write_tuple_struct(data: &BsnTupleStructData, out: &mut Vec<u8>) {
+    write_str(&data.type_path, out);
+    write_len(data.values.len(), out);
+    for value in &data.values {
+        write_value(value, out);
+    }
+}
+
+fn write_fields(fields: &BsnStructFields, out: &mut Vec<u8>) {
+    write_len(fields.0.len(), out);
+    for field in &fields.0 {
+        write_str(&field.name, out);
+        write_value(&field.value, out);
+    }
+}
+
+fn write_value(value: &BsnValue, out: &mut Vec<u8>) {
+    match value {
+        BsnValue::Float(number) => {
+            out.push(VALUE_FLOAT);
+            out.extend_from_slice(&number.to_le_bytes());
+        }
+        BsnValue::Int(number) => {
+            out.push(VALUE_INT);
+            out.extend_from_slice(&number.to_le_bytes());
+        }
+        BsnValue::Bool(flag) => {
+            out.push(VALUE_BOOL);
+            out.push(u8::from(*flag));
+        }
+        BsnValue::String(text) => {
+            out.push(VALUE_STRING);
+            write_str(text, out);
+        }
+        BsnValue::Type(type_path) => {
+            out.push(VALUE_TYPE);
+            write_str(type_path, out);
+        }
+        BsnValue::Struct(data) => {
+            out.push(VALUE_STRUCT);
+            write_struct(data, out);
+        }
+        BsnValue::TupleStruct(data) => {
+            out.push(VALUE_TUPLE_STRUCT);
+            write_tuple_struct(data, out);
+        }
+        BsnValue::List(items) => {
+            out.push(VALUE_LIST);
+            write_len(items.len(), out);
+            for item in items {
+                write_value(item, out);
+            }
+        }
+        BsnValue::Map(entries) => {
+            out.push(VALUE_MAP);
+            write_len(entries.len(), out);
+            for (key, item) in entries {
+                write_value(key, out);
+                write_value(item, out);
+            }
+        }
+    }
+}
+
+fn write_len(len: usize, out: &mut Vec<u8>) {
+    out.extend_from_slice(&u64::try_from(len).unwrap_or(u64::MAX).to_le_bytes());
+}
+
+fn write_str(text: &str, out: &mut Vec<u8>) {
+    write_len(text.len(), out);
+    out.extend_from_slice(text.as_bytes());
+}
+
+fn write_option_str(text: Option<&str>, out: &mut Vec<u8>) {
+    match text {
+        Some(text) => {
+            out.push(1);
+            write_str(text, out);
+        }
+        None => out.push(0),
+    }
+}
+
+struct Reader<'a> {
+    bytes: &'a [u8],
+    at: usize,
+}
+
+impl<'a> Reader<'a> {
+    fn new(bytes: &'a [u8]) -> Self {
+        Self { bytes, at: 0 }
+    }
+
+    fn take(&mut self, count: usize) -> Result<&'a [u8], BinaryError> {
+        let end = self.at.checked_add(count).ok_or(BinaryError::Truncated)?;
+        let slice = self.bytes.get(self.at..end).ok_or(BinaryError::Truncated)?;
+        self.at = end;
+        Ok(slice)
+    }
+
+    fn byte(&mut self) -> Result<u8, BinaryError> {
+        Ok(self.take(1)?[0])
+    }
+
+    fn u16(&mut self) -> Result<u16, BinaryError> {
+        let bytes: [u8; 2] = self
+            .take(2)?
+            .try_into()
+            .map_err(|_| BinaryError::Truncated)?;
+        Ok(u16::from_le_bytes(bytes))
+    }
+
+    fn u64(&mut self) -> Result<u64, BinaryError> {
+        let bytes: [u8; 8] = self
+            .take(8)?
+            .try_into()
+            .map_err(|_| BinaryError::Truncated)?;
+        Ok(u64::from_le_bytes(bytes))
+    }
+
+    fn f64(&mut self) -> Result<f64, BinaryError> {
+        let bytes: [u8; 8] = self
+            .take(8)?
+            .try_into()
+            .map_err(|_| BinaryError::Truncated)?;
+        Ok(f64::from_le_bytes(bytes))
+    }
+
+    fn i128(&mut self) -> Result<i128, BinaryError> {
+        let bytes: [u8; 16] = self
+            .take(16)?
+            .try_into()
+            .map_err(|_| BinaryError::Truncated)?;
+        Ok(i128::from_le_bytes(bytes))
+    }
+
+    fn bool(&mut self) -> Result<bool, BinaryError> {
+        Ok(self.byte()? != 0)
+    }
+
+    /// A count, refused up front when it is longer than the bytes that remain.
+    fn len(&mut self) -> Result<usize, BinaryError> {
+        let len = usize::try_from(self.u64()?).map_err(|_| BinaryError::Truncated)?;
+        if len > self.bytes.len() - self.at {
+            return Err(BinaryError::Truncated);
+        }
+        Ok(len)
+    }
+
+    fn string(&mut self) -> Result<String, BinaryError> {
+        let len = self.len()?;
+        let bytes = self.take(len)?;
+        String::from_utf8(bytes.to_vec()).map_err(|_| BinaryError::NotUtf8)
+    }
+
+    fn option_str(&mut self) -> Result<Option<String>, BinaryError> {
+        match self.byte()? {
+            0 => Ok(None),
+            _ => Ok(Some(self.string()?)),
+        }
+    }
+}
+
+fn read_node(
+    reader: &mut Reader<'_>,
+    ast: &mut SceneBsnAst,
+    depth: usize,
+) -> Result<Entity, BinaryError> {
+    if depth >= MAX_AST_DEPTH {
+        return Err(BinaryError::TooDeep);
+    }
+    let count = reader.len()?;
+    let mut patches = Vec::new();
+    for _ in 0..count {
+        patches.push(read_patch(reader, ast, depth)?);
+    }
+    Ok(ast.create_entity_node(patches))
+}
+
+fn read_patch(
+    reader: &mut Reader<'_>,
+    ast: &mut SceneBsnAst,
+    depth: usize,
+) -> Result<BsnPatch, BinaryError> {
+    let tag = reader.byte()?;
+    match tag {
+        PATCH_NAME => Ok(BsnPatch::Name(reader.string()?)),
+        PATCH_BASE => Ok(BsnPatch::Base(reader.string()?)),
+        PATCH_TYPE => Ok(BsnPatch::Type(reader.string()?)),
+        PATCH_STRUCT => Ok(BsnPatch::Struct(read_struct(reader, 0)?)),
+        PATCH_TUPLE_STRUCT => Ok(BsnPatch::TupleStruct(read_tuple_struct(reader, 0)?)),
+        PATCH_TEMPLATE => {
+            let type_path = reader.string()?;
+            let fields = match reader.byte()? {
+                0 => None,
+                _ => Some(read_fields(reader, 0)?),
+            };
+            Ok(BsnPatch::Template(type_path, fields))
+        }
+        PATCH_CHILDREN => {
+            let count = reader.len()?;
+            let mut children = Vec::new();
+            for _ in 0..count {
+                children.push(read_node(reader, ast, depth + 1)?);
+            }
+            Ok(BsnPatch::Children(children))
+        }
+        tag => Err(BinaryError::UnknownTag { kind: "patch", tag }),
+    }
+}
+
+fn read_struct(reader: &mut Reader<'_>, depth: usize) -> Result<BsnStructData, BinaryError> {
+    let type_path = reader.string()?;
+    let fields = read_fields(reader, depth)?;
+    Ok(BsnStructData { type_path, fields })
+}
+
+fn read_tuple_struct(
+    reader: &mut Reader<'_>,
+    depth: usize,
+) -> Result<BsnTupleStructData, BinaryError> {
+    let type_path = reader.string()?;
+    let count = reader.len()?;
+    let mut values = Vec::new();
+    for _ in 0..count {
+        values.push(read_value(reader, depth + 1)?);
+    }
+    Ok(BsnTupleStructData { type_path, values })
+}
+
+fn read_fields(reader: &mut Reader<'_>, depth: usize) -> Result<BsnStructFields, BinaryError> {
+    let count = reader.len()?;
+    let mut fields = Vec::new();
+    for _ in 0..count {
+        let name = reader.string()?;
+        let value = read_value(reader, depth + 1)?;
+        fields.push(BsnField { name, value });
+    }
+    Ok(BsnStructFields(fields))
+}
+
+fn read_value(reader: &mut Reader<'_>, depth: usize) -> Result<BsnValue, BinaryError> {
+    if depth >= MAX_AST_DEPTH {
+        return Err(BinaryError::TooDeep);
+    }
+    let tag = reader.byte()?;
+    match tag {
+        VALUE_FLOAT => Ok(BsnValue::Float(reader.f64()?)),
+        VALUE_INT => Ok(BsnValue::Int(reader.i128()?)),
+        VALUE_BOOL => Ok(BsnValue::Bool(reader.bool()?)),
+        VALUE_STRING => Ok(BsnValue::String(reader.string()?)),
+        VALUE_TYPE => Ok(BsnValue::Type(reader.string()?)),
+        VALUE_STRUCT => Ok(BsnValue::Struct(read_struct(reader, depth)?)),
+        VALUE_TUPLE_STRUCT => Ok(BsnValue::TupleStruct(read_tuple_struct(reader, depth)?)),
+        VALUE_LIST => {
+            let count = reader.len()?;
+            let mut items = Vec::new();
+            for _ in 0..count {
+                items.push(read_value(reader, depth + 1)?);
+            }
+            Ok(BsnValue::List(items))
+        }
+        VALUE_MAP => {
+            let count = reader.len()?;
+            let mut entries = Vec::new();
+            for _ in 0..count {
+                let key = read_value(reader, depth + 1)?;
+                let value = read_value(reader, depth + 1)?;
+                entries.push((key, value));
+            }
+            Ok(BsnValue::Map(entries))
+        }
+        tag => Err(BinaryError::UnknownTag { kind: "value", tag }),
+    }
+}

--- a/crates/jackdaw_bsn/src/file.rs
+++ b/crates/jackdaw_bsn/src/file.rs
@@ -1,0 +1,325 @@
+//! Reading and writing a BSN document in either of its two forms.
+//!
+//! A document on disk is either `.bsn` text or its `.bsb` binary twin. Which
+//! one a file holds is decided by its first bytes, never by its extension, so
+//! a reader handles both without knowing which it was handed. Writing goes the
+//! other way: the path's extension picks the form, which is how a save keeps a
+//! file in the form it was opened in.
+
+use std::path::{Path, PathBuf};
+
+use crate::binary::{self, BinaryError};
+use crate::header::read_asset_header;
+use crate::{BsnLoadError, SceneBsnAst, emit_scene, parse_bsn_text};
+
+/// The extension a text document carries.
+pub const TEXT_EXTENSION: &str = "bsn";
+
+/// The extension a binary document carries.
+pub const BINARY_EXTENSION: &str = "bsb";
+
+/// Which of the two forms a document is in.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum DocumentForm {
+    /// `.bsn` source text.
+    Text,
+    /// The `.bsb` binary twin.
+    Binary,
+}
+
+/// A document read off disk, with the form it was in.
+pub struct Document {
+    /// The parsed document.
+    pub ast: SceneBsnAst,
+    /// The comment lines the document opens with, verbatim.
+    pub preamble: Option<String>,
+    /// The form the file on disk was in.
+    pub form: DocumentForm,
+}
+
+impl Document {
+    /// The type path the asset header names, for a document that carries one.
+    pub fn header(&self) -> Option<String> {
+        self.preamble.as_deref().and_then(read_asset_header)
+    }
+}
+
+/// Why a document did not read or write.
+#[derive(Debug, thiserror::Error)]
+pub enum DocumentError {
+    #[error("failed to read {}: {}", .0.display(), .1)]
+    Read(PathBuf, std::io::Error),
+    #[error("failed to write {}: {}", .0.display(), .1)]
+    Write(PathBuf, std::io::Error),
+    #[error("failed to parse {}: {}", .0.display(), .1)]
+    Parse(PathBuf, BsnLoadError),
+    #[error("failed to read {}: {}", .0.display(), .1)]
+    Binary(PathBuf, BinaryError),
+    #[error("{} holds text that is not UTF-8", .0.display())]
+    NotUtf8(PathBuf),
+    #[error("refusing to convert {}: {} is already on disk", .1.display(), .0.display())]
+    TwinExists(PathBuf, PathBuf),
+    #[error("refusing to export {}: {} sits inside it", .1.display(), .0.display())]
+    DestinationInsideSource(PathBuf, PathBuf),
+}
+
+/// Whether an extension names a BSN document in either form.
+pub fn is_document_extension(extension: &str) -> bool {
+    extension.eq_ignore_ascii_case(TEXT_EXTENSION)
+        || extension.eq_ignore_ascii_case(BINARY_EXTENSION)
+}
+
+/// Whether a path names a BSN document in either form.
+pub fn is_document_path(path: &Path) -> bool {
+    path.extension()
+        .and_then(|extension| extension.to_str())
+        .is_some_and(is_document_extension)
+}
+
+/// Whether a path names a document in the binary form.
+pub fn is_binary_path(path: &Path) -> bool {
+    path.extension()
+        .and_then(|extension| extension.to_str())
+        .is_some_and(|extension| extension.eq_ignore_ascii_case(BINARY_EXTENSION))
+}
+
+/// The binary twin of a document path.
+pub fn binary_twin(path: &Path) -> PathBuf {
+    path.with_extension(BINARY_EXTENSION)
+}
+
+/// The text twin of a document path.
+pub fn text_twin(path: &Path) -> PathBuf {
+    path.with_extension(TEXT_EXTENSION)
+}
+
+/// The form of a document that exists at this path or at its twin, preferring
+/// the path as written and then the text form.
+pub fn existing_form(path: &Path) -> Option<PathBuf> {
+    if path.is_file() {
+        return Some(path.to_path_buf());
+    }
+    if !is_document_path(path) {
+        return None;
+    }
+    let text = text_twin(path);
+    if text.is_file() {
+        return Some(text);
+    }
+    let binary = binary_twin(path);
+    binary.is_file().then_some(binary)
+}
+
+/// Read a document, choosing its form by what the first bytes say.
+pub fn read_document(path: &Path) -> Result<Document, DocumentError> {
+    let bytes = std::fs::read(path).map_err(|err| DocumentError::Read(path.to_path_buf(), err))?;
+    document_from_bytes(&bytes, path)
+}
+
+/// [`read_document`] over bytes already in hand, `path` naming them in errors.
+pub fn document_from_bytes(bytes: &[u8], path: &Path) -> Result<Document, DocumentError> {
+    if binary::is_binary(bytes) {
+        let decoded =
+            binary::decode(bytes).map_err(|err| DocumentError::Binary(path.to_path_buf(), err))?;
+        return Ok(Document {
+            ast: decoded.ast,
+            preamble: decoded.preamble,
+            form: DocumentForm::Binary,
+        });
+    }
+    let text =
+        std::str::from_utf8(bytes).map_err(|_| DocumentError::NotUtf8(path.to_path_buf()))?;
+    let ast = parse_bsn_text(text).map_err(|err| DocumentError::Parse(path.to_path_buf(), err))?;
+    Ok(Document {
+        ast,
+        preamble: leading_comments(text),
+        form: DocumentForm::Text,
+    })
+}
+
+/// Read a document as `.bsn` text, whichever form it is stored in.
+///
+/// A text file reads back verbatim; a binary one is emitted under the comment
+/// lines it was written with.
+pub fn read_document_text(path: &Path) -> Result<String, DocumentError> {
+    let bytes = std::fs::read(path).map_err(|err| DocumentError::Read(path.to_path_buf(), err))?;
+    document_text_from_bytes(&bytes, path)
+}
+
+/// [`read_document_text`] over bytes already in hand.
+pub fn document_text_from_bytes(bytes: &[u8], path: &Path) -> Result<String, DocumentError> {
+    if !binary::is_binary(bytes) {
+        return std::str::from_utf8(bytes)
+            .map(str::to_string)
+            .map_err(|_| DocumentError::NotUtf8(path.to_path_buf()));
+    }
+    let decoded =
+        binary::decode(bytes).map_err(|err| DocumentError::Binary(path.to_path_buf(), err))?;
+    Ok(document_as_text(&decoded.ast, decoded.preamble.as_deref()))
+}
+
+/// A document as the `.bsn` text it emits, under the comment lines it opens
+/// with.
+pub fn document_as_text(ast: &SceneBsnAst, preamble: Option<&str>) -> String {
+    let body = emit_scene(ast);
+    match preamble {
+        Some(preamble) => format!("{preamble}{body}"),
+        None => body,
+    }
+}
+
+/// The comment lines a document opens with, which carry its asset header and
+/// its version stamp.
+pub fn leading_comments(text: &str) -> Option<String> {
+    let mut end = 0;
+    for line in text.split_inclusive('\n') {
+        let trimmed = line.trim();
+        if !trimmed.is_empty() && !trimmed.starts_with("//") {
+            break;
+        }
+        end += line.len();
+    }
+    (end > 0).then(|| text[..end].to_string())
+}
+
+/// Write `text` to `path` in the form the path's extension names.
+pub fn write_document_text(path: &Path, text: &str) -> Result<(), DocumentError> {
+    let bytes = document_bytes(path, text)?;
+    std::fs::write(path, bytes).map_err(|err| DocumentError::Write(path.to_path_buf(), err))
+}
+
+/// The bytes `text` is stored as at `path`, in the form its extension names.
+pub fn document_bytes(path: &Path, text: &str) -> Result<Vec<u8>, DocumentError> {
+    if !is_binary_path(path) {
+        return Ok(text.as_bytes().to_vec());
+    }
+    text_as_binary(text, path)
+}
+
+/// `.bsn` text encoded as its binary twin, leading comments and all.
+pub fn text_as_binary(text: &str, path: &Path) -> Result<Vec<u8>, DocumentError> {
+    let ast = parse_bsn_text(text).map_err(|err| DocumentError::Parse(path.to_path_buf(), err))?;
+    Ok(binary::encode(&ast, leading_comments(text).as_deref()))
+}
+
+/// Rewrite one document as its binary twin, removing the text file once the
+/// binary one is on disk. Returns the path the document now sits at.
+pub fn convert_to_binary(path: &Path) -> Result<PathBuf, DocumentError> {
+    convert(path, DocumentForm::Binary)
+}
+
+/// Rewrite one document as `.bsn` text, removing the binary file once the text
+/// one is on disk. Returns the path the document now sits at.
+pub fn convert_to_text(path: &Path) -> Result<PathBuf, DocumentError> {
+    convert(path, DocumentForm::Text)
+}
+
+fn convert(path: &Path, to: DocumentForm) -> Result<PathBuf, DocumentError> {
+    let document = read_document(path)?;
+    let (target, bytes) = match to {
+        DocumentForm::Binary => (
+            binary_twin(path),
+            binary::encode(&document.ast, document.preamble.as_deref()),
+        ),
+        DocumentForm::Text => (
+            text_twin(path),
+            document_as_text(&document.ast, document.preamble.as_deref()).into_bytes(),
+        ),
+    };
+    if document.form == to && target == path {
+        return Ok(target);
+    }
+    if target != path && target.exists() {
+        return Err(DocumentError::TwinExists(target, path.to_path_buf()));
+    }
+    std::fs::write(&target, bytes).map_err(|err| DocumentError::Write(target.clone(), err))?;
+    if target != path {
+        std::fs::remove_file(path).map_err(|err| DocumentError::Write(path.to_path_buf(), err))?;
+    }
+    Ok(target)
+}
+
+/// Write every `.bsn` document under `source` into `destination` as its binary
+/// twin, copying every other file through unchanged. Returns how many
+/// documents were converted.
+pub fn export_binary(source: &Path, destination: &Path) -> Result<usize, DocumentError> {
+    let held = resolved(source);
+    if resolved(destination).starts_with(&held) {
+        return Err(DocumentError::DestinationInsideSource(
+            destination.to_path_buf(),
+            source.to_path_buf(),
+        ));
+    }
+    let mut converted = 0;
+    export_tree(source, source, destination, 0, &mut converted)?;
+    Ok(converted)
+}
+
+/// A path with every part of it that exists on disk resolved, so two spellings
+/// of one folder compare equal.
+fn resolved(path: &Path) -> PathBuf {
+    if let Ok(held) = path.canonicalize() {
+        return held;
+    }
+    match (path.parent(), path.file_name()) {
+        (Some(parent), Some(name)) => resolved(parent).join(name),
+        _ => path.to_path_buf(),
+    }
+}
+
+fn export_tree(
+    root: &Path,
+    dir: &Path,
+    destination: &Path,
+    depth: usize,
+    converted: &mut usize,
+) -> Result<(), DocumentError> {
+    if depth > crate::header::MAX_ASSET_DEPTH {
+        return Ok(());
+    }
+    let entries =
+        std::fs::read_dir(dir).map_err(|err| DocumentError::Read(dir.to_path_buf(), err))?;
+    for entry in entries.flatten() {
+        let path = entry.path();
+        let name = entry.file_name();
+        if name.to_string_lossy().starts_with('.') {
+            continue;
+        }
+        let Ok(file_type) = entry.file_type() else {
+            continue;
+        };
+        if file_type.is_symlink() {
+            continue;
+        }
+        let Ok(relative) = path.strip_prefix(root) else {
+            continue;
+        };
+        let target = destination.join(relative);
+        if file_type.is_dir() {
+            export_tree(root, &path, destination, depth + 1, converted)?;
+            continue;
+        }
+        if let Some(parent) = target.parent() {
+            std::fs::create_dir_all(parent)
+                .map_err(|err| DocumentError::Write(parent.to_path_buf(), err))?;
+        }
+        let is_text_document = path
+            .extension()
+            .and_then(|extension| extension.to_str())
+            .is_some_and(|extension| extension.eq_ignore_ascii_case(TEXT_EXTENSION));
+        if !is_text_document {
+            std::fs::copy(&path, &target)
+                .map_err(|err| DocumentError::Write(target.clone(), err))?;
+            continue;
+        }
+        let document = read_document(&path)?;
+        let target = binary_twin(&target);
+        std::fs::write(
+            &target,
+            binary::encode(&document.ast, document.preamble.as_deref()),
+        )
+        .map_err(|err| DocumentError::Write(target.clone(), err))?;
+        *converted += 1;
+    }
+    Ok(())
+}

--- a/crates/jackdaw_bsn/src/header.rs
+++ b/crates/jackdaw_bsn/src/header.rs
@@ -23,7 +23,7 @@ pub const ASSET_HEADER: &str = "// jackdaw asset ";
 pub const PREFAB_TYPE: &str = "jackdaw::prefab::components::Prefab";
 
 /// How deep under the assets directory a walk looks.
-const MAX_ASSET_DEPTH: usize = 12;
+pub(crate) const MAX_ASSET_DEPTH: usize = 12;
 
 /// Prepend the header naming the type an asset file holds.
 pub fn with_asset_header(type_path: &str, body: &str) -> String {
@@ -161,17 +161,14 @@ pub fn document_type_path(text: &str) -> Option<String> {
     root_type_path(&ast, root)
 }
 
-/// The type the `.bsn` file at `path` holds, taken from its first root and
-/// from its header only where the document names no type of its own.
+/// The type the document at `path` holds, taken from its first root and from
+/// its header only where the document names no type of its own. Either form
+/// of the document reads.
 pub fn asset_file_type(path: &Path) -> Option<String> {
-    if !path
-        .extension()
-        .and_then(|extension| extension.to_str())
-        .is_some_and(|extension| extension.eq_ignore_ascii_case("bsn"))
-    {
+    if !crate::file::is_document_path(path) {
         return None;
     }
-    let text = std::fs::read_to_string(path).ok()?;
+    let text = crate::file::read_document_text(path).ok()?;
     asset_text_type(&text, path)
 }
 
@@ -191,10 +188,23 @@ pub fn asset_text_type(text: &str, path: &Path) -> Option<String> {
     Some(found)
 }
 
-/// Every `.bsn` and `.jsn` file under `dir`, as absolute paths, skipping
-/// hidden directories and following no symlink out of the tree.
+/// Every document under `dir`, as absolute paths, skipping hidden directories
+/// and following no symlink out of the tree.
+///
+/// A document held in both forms is listed once, as its text file.
 pub fn walk_document_files(dir: &Path) -> Vec<PathBuf> {
-    walk_files_with_extensions(dir, &["bsn", "jsn"])
+    let found = walk_files_with_extensions(dir, &["bsn", "bsb", "jsn"]);
+    let text: std::collections::HashSet<PathBuf> = found
+        .iter()
+        .filter(|path| !crate::file::is_binary_path(path))
+        .cloned()
+        .collect();
+    found
+        .into_iter()
+        .filter(|path| {
+            !crate::file::is_binary_path(path) || !text.contains(&crate::file::text_twin(path))
+        })
+        .collect()
 }
 
 /// Every file under `dir` whose extension is one of `extensions`, as absolute
@@ -256,8 +266,8 @@ pub fn walk_asset_files(assets_root: &Path) -> impl Iterator<Item = (PathBuf, St
 /// Why an asset file did not read as the value it was asked for.
 #[derive(Debug, thiserror::Error)]
 pub enum AssetFileError {
-    #[error("failed to read {}: {}", .0.display(), .1)]
-    Read(PathBuf, std::io::Error),
+    #[error("{1}")]
+    Read(PathBuf, crate::file::DocumentError),
     #[error("failed to parse {}: {}", .0.display(), .1)]
     Parse(PathBuf, BsnLoadError),
     #[error("{} holds no value", .0.display())]
@@ -283,7 +293,7 @@ where
     T: FromReflect + TypePath + GetTypeRegistration,
 {
     let expected = T::type_path();
-    let text = std::fs::read_to_string(path)
+    let text = crate::file::read_document_text(path)
         .map_err(|err| AssetFileError::Read(path.to_path_buf(), err))?;
     if let Some(header) = read_asset_header(&text).filter(|header| header != expected) {
         return Err(AssetFileError::WrongType {

--- a/crates/jackdaw_bsn/src/lib.rs
+++ b/crates/jackdaw_bsn/src/lib.rs
@@ -7,10 +7,12 @@
 //! dynamic-BSN work in bevyengine/bevy#23576.
 
 pub mod apply;
+pub mod binary;
 pub mod catalog;
 pub mod delta;
 pub mod document;
 pub mod emitter;
+pub mod file;
 pub mod header;
 pub mod loader;
 pub mod parse;
@@ -29,6 +31,16 @@ pub use header::{
     asset_text_type, document_type_path, path_stem, read_asset_file, read_asset_header,
     root_type_path, walk_asset_files, walk_document_files, walk_files_with_extensions,
     with_asset_header,
+};
+
+pub use binary::{BinaryError, DecodedDocument, is_binary};
+
+pub use file::{
+    BINARY_EXTENSION, Document, DocumentError, DocumentForm, TEXT_EXTENSION, binary_twin,
+    convert_to_binary, convert_to_text, document_as_text, document_bytes, document_from_bytes,
+    document_text_from_bytes, existing_form, export_binary, is_binary_path, is_document_extension,
+    is_document_path, leading_comments, read_document, read_document_text, text_as_binary,
+    text_twin, write_document_text,
 };
 
 pub use parse::{ParseError, parse_bsn};

--- a/crates/jackdaw_bsn/tests/binary_form.rs
+++ b/crates/jackdaw_bsn/tests/binary_form.rs
@@ -1,0 +1,457 @@
+//! The binary twin of a BSN document: round-trips, refusals, and conversion.
+
+use std::path::Path;
+
+use jackdaw_bsn::binary::{self, BinaryError, MAGIC, VERSION};
+use jackdaw_bsn::{
+    ASSET_HEADER, BsnField, BsnPatch, BsnStructData, BsnStructFields, BsnValue, DocumentError,
+    DocumentForm, SceneBsnAst, convert_to_binary, convert_to_text, document_as_text, emit_scene,
+    export_binary, leading_comments, parse_bsn_text, read_asset_header, read_document,
+    read_document_text, with_asset_header, write_document_text,
+};
+
+const SCENE: &str = r#"#Root
+bevy_transform::components::transform::Transform { translation: bevy_math::Vec3 { x: 1.0, y: -2.5, z: 0.0 } }
+bevy_ecs::hierarchy::Children [
+    #Child
+    bevy_core::name::Name("a child"),
+    :"prefabs/tree.bsn"
+    my_game::Tags { names: ["one", "two"], counts: map[(1, true), (2, false)] }
+]
+"#;
+
+fn round_tripped(text: &str) -> String {
+    let ast = parse_bsn_text(text).expect("the document parses");
+    let bytes = binary::encode(&ast, None);
+    let decoded = binary::decode(&bytes).expect("the binary document reads back");
+    emit_scene(&decoded.ast)
+}
+
+#[test]
+fn a_document_round_trips_text_to_binary_to_text_unchanged() {
+    let ast = parse_bsn_text(SCENE).expect("the document parses");
+
+    assert_eq!(round_tripped(SCENE), emit_scene(&ast));
+}
+
+#[test]
+fn every_value_shape_survives_the_binary_form() {
+    let text = r#"my_game::Every {
+    float: 1.5,
+    int: -9000000000000000000000,
+    flag: true,
+    text: "words",
+    unit: my_game::Kind::One,
+    nested: my_game::Inner { a: 1.0 },
+    tuple: my_game::Wrap(1, "two"),
+    list: [1, 2, 3],
+    pairs: map[("a", 1), ("b", 2)]
+}
+"#;
+
+    assert_eq!(
+        round_tripped(text),
+        emit_scene(&parse_bsn_text(text).unwrap())
+    );
+}
+
+#[test]
+fn a_string_holding_nul_bytes_survives_the_binary_form() {
+    let mut ast = SceneBsnAst::default();
+    let node = ast.create_entity_node(vec![BsnPatch::Struct(BsnStructData {
+        type_path: "my_game::Label".to_string(),
+        fields: BsnStructFields(vec![BsnField {
+            name: "text".to_string(),
+            value: BsnValue::String("a\0b\u{1}c".to_string()),
+        }]),
+    })]);
+    ast.add_to_roots(node);
+
+    let decoded = binary::decode(&binary::encode(&ast, None)).expect("it reads back");
+
+    assert_eq!(emit_scene(&decoded.ast), emit_scene(&ast));
+    assert!(emit_scene(&decoded.ast).contains('\0'));
+}
+
+#[test]
+fn a_binary_document_keeps_its_header_type() {
+    let text = with_asset_header(
+        "my_game::content::ItemDef",
+        "my_game::content::ItemDef { damage: 3.0 }\n",
+    );
+    let ast = parse_bsn_text(&text).expect("it parses");
+
+    let bytes = binary::encode(&ast, leading_comments(&text).as_deref());
+    let decoded = binary::decode(&bytes).expect("it reads back");
+
+    assert_eq!(
+        decoded.preamble.as_deref().and_then(read_asset_header),
+        Some("my_game::content::ItemDef".to_string())
+    );
+}
+
+#[test]
+fn a_version_stamp_survives_the_binary_form() {
+    let stamped = format!("// jackdaw 0.19.0 | bevy 0.19\n{SCENE}");
+
+    let bytes = binary::encode(
+        &parse_bsn_text(&stamped).expect("it parses"),
+        leading_comments(&stamped).as_deref(),
+    );
+
+    let decoded = binary::decode(&bytes).expect("it reads back");
+
+    assert_eq!(
+        document_as_text(&decoded.ast, decoded.preamble.as_deref()),
+        format!(
+            "// jackdaw 0.19.0 | bevy 0.19\n{}",
+            emit_scene(&parse_bsn_text(SCENE).expect("it parses"))
+        ),
+        "the stamp the editor wrote is still the first line"
+    );
+}
+
+#[test]
+fn converting_a_document_whose_twin_is_already_on_disk_is_refused() {
+    let dir = tempfile::tempdir().expect("tempdir");
+    let text_path = dir.path().join("thing.bsn");
+    let binary_path = dir.path().join("thing.bsb");
+    write_document_text(&text_path, SCENE).expect("written");
+    write_document_text(&binary_path, "my_game::Older\n").expect("written");
+    let before = std::fs::read_to_string(&text_path).expect("read back");
+
+    let refused = convert_to_text(&binary_path).err();
+
+    assert!(
+        matches!(refused, Some(DocumentError::TwinExists(..))),
+        "got {refused:?}"
+    );
+    assert_eq!(
+        std::fs::read_to_string(&text_path).expect("read back"),
+        before,
+        "the text the repository holds is untouched"
+    );
+    assert!(binary_path.exists());
+    assert!(matches!(
+        convert_to_binary(&text_path).err(),
+        Some(DocumentError::TwinExists(..))
+    ));
+}
+
+#[test]
+fn a_binary_document_is_known_by_its_first_bytes() {
+    let bytes = binary::encode(&parse_bsn_text(SCENE).unwrap(), None);
+
+    assert!(binary::is_binary(&bytes));
+    assert!(!binary::is_binary(SCENE.as_bytes()));
+}
+
+#[test]
+fn no_text_document_can_open_with_the_magic() {
+    assert!(std::str::from_utf8(&MAGIC).is_err());
+
+    let dir = tempfile::tempdir().expect("tempdir");
+    let path = dir.path().join("odd.bsn");
+    std::fs::write(&path, "BSB::Marker\n").expect("the file is written");
+
+    assert_eq!(
+        read_document(&path).expect("it reads").form,
+        DocumentForm::Text
+    );
+}
+
+#[test]
+fn the_form_is_read_from_the_bytes_rather_than_the_name() {
+    let dir = tempfile::tempdir().expect("tempdir");
+    let path = dir.path().join("misnamed.bsn");
+    std::fs::write(&path, binary::encode(&parse_bsn_text(SCENE).unwrap(), None))
+        .expect("the file is written");
+
+    let document = read_document(&path).expect("it reads");
+
+    assert_eq!(document.form, DocumentForm::Binary);
+    assert_eq!(
+        emit_scene(&document.ast),
+        emit_scene(&parse_bsn_text(SCENE).unwrap())
+    );
+}
+
+#[test]
+fn a_corrupt_binary_document_is_refused_with_a_clear_error() {
+    let bytes = binary::encode(&parse_bsn_text(SCENE).unwrap(), None);
+
+    let mut bad_magic = bytes.clone();
+    bad_magic[..4].copy_from_slice(b"XXXX");
+    assert!(matches!(
+        binary::decode(&bad_magic),
+        Err(BinaryError::BadMagic)
+    ));
+
+    for cut in 4..bytes.len() {
+        let refused = binary::decode(&bytes[..cut]);
+        assert!(
+            refused.is_err(),
+            "{cut} of {} bytes decoded as a whole document",
+            bytes.len()
+        );
+    }
+}
+
+#[test]
+fn a_document_from_a_later_version_is_refused_by_name() {
+    let mut bytes = binary::encode(&parse_bsn_text(SCENE).unwrap(), None);
+    bytes[4..6].copy_from_slice(&(VERSION + 1).to_le_bytes());
+
+    let refused = binary::decode(&bytes).err();
+
+    assert!(
+        matches!(refused, Some(BinaryError::UnsupportedVersion(version)) if version == VERSION + 1),
+        "got {refused:?}"
+    );
+}
+
+#[test]
+fn a_length_longer_than_the_document_is_refused_rather_than_reserved() {
+    let mut bytes = Vec::new();
+    bytes.extend_from_slice(&MAGIC);
+    bytes.extend_from_slice(&VERSION.to_le_bytes());
+    bytes.push(0);
+    bytes.extend_from_slice(&u64::MAX.to_le_bytes());
+
+    let refused = binary::decode(&bytes).err();
+    assert!(
+        matches!(refused, Some(BinaryError::Truncated)),
+        "got {refused:?}"
+    );
+
+    bytes.truncate(7);
+    bytes.extend_from_slice(&u64::MAX.to_le_bytes());
+    assert!(matches!(
+        binary::decode(&bytes).err(),
+        Some(BinaryError::Truncated)
+    ));
+}
+
+#[test]
+fn a_deeply_nested_document_round_trips() {
+    let depth = 60;
+    let mut text = String::new();
+    for _ in 0..depth {
+        text.push_str("bevy_ecs::hierarchy::Children [\n");
+    }
+    text.push_str("my_game::Leaf\n");
+    for _ in 0..depth {
+        text.push_str("]\n");
+    }
+
+    assert_eq!(
+        round_tripped(&text),
+        emit_scene(&parse_bsn_text(&text).unwrap())
+    );
+}
+
+#[test]
+fn a_scene_saved_as_binary_loads_identically() {
+    let dir = tempfile::tempdir().expect("tempdir");
+    let text_path = dir.path().join("scene.bsn");
+    let binary_path = dir.path().join("scene.bsb");
+    write_document_text(&text_path, SCENE).expect("the text scene is written");
+    write_document_text(&binary_path, SCENE).expect("the binary scene is written");
+
+    let from_text = read_document(&text_path).expect("the text scene reads");
+    let from_binary = read_document(&binary_path).expect("the binary scene reads");
+
+    assert_eq!(from_binary.form, DocumentForm::Binary);
+    assert_eq!(emit_scene(&from_binary.ast), emit_scene(&from_text.ast));
+}
+
+#[test]
+fn an_asset_file_saved_as_binary_keeps_its_header_type() {
+    let dir = tempfile::tempdir().expect("tempdir");
+    let path = dir.path().join("torch.bsb");
+    let text = with_asset_header(
+        "my_game::content::ItemDef",
+        "#torch\nmy_game::content::ItemDef { damage: 3.0 }\n",
+    );
+    write_document_text(&path, &text).expect("the asset is written");
+
+    let document = read_document(&path).expect("the asset reads");
+
+    assert_eq!(
+        document.header(),
+        Some("my_game::content::ItemDef".to_string())
+    );
+    assert_eq!(
+        jackdaw_bsn::asset_file_type(&path).as_deref(),
+        Some("my_game::content::ItemDef")
+    );
+    assert!(read_document_text(&path).unwrap().starts_with(ASSET_HEADER));
+}
+
+#[test]
+fn a_document_resolves_to_its_binary_twin_when_the_text_file_is_absent() {
+    let dir = tempfile::tempdir().expect("tempdir");
+    let text_path = dir.path().join("materials/grass.bsn");
+    std::fs::create_dir_all(text_path.parent().unwrap()).expect("the folder is made");
+    write_document_text(&text_path, "my_game::Material { rough: 1.0 }\n").expect("written");
+
+    assert_eq!(
+        jackdaw_bsn::existing_form(&text_path).as_deref(),
+        Some(text_path.as_path())
+    );
+
+    let binary_path = convert_to_binary(&text_path).expect("it converts");
+
+    assert_eq!(binary_path, dir.path().join("materials/grass.bsb"));
+    assert_eq!(
+        jackdaw_bsn::existing_form(&text_path).as_deref(),
+        Some(binary_path.as_path())
+    );
+}
+
+#[test]
+fn a_walk_lists_a_document_held_in_both_forms_once_as_its_text_file() {
+    let dir = tempfile::tempdir().expect("tempdir");
+    let both = dir.path().join("both.bsn");
+    write_document_text(&both, "my_game::Marker\n").expect("written");
+    write_document_text(&dir.path().join("both.bsb"), "my_game::Marker\n").expect("written");
+    let lone = dir.path().join("lone.bsb");
+    write_document_text(&lone, "my_game::Marker\n").expect("written");
+
+    let found = jackdaw_bsn::walk_document_files(dir.path());
+
+    assert_eq!(found, vec![both, lone]);
+}
+
+#[test]
+fn converting_in_place_removes_the_other_form() {
+    let dir = tempfile::tempdir().expect("tempdir");
+    let text_path = dir.path().join("thing.bsn");
+    write_document_text(&text_path, SCENE).expect("written");
+
+    let binary_path = convert_to_binary(&text_path).expect("it converts to binary");
+    assert!(!text_path.exists());
+    assert!(binary_path.exists());
+
+    let back = convert_to_text(&binary_path).expect("it converts back");
+    assert_eq!(back, text_path);
+    assert!(!binary_path.exists());
+    assert_eq!(
+        std::fs::read_to_string(&back).unwrap(),
+        emit_scene(&parse_bsn_text(SCENE).unwrap())
+    );
+}
+
+#[test]
+fn converting_to_binary_and_back_leaves_the_bytes_the_repository_held() {
+    let dir = tempfile::tempdir().expect("tempdir");
+    let path = dir.path().join("torch.bsn");
+    let held = format!(
+        "// jackdaw 0.19.0 | bevy 0.19\n{}",
+        with_asset_header(
+            "my_game::content::ItemDef",
+            &emit_scene(
+                &parse_bsn_text("#torch\nmy_game::content::ItemDef { damage: 3.0 }\n")
+                    .expect("it parses")
+            ),
+        )
+    );
+    std::fs::write(&path, &held).expect("written");
+
+    let binary = convert_to_binary(&path).expect("it converts to binary");
+    let back = convert_to_text(&binary).expect("it converts back");
+
+    assert_eq!(back, path);
+    assert_eq!(
+        std::fs::read_to_string(&back).expect("read back"),
+        held,
+        "the stamp, the header and the body all came back"
+    );
+}
+
+#[test]
+fn a_failed_conversion_leaves_the_file_it_was_given() {
+    let dir = tempfile::tempdir().expect("tempdir");
+    let path = dir.path().join("broken.bsn");
+    std::fs::write(&path, "my_game::Broken {{{").expect("written");
+
+    let refused = convert_to_binary(&path).err();
+
+    assert!(
+        matches!(refused, Some(DocumentError::Parse(..))),
+        "got {refused:?}"
+    );
+    assert!(path.exists());
+    assert!(!dir.path().join("broken.bsb").exists());
+}
+
+#[test]
+fn export_binary_converts_a_tree_and_leaves_other_files_alone() {
+    let dir = tempfile::tempdir().expect("tempdir");
+    let source = dir.path().join("assets");
+    std::fs::create_dir_all(source.join("materials")).expect("the folder is made");
+    write_document_text(&source.join("scene.bsn"), SCENE).expect("written");
+    write_document_text(
+        &source.join("materials/grass.bsn"),
+        "my_game::Material { rough: 1.0 }\n",
+    )
+    .expect("written");
+    std::fs::write(source.join("materials/grass.png"), [1, 2, 3]).expect("written");
+
+    let destination = dir.path().join("export");
+    let converted = export_binary(&source, &destination).expect("the tree exports");
+
+    assert_eq!(converted, 2);
+    assert!(destination.join("scene.bsb").exists());
+    assert!(!destination.join("scene.bsn").exists());
+    assert_eq!(
+        std::fs::read(destination.join("materials/grass.png")).unwrap(),
+        vec![1, 2, 3]
+    );
+    assert!(source.join("scene.bsn").exists());
+
+    let exported = read_document(&destination.join("scene.bsb")).expect("the export reads");
+    assert_eq!(
+        emit_scene(&exported.ast),
+        emit_scene(&parse_bsn_text(SCENE).unwrap())
+    );
+}
+
+#[test]
+fn export_binary_refuses_a_destination_inside_the_tree_it_reads() {
+    let dir = tempfile::tempdir().expect("tempdir");
+    let source = dir.path().join("assets");
+    std::fs::create_dir_all(source.join("materials")).expect("the folder is made");
+    write_document_text(&source.join("scene.bsn"), SCENE).expect("written");
+
+    for destination in [
+        source.clone(),
+        source.join("export"),
+        source.join("materials/../export"),
+    ] {
+        let refused = export_binary(&source, &destination).err();
+        assert!(
+            matches!(refused, Some(DocumentError::DestinationInsideSource(..))),
+            "{} was accepted: got {refused:?}",
+            destination.display()
+        );
+    }
+
+    assert!(source.join("scene.bsn").exists());
+    assert!(!source.join("scene.bsb").exists());
+}
+
+#[test]
+fn a_file_that_is_not_a_document_is_refused_by_name() {
+    let dir = tempfile::tempdir().expect("tempdir");
+    let path = dir.path().join("picture.bsn");
+    std::fs::write(&path, [0xff, 0xfe, 0xfd]).expect("written");
+
+    let refused = read_document(&path).err();
+
+    assert!(
+        matches!(refused, Some(DocumentError::NotUtf8(_))),
+        "got {refused:?}"
+    );
+    assert!(read_document(Path::new("nowhere/at/all.bsn")).is_err());
+}

--- a/crates/jackdaw_prefab/src/source.rs
+++ b/crates/jackdaw_prefab/src/source.rs
@@ -191,7 +191,8 @@ pub fn normalize_as_prefab_source(ast: &mut SceneBsnAst, display_name: &str) {
 /// directory it came from. The file stem names a synthetic root when the
 /// document needs one.
 pub fn read_prefab_document(path: &Path) -> Result<SceneBsnAst, std::io::Error> {
-    let text = std::fs::read_to_string(path)?;
+    let text = jackdaw_bsn::read_document_text(path)
+        .map_err(|err| std::io::Error::new(std::io::ErrorKind::InvalidData, err.to_string()))?;
     let mut ast = jackdaw_bsn::parse_bsn_text(&text)
         .map_err(|e| std::io::Error::new(std::io::ErrorKind::InvalidData, e.to_string()))?;
     let display_name = path.file_stem().and_then(|s| s.to_str()).unwrap_or("scene");

--- a/crates/jackdaw_runtime/src/lib.rs
+++ b/crates/jackdaw_runtime/src/lib.rs
@@ -377,14 +377,14 @@ impl AssetLoader for JackdawSceneLoader {
             .await
             .map_err(|e| JackdawLoadError::Io(e.to_string()))?;
 
-        let text =
-            std::str::from_utf8(&bytes).map_err(|e| JackdawLoadError::Parse(e.to_string()))?;
+        let text = jackdaw_bsn::document_text_from_bytes(&bytes, load_context.path().path())
+            .map_err(|e| JackdawLoadError::Parse(e.to_string()))?;
 
         // Parse once at load so a malformed scene fails here with a clear
         // error rather than silently spawning nothing later. The document is
         // rebuilt from `bsn` on spawn (it owns a `World` and cannot be stored
         // in the asset).
-        let ast = parse_bsn_text(text).map_err(|e| JackdawLoadError::Parse(e.to_string()))?;
+        let ast = parse_bsn_text(&text).map_err(|e| JackdawLoadError::Parse(e.to_string()))?;
 
         // A document naming a component the engine does not have would load as
         // a scene missing part of itself, so the load fails here by name.
@@ -398,14 +398,14 @@ impl AssetLoader for JackdawSceneLoader {
             .map(|s| s.to_string_lossy().into_owned());
 
         Ok(JackdawScene {
-            bsn: text.to_owned(),
+            bsn: text,
             parent_path,
             stem,
         })
     }
 
     fn extensions(&self) -> &[&str] {
-        &["bsn"]
+        &["bsn", "bsb"]
     }
 }
 
@@ -663,7 +663,8 @@ fn read_prefab_sources(
         if !path.starts_with(assets_root) {
             return Err(path);
         }
-        match jackdaw_prefab::read_prefab_document(&path) {
+        let file = jackdaw_bsn::existing_form(&path).unwrap_or_else(|| path.clone());
+        match jackdaw_prefab::read_prefab_document(&file) {
             Ok(document) => {
                 pending.extend(isa_sources(&document));
                 documents.insert(path, document);
@@ -1305,7 +1306,8 @@ fn load_asset_files(world: &mut World) {
     let catalog_path = world
         .get_resource::<JackdawCatalogPath>()
         .map(|path| path.0.clone())
-        .or_else(|| root.as_ref().map(|root| root.join(CATALOG_FILE)));
+        .or_else(|| root.as_ref().map(|root| root.join(CATALOG_FILE)))
+        .and_then(|path| jackdaw_bsn::existing_form(&path).or(Some(path)));
 
     if let Some(root) = root.clone() {
         load_walked_assets(world, &root, catalog_path.as_deref());
@@ -1322,8 +1324,8 @@ fn load_asset_files(world: &mut World) {
         return;
     }
 
-    let text = match std::fs::read_to_string(&catalog_path) {
-        Ok(t) => t,
+    let text = match jackdaw_bsn::read_document_text(&catalog_path) {
+        Ok(text) => text,
         Err(err) => {
             warn!("Failed to read catalog {}: {err}", catalog_path.display());
             return;
@@ -1370,24 +1372,23 @@ fn load_walked_assets(world: &mut World, root: &Path, catalog_path: Option<&Path
     let mut skipped = SkippedTypes::default();
 
     for path in jackdaw_bsn::walk_document_files(root) {
-        let is_bsn = path
-            .extension()
-            .and_then(|extension| extension.to_str())
-            .is_some_and(|extension| extension.eq_ignore_ascii_case("bsn"));
-        if !is_bsn || Some(path.as_path()) == catalog_path {
+        if !jackdaw_bsn::is_document_path(&path) || Some(path.as_path()) == catalog_path {
             continue;
         }
-        let Some(key) = assets_relative_key(root, &path) else {
+        let Some(key) = assets_relative_key(root, &jackdaw_bsn::text_twin(&path)) else {
             continue;
         };
         stems.insert(PathBuf::from(&key));
         let Some(handle) = load_asset_file(world, &path, &mut skipped) else {
             continue;
         };
-        world
-            .resource_mut::<JackdawCatalog>()
-            .files
-            .insert(key.clone(), handle.clone());
+        {
+            let mut catalog = world.resource_mut::<JackdawCatalog>();
+            catalog.files.insert(key.clone(), handle.clone());
+            if let Some(written) = assets_relative_key(root, &path) {
+                catalog.files.insert(written, handle.clone());
+            }
+        }
         loaded.push((jackdaw_bsn::path_stem(&path), key, handle));
     }
 
@@ -1461,7 +1462,7 @@ fn load_asset_file(
     path: &Path,
     skipped: &mut SkippedTypes,
 ) -> Option<UntypedHandle> {
-    let text = match std::fs::read_to_string(path) {
+    let text = match jackdaw_bsn::read_document_text(path) {
         Ok(text) => text,
         Err(err) => {
             warn!("Failed to read {}: {err}", path.display());

--- a/crates/jackdaw_runtime/tests/binary_assets.rs
+++ b/crates/jackdaw_runtime/tests/binary_assets.rs
@@ -1,0 +1,100 @@
+//! The startup walk reads a document in either form, and keys a binary one by
+//! the path its text twin would sit at, so references written before an export
+//! still resolve.
+
+use std::path::PathBuf;
+
+use bevy::asset::{Asset, AssetApp};
+use bevy::prelude::*;
+use bevy::reflect::TypePath;
+use jackdaw_runtime::{JackdawCatalog, JackdawCatalogPath, JackdawPlugin};
+
+/// A reflectable stand-in for a material, so the walk has a registered asset
+/// type to load without the render stack.
+#[derive(Asset, Reflect, Default)]
+#[reflect(Default)]
+struct BinaryMaterial {
+    tint: f32,
+}
+
+fn unique_temp_dir(label: &str) -> PathBuf {
+    let nanos = std::time::SystemTime::now()
+        .duration_since(std::time::UNIX_EPOCH)
+        .map(|d| d.as_nanos())
+        .unwrap_or(0);
+    std::env::temp_dir().join(format!(
+        "jackdaw-runtime-{label}-{}-{nanos}",
+        std::process::id()
+    ))
+}
+
+fn app_over(dir: &std::path::Path) -> App {
+    let mut app = App::new();
+    app.add_plugins(MinimalPlugins);
+    app.add_plugins(bevy::transform::TransformPlugin);
+    app.add_plugins(bevy::asset::AssetPlugin::default());
+    app.add_plugins(bevy::world_serialization::WorldSerializationPlugin);
+    app.add_plugins(bevy::image::ImagePlugin::default());
+    app.init_asset::<BinaryMaterial>();
+    app.register_asset_reflect::<BinaryMaterial>();
+    app.insert_resource(JackdawCatalogPath(dir.join("catalog.bsn")));
+    app.add_plugins(JackdawPlugin);
+    app
+}
+
+#[test]
+fn the_runtime_loads_a_material_held_in_the_binary_form() {
+    let type_path = <BinaryMaterial as TypePath>::type_path();
+    let dir = unique_temp_dir("binary-material");
+    std::fs::create_dir_all(dir.join("materials")).unwrap();
+    let text = jackdaw_bsn::with_asset_header(type_path, &format!("#grass\n{type_path}\n"));
+    jackdaw_bsn::write_document_text(&dir.join("materials/grass.bsb"), &text).unwrap();
+
+    let mut app = app_over(&dir);
+    app.update();
+
+    let catalog = app.world().resource::<JackdawCatalog>();
+    assert!(
+        catalog.get("materials/grass.bsn").is_some(),
+        "a binary material answers to the path its text twin would sit at"
+    );
+    assert!(
+        catalog.get("materials/grass.bsb").is_some(),
+        "and to the path it is written at"
+    );
+    assert!(
+        catalog.get("@grass").is_some(),
+        "and to the one name it carries"
+    );
+
+    let _ = std::fs::remove_dir_all(&dir);
+}
+
+#[test]
+fn a_document_held_in_both_forms_is_loaded_once_from_its_text() {
+    let type_path = <BinaryMaterial as TypePath>::type_path();
+    let dir = unique_temp_dir("binary-material-pair");
+    std::fs::create_dir_all(dir.join("materials")).unwrap();
+    let text = jackdaw_bsn::with_asset_header(
+        type_path,
+        &format!("#grass\n{type_path} {{ tint: 1.0 }}\n"),
+    );
+    jackdaw_bsn::write_document_text(&dir.join("materials/grass.bsn"), &text).unwrap();
+    jackdaw_bsn::write_document_text(&dir.join("materials/grass.bsb"), &text).unwrap();
+
+    let mut app = app_over(&dir);
+    app.update();
+
+    let catalog = app.world().resource::<JackdawCatalog>();
+    assert!(
+        catalog.get("materials/grass.bsn").is_some(),
+        "the text file is the one that loaded"
+    );
+    assert_eq!(
+        catalog.len(),
+        2,
+        "the pair is one asset under one path and one name, not two"
+    );
+
+    let _ = std::fs::remove_dir_all(&dir);
+}

--- a/crates/jackdaw_runtime/tests/prefab_resolution.rs
+++ b/crates/jackdaw_runtime/tests/prefab_resolution.rs
@@ -190,6 +190,32 @@ fn a_reference_deeper_than_the_cap_is_refused() {
     );
 }
 
+#[test]
+fn a_prefab_held_only_in_the_binary_form_still_resolves() {
+    let dir = tempfile::tempdir().unwrap();
+    jackdaw_bsn::write_document_text(&dir.path().join("panel.bsb"), PANEL_BSN).unwrap();
+
+    let mut app = runtime_app(dir.path());
+    let scene = add_scene(
+        &mut app,
+        "jackdaw::prefab::components::IsA { source: \"panel.bsn\", deleted: [] }\n\
+         jackdaw::prefab::components::PrefabEntityId(0)\n",
+    );
+    app.world_mut().spawn(JackdawSceneRoot(scene));
+
+    app.update();
+    app.update();
+
+    assert!(
+        named_entity(app.world_mut(), "Panel").is_some(),
+        "the reference an export left spelled .bsn found the file that is there"
+    );
+    assert!(
+        named_entity(app.world_mut(), "Label").is_some(),
+        "and the inherited child spawned with it"
+    );
+}
+
 fn add_scene(app: &mut App, bsn: &str) -> Handle<JackdawScene> {
     app.world_mut()
         .resource_mut::<Assets<JackdawScene>>()

--- a/src/asset_browser.rs
+++ b/src/asset_browser.rs
@@ -287,13 +287,16 @@ fn on_asset_browser_context_action(
         }
         return;
     }
-    if event.action != "asset_browser.delete" {
-        return;
-    }
+    let operator = match event.action.as_str() {
+        "asset_browser.delete" => "file.delete",
+        "asset_browser.convert_to_binary" => "file.convert_to_binary",
+        "asset_browser.convert_to_text" => "file.convert_to_text",
+        _ => return,
+    };
     let Some(path) = state.selected_file.clone() else {
         return;
     };
-    commands.operator("file.delete").param("path", path).call();
+    commands.operator(operator).param("path", path).call();
     if let Some(menu) = menu_state.menu_entity.take()
         && let Ok(mut ec) = commands.get_entity(menu)
     {
@@ -569,7 +572,9 @@ fn refresh_browser_on_change(
                     .path
                     .extension()
                     .and_then(|e| e.to_str())
-                    .is_some_and(|e| e.eq_ignore_ascii_case("jsn") || e.eq_ignore_ascii_case("bsn"))
+                    .is_some_and(|e| {
+                        e.eq_ignore_ascii_case("jsn") || jackdaw_bsn::is_document_extension(e)
+                    })
             {
                 entry.kind = state.kind_cache.check(&entry.path, &asset_kinds);
             }
@@ -885,6 +890,13 @@ fn refresh_browser_on_change(
                             crate::new_asset::NEW_ASSET_LABEL.to_string(),
                         ));
                     }
+                    if jackdaw_bsn::is_document_path(&rmb_path) {
+                        let convert = match jackdaw_bsn::is_binary_path(&rmb_path) {
+                            true => ("asset_browser.convert_to_text", "Convert to Text"),
+                            false => ("asset_browser.convert_to_binary", "Convert to Binary"),
+                        };
+                        items.push((convert.0.to_string(), convert.1.to_string()));
+                    }
                     items.push(("asset_browser.delete".to_string(), "Delete".to_string()));
                     let entries: Vec<(&str, &str)> = items
                         .iter()
@@ -905,8 +917,8 @@ fn refresh_browser_on_change(
             // out of `ActiveAssetDrag` and route through `spawn_instance`,
             // which normalizes a plain scene into an instanceable prefab.
             // Clear on DragEnd if nothing consumed it.
-            let is_bsn_scene = entry.path.extension().is_some_and(|e| e == "bsn");
-            if entry.is_prefab() || is_bsn_scene {
+            let is_document = jackdaw_bsn::is_document_path(&entry.path);
+            if entry.is_prefab() || is_document {
                 let drag_path = entry.path.clone();
                 commands.entity(item_entity).observe(
                     move |_: On<Pointer<DragStart>>, mut drag: ResMut<ActiveAssetDrag>| {
@@ -1161,7 +1173,7 @@ fn handle_file_double_click(
     }
 
     let path_lower = event.path.to_lowercase();
-    if path_lower.ends_with(".jsn") || path_lower.ends_with(".bsn") {
+    if path_lower.ends_with(".jsn") || jackdaw_bsn::is_document_path(Path::new(&path_lower)) {
         let path_owned = std::path::PathBuf::from(&event.path);
         commands.queue(move |world: &mut World| {
             crate::scenes::operators::scene_open_system(world, &path_owned);

--- a/src/asset_catalog.rs
+++ b/src/asset_catalog.rs
@@ -106,7 +106,7 @@ pub fn load_catalog(world: &mut World) {
         }
     };
 
-    if catalog_path.extension().is_some_and(|e| e == "bsn") {
+    if jackdaw_bsn::is_document_path(&catalog_path) {
         if is_empty_catalog_text(&json) {
             info!("Asset catalog holds no entries");
             return;

--- a/src/asset_index.rs
+++ b/src/asset_index.rs
@@ -215,13 +215,11 @@ pub fn assets_dir(world: &World) -> Option<PathBuf> {
 
 /// An indexed path as the file it names on disk.
 pub fn absolute_path(world: &World, path: &Path) -> PathBuf {
-    if path.is_absolute() {
-        return path.to_path_buf();
-    }
-    match assets_dir(world) {
-        Some(assets) => assets.join(path),
-        None => path.to_path_buf(),
-    }
+    let path = match (path.is_absolute(), assets_dir(world)) {
+        (true, _) | (false, None) => path.to_path_buf(),
+        (false, Some(assets)) => assets.join(path),
+    };
+    jackdaw_bsn::existing_form(&path).unwrap_or(path)
 }
 
 /// A file on disk as the path the index keys it by. `None` for a file outside
@@ -241,7 +239,17 @@ pub fn indexed_path(world: &World, path: &Path) -> Option<PathBuf> {
 /// Whether an indexed path is the project's catalog file, which holds what has
 /// no file of its own and is no asset in its own right.
 pub fn is_catalog_file(path: &Path) -> bool {
-    matches!(path.to_str(), Some("catalog.bsn") | Some("catalog.jsn"))
+    matches!(
+        path.to_str(),
+        Some("catalog.bsn") | Some("catalog.bsb") | Some("catalog.jsn")
+    )
+}
+
+/// The file a keyed document sits in: the text file, or the binary twin where
+/// that is the only form on disk.
+fn document_file(assets: &Path, relative: &Path) -> PathBuf {
+    let path = assets.join(relative);
+    jackdaw_bsn::existing_form(&path).unwrap_or(path)
 }
 
 /// What a file says it holds, and the kind that claims it.
@@ -359,7 +367,13 @@ pub fn rescan_asset_index(world: &mut World) -> AssetRescan {
         .into_iter()
         .filter_map(|path| {
             let relative = path.strip_prefix(&assets).ok()?.to_path_buf();
-            (!is_catalog_file(&relative)).then_some(relative)
+            if is_catalog_file(&relative) {
+                return None;
+            }
+            Some(match jackdaw_bsn::is_binary_path(&relative) {
+                true => jackdaw_bsn::text_twin(&relative),
+                false => relative,
+            })
         })
         .collect();
     world
@@ -373,7 +387,7 @@ pub fn rescan_asset_index(world: &mut World) -> AssetRescan {
         documents
             .into_iter()
             .filter_map(|relative| {
-                let path = assets.join(&relative);
+                let path = document_file(&assets, &relative);
                 let kind = kind_of_file(&path, kinds, &mut cache)?;
                 let mtime = std::fs::metadata(&path)
                     .and_then(|meta| meta.modified())
@@ -409,7 +423,7 @@ pub fn rescan_asset_index(world: &mut World) -> AssetRescan {
             .resource::<AssetIndex>()
             .get(&relative)
             .map(|entry| (entry.mtime, entry.value.clone(), entry.kind.clone()));
-        let file = assets.join(&relative);
+        let file = document_file(&assets, &relative);
         let value = match held {
             Some((known, _, _)) if known == mtime => continue,
             Some((_, _, known_kind)) if known_kind != kind.kind => {
@@ -706,12 +720,8 @@ mod tests {
         );
     }
 
-    /// The runtime counts a name over every document its walk saw, and so does
-    /// this: a scene sharing a stem with an asset makes the name ambiguous in
-    /// both.
-    #[test]
-    fn a_name_a_scene_and_an_asset_share_stands_for_neither() {
-        let tmp = tempfile::tempdir().expect("tempdir");
+    /// A project holding one registered asset kind, for the walk to index.
+    fn material_project(root: &Path) -> App {
         let mut app = App::new();
         app.add_plugins((
             bevy::app::TaskPoolPlugin::default(),
@@ -723,7 +733,7 @@ mod tests {
         app.register_asset_reflect::<StandardMaterial>();
         app.register_type::<StandardMaterial>();
         app.insert_resource(ProjectRoot {
-            root: tmp.path().to_path_buf(),
+            root: root.to_path_buf(),
             config: crate::project::ProjectConfig::default(),
         });
         app.init_resource::<AssetIndex>();
@@ -738,22 +748,34 @@ mod tests {
                 "Material",
                 <StandardMaterial as bevy::reflect::TypePath>::type_path(),
             ));
-        for (relative, text) in [
-            (
-                "materials/grass.bsn",
-                "#grass\nbevy_pbr::pbr_material::StandardMaterial {}\n",
-            ),
-            (
-                "zones/grass.bsn",
-                "#Root\nbevy_transform::components::transform::Transform\n\
-                 bevy_ecs::hierarchy::Children [\n    \
-                 bevy_transform::components::transform::Transform\n]\n",
-            ),
-        ] {
-            let path = tmp.path().join("assets").join(relative);
-            std::fs::create_dir_all(path.parent().expect("a parent")).expect("the folder is made");
-            std::fs::write(path, text).expect("the file is written");
-        }
+        app
+    }
+
+    /// Write one document under the project's assets, in the form its
+    /// extension names.
+    fn write_asset(root: &Path, relative: &str, text: &str) {
+        let path = root.join("assets").join(relative);
+        std::fs::create_dir_all(path.parent().expect("a parent")).expect("the folder is made");
+        jackdaw_bsn::write_document_text(&path, text).expect("the file is written");
+    }
+
+    const GRASS: &str = "#grass\nbevy_pbr::pbr_material::StandardMaterial {}\n";
+
+    /// The runtime counts a name over every document its walk saw, and so does
+    /// this: a scene sharing a stem with an asset makes the name ambiguous in
+    /// both.
+    #[test]
+    fn a_name_a_scene_and_an_asset_share_stands_for_neither() {
+        let tmp = tempfile::tempdir().expect("tempdir");
+        let mut app = material_project(tmp.path());
+        write_asset(tmp.path(), "materials/grass.bsn", GRASS);
+        write_asset(
+            tmp.path(),
+            "zones/grass.bsn",
+            "#Root\nbevy_transform::components::transform::Transform\n\
+             bevy_ecs::hierarchy::Children [\n    \
+             bevy_transform::components::transform::Transform\n]\n",
+        );
 
         rescan_asset_index(app.world_mut());
 
@@ -765,6 +787,47 @@ mod tests {
         assert!(
             index.get(Path::new("materials/grass.bsn")).is_some(),
             "the file is there to be named by its path"
+        );
+    }
+
+    #[test]
+    fn a_document_held_only_in_binary_is_keyed_by_the_path_its_text_twin_would_sit_at() {
+        let tmp = tempfile::tempdir().expect("tempdir");
+        let mut app = material_project(tmp.path());
+        write_asset(tmp.path(), "materials/grass.bsb", GRASS);
+
+        rescan_asset_index(app.world_mut());
+
+        let index = app.world().resource::<AssetIndex>();
+        assert!(
+            index.get(Path::new("materials/grass.bsn")).is_some(),
+            "a reference written before the export still names it"
+        );
+        assert!(index.get(Path::new("materials/grass.bsb")).is_none());
+        assert_eq!(
+            index.by_stem("grass").map(|entry| entry.path.clone()),
+            Some(PathBuf::from("materials/grass.bsn")),
+            "and the one name it carries is not made ambiguous by its own form"
+        );
+    }
+
+    #[test]
+    fn a_document_held_in_both_forms_is_keyed_once_and_read_from_its_text() {
+        let tmp = tempfile::tempdir().expect("tempdir");
+        let mut app = material_project(tmp.path());
+        write_asset(tmp.path(), "materials/grass.bsn", GRASS);
+        write_asset(tmp.path(), "materials/grass.bsb", GRASS);
+
+        rescan_asset_index(app.world_mut());
+
+        let assets = tmp.path().join("assets");
+        let index = app.world().resource::<AssetIndex>();
+        assert_eq!(index.iter().count(), 1, "the pair is one asset");
+        assert!(index.get(Path::new("materials/grass.bsn")).is_some());
+        assert_eq!(
+            document_file(&assets, Path::new("materials/grass.bsn")),
+            assets.join("materials/grass.bsn"),
+            "and the text file is the one it is read from"
         );
     }
 

--- a/src/definition_assets.rs
+++ b/src/definition_assets.rs
@@ -123,7 +123,7 @@ pub fn new_definition_dir(world: &World) -> Option<PathBuf> {
 /// Read one asset file into a value. A file that cannot be read or parsed, or
 /// that holds a value of another type, is reported and skipped.
 pub fn read_asset_file(world: &mut World, kind: &AssetKind, path: &Path) -> Option<AssetValue> {
-    let text = match std::fs::read_to_string(path) {
+    let text = match jackdaw_bsn::read_document_text(path) {
         Ok(text) => text,
         Err(err) => {
             warn!("Failed to read {}: {err}", path.display());
@@ -221,7 +221,8 @@ pub fn write_asset_file(
     value: &AssetValue,
     path: &Path,
 ) -> std::io::Result<PathBuf> {
-    let existing = std::fs::read_to_string(path).ok();
+    let path = &jackdaw_bsn::existing_form(path).unwrap_or_else(|| path.to_path_buf());
+    let existing = jackdaw_bsn::read_document_text(path).ok();
     let name = existing
         .as_deref()
         .and_then(root_name_of)
@@ -238,7 +239,8 @@ pub fn write_asset_file(
     if let Some(parent) = path.parent() {
         std::fs::create_dir_all(parent)?;
     }
-    crate::scene_io::save::write_atomic(path, text.as_bytes())?;
+    let bytes = jackdaw_bsn::document_bytes(path, &text).map_err(std::io::Error::other)?;
+    crate::scene_io::save::write_atomic(path, &bytes)?;
     Ok(path.to_path_buf())
 }
 

--- a/src/file_ops.rs
+++ b/src/file_ops.rs
@@ -1,11 +1,12 @@
 //! Filesystem operators for the asset browser and project files panel.
 //!
-//! Currently exposes `file.delete`, which confirms via a dialog before
-//! removing the path from disk. Both the asset browser and the project
-//! files panel call into this operator when the user picks the Delete
-//! entry from a right-click menu.
+//! `file.delete` confirms via a dialog before removing the path from disk,
+//! `file.convert_to_binary` and `file.convert_to_text` rewrite one document in
+//! the other form, and `project.export_binary` writes a whole tree out as
+//! binary for a shipped game. Both the asset browser and the project files
+//! panel reach these from a right-click menu.
 
-use std::path::PathBuf;
+use std::path::{Path, PathBuf};
 
 use bevy::prelude::*;
 use jackdaw_api::prelude::*;
@@ -30,6 +31,21 @@ pub struct PendingFileDelete {
 
 pub(crate) fn add_to_extension(ctx: &mut ExtensionContext) {
     ctx.register_operator::<FileDeleteOp>();
+    ctx.register_operator::<FileConvertToBinaryOp>();
+    ctx.register_operator::<FileConvertToTextOp>();
+    ctx.register_operator::<ProjectExportBinaryOp>();
+}
+
+/// The folder an export writes into when none is named: a sibling of the tree.
+fn default_export_dir(source: &Path) -> PathBuf {
+    let name = source
+        .file_name()
+        .map(|name| name.to_string_lossy().into_owned())
+        .unwrap_or_else(|| "assets".to_string());
+    source
+        .parent()
+        .unwrap_or(Path::new("."))
+        .join(format!("{name}-binary"))
 }
 
 /// Confirm and delete a file or directory from disk. The path is taken
@@ -98,6 +114,148 @@ fn on_file_delete_confirmed(
         if browser.selected_file.as_deref() == Some(path_str.as_str()) {
             browser.selected_file = None;
             browser.needs_refresh = true;
+        }
+    }
+}
+
+/// Rewrite one document as its binary twin, in place.
+#[operator(
+    id = "file.convert_to_binary",
+    label = "Convert to Binary",
+    description = "Rewrite one BSN document in the binary form, removing the text file.",
+    allows_undo = false,
+    params(path(String, doc = "The document to convert."))
+)]
+pub fn file_convert_to_binary(
+    params: In<OperatorParameters>,
+    scenes: Option<Res<crate::scenes::Scenes>>,
+) -> OperatorResult {
+    convert_document(
+        params.as_str("path"),
+        jackdaw_bsn::DocumentForm::Binary,
+        scenes.as_deref(),
+    )
+}
+
+/// Rewrite one document as `.bsn` text, in place.
+#[operator(
+    id = "file.convert_to_text",
+    label = "Convert to Text",
+    description = "Rewrite one BSN document in the text form, removing the binary file.",
+    allows_undo = false,
+    params(path(String, doc = "The document to convert."))
+)]
+pub fn file_convert_to_text(
+    params: In<OperatorParameters>,
+    scenes: Option<Res<crate::scenes::Scenes>>,
+) -> OperatorResult {
+    convert_document(
+        params.as_str("path"),
+        jackdaw_bsn::DocumentForm::Text,
+        scenes.as_deref(),
+    )
+}
+
+fn convert_document(
+    path: Option<&str>,
+    to: jackdaw_bsn::DocumentForm,
+    scenes: Option<&crate::scenes::Scenes>,
+) -> OperatorResult {
+    let Some(path) = path.map(PathBuf::from) else {
+        warn!("convert: no path provided");
+        return OperatorResult::Cancelled;
+    };
+    if !jackdaw_bsn::is_document_path(&path) {
+        warn!("convert: {} is not a BSN document", path.display());
+        return OperatorResult::Cancelled;
+    }
+    if scenes.is_some_and(|scenes| is_open_in_a_tab(scenes, &path)) {
+        warn!(
+            "convert: {} is open; close its tab before changing the form it is held in",
+            path.display()
+        );
+        return OperatorResult::Cancelled;
+    }
+    let converted = match to {
+        jackdaw_bsn::DocumentForm::Binary => jackdaw_bsn::convert_to_binary(&path),
+        jackdaw_bsn::DocumentForm::Text => jackdaw_bsn::convert_to_text(&path),
+    };
+    match converted {
+        Ok(written) => {
+            info!("{} is now {}", path.display(), written.display());
+            OperatorResult::Finished
+        }
+        Err(err) => {
+            warn!("convert: {err}");
+            OperatorResult::Cancelled
+        }
+    }
+}
+
+/// Whether a tab holds the document at `path`, whose file a conversion moves.
+fn is_open_in_a_tab(scenes: &crate::scenes::Scenes, path: &Path) -> bool {
+    let held = path.canonicalize().unwrap_or_else(|_| path.to_path_buf());
+    scenes.tabs.iter().any(|tab| {
+        tab.path
+            .as_ref()
+            .map(|open| open.canonicalize().unwrap_or_else(|_| open.clone()))
+            .is_some_and(|open| open == held)
+    })
+}
+
+/// Write a tree of documents out in the binary form, for a shipped game.
+#[operator(
+    id = "project.export_binary",
+    label = "Export Binary Assets",
+    description = "Write every BSN document under a folder out in the binary form, leaving the \
+                   source files as they are and copying everything else through.",
+    allows_undo = false,
+    params(
+        path(
+            String,
+            doc = "The folder to convert. Defaults to the project's assets folder."
+        ),
+        out(
+            String,
+            doc = "The folder to write into. Defaults to a sibling of the source."
+        )
+    )
+)]
+pub fn project_export_binary(
+    params: In<OperatorParameters>,
+    project: Option<Res<crate::project::ProjectRoot>>,
+) -> OperatorResult {
+    let source = params
+        .as_str("path")
+        .map(PathBuf::from)
+        .or_else(|| project.as_ref().map(|project| project.assets_dir()));
+    let Some(source) = source else {
+        warn!("project.export_binary: no folder to convert");
+        return OperatorResult::Cancelled;
+    };
+    if !source.is_dir() {
+        warn!(
+            "project.export_binary: {} is not a folder",
+            source.display()
+        );
+        return OperatorResult::Cancelled;
+    }
+    let destination = params
+        .as_str("out")
+        .map(PathBuf::from)
+        .unwrap_or_else(|| default_export_dir(&source));
+    match jackdaw_bsn::export_binary(&source, &destination) {
+        Ok(converted) => {
+            info!(
+                "exported {converted} documents from {} into {}",
+                source.display(),
+                destination.display()
+            );
+            OperatorResult::Finished
+        }
+        Err(err) => {
+            warn!("project.export_binary: {err}");
+            OperatorResult::Cancelled
         }
     }
 }

--- a/src/material_assets.rs
+++ b/src/material_assets.rs
@@ -236,7 +236,10 @@ pub fn material_save_path(
         .get_resource::<crate::asset_index::AssetIndex>()
         .and_then(|index| index.by_handle(&handle.clone().untyped()))
         .filter(|entry| entry.name() == stem)
-        .map(|entry| project.assets_dir().join(&entry.path));
+        .map(|entry| {
+            let filed = project.assets_dir().join(&entry.path);
+            jackdaw_bsn::existing_form(&filed).unwrap_or(filed)
+        });
     Some(filed.unwrap_or_else(|| material_file_path(project, name)))
 }
 
@@ -291,6 +294,7 @@ pub fn remove_material_file(world: &World, name: &str) {
         .and_then(|index| index.material_named(name))
         .map(|entry| project.assets_dir().join(&entry.path));
     let path = filed.unwrap_or_else(|| material_file_path(project, name));
+    let path = jackdaw_bsn::existing_form(&path).unwrap_or(path);
     match std::fs::remove_file(&path) {
         Ok(()) => info!("Removed {}", path.display()),
         Err(err) if err.kind() == std::io::ErrorKind::NotFound => {}
@@ -302,7 +306,7 @@ pub fn remove_material_file(world: &World, name: &str) {
 /// skipped; a missing texture path still produces a handle (the asset server
 /// surfaces the missing file), so one dead texture never drops the material.
 pub fn load_material_file(world: &mut World, path: &Path) -> Option<UntypedHandle> {
-    let text = match std::fs::read_to_string(path) {
+    let text = match jackdaw_bsn::read_document_text(path) {
         Ok(text) => text,
         Err(err) => {
             warn!("Failed to read {}: {err}", path.display());

--- a/src/prefab/save_load.rs
+++ b/src/prefab/save_load.rs
@@ -96,6 +96,9 @@ pub(crate) fn resolve_source_path(source: &Path, scene_dir: &Path) -> PathBuf {
     // Scenes written before (or after) their prefab converted formats may
     // reference the other extension; fall back to the sibling.
     if !resolved.exists() {
+        if let Some(held) = jackdaw_bsn::existing_form(&resolved) {
+            return held;
+        }
         let sibling = match resolved.extension().and_then(|e| e.to_str()) {
             Some("jsn") => Some(resolved.with_extension("bsn")),
             Some("bsn") => Some(resolved.with_extension("jsn")),
@@ -112,7 +115,7 @@ pub(crate) fn resolve_source_path(source: &Path, scene_dir: &Path) -> PathBuf {
 
 /// Read a prefab file into a document.
 pub fn read_prefab_ast(path: &Path) -> Result<SceneBsnAst, std::io::Error> {
-    if path.extension().is_some_and(|e| e == "bsn") {
+    if jackdaw_bsn::is_document_path(path) {
         return jackdaw_prefab::source::read_prefab_document(path);
     }
     // TODO: legacy `.jsn` prefabs with no `.bsn` sibling cannot be cached

--- a/src/project_files.rs
+++ b/src/project_files.rs
@@ -64,10 +64,13 @@ fn on_project_files_context_action(
         }
         return;
     }
-    if event.action != "project_files.delete" {
-        return;
-    }
-    commands.operator("file.delete").param("path", path).call();
+    let operator = match event.action.as_str() {
+        "project_files.delete" => "file.delete",
+        "project_files.convert_to_binary" => "file.convert_to_binary",
+        "project_files.convert_to_text" => "file.convert_to_text",
+        _ => return,
+    };
+    commands.operator(operator).param("path", path).call();
     if let Some(menu) = state.menu_entity.take()
         && let Ok(mut ec) = commands.get_entity(menu)
     {
@@ -476,6 +479,12 @@ fn spawn_file_tree_row(
             let mut items: Vec<(&str, &str)> = Vec::new();
             if is_dir {
                 items.push((NEW_ASSET_ACTION, crate::new_asset::NEW_ASSET_LABEL));
+            }
+            if jackdaw_bsn::is_document_path(&rmb_path) {
+                items.push(match jackdaw_bsn::is_binary_path(&rmb_path) {
+                    true => ("project_files.convert_to_text", "Convert to Text"),
+                    false => ("project_files.convert_to_binary", "Convert to Binary"),
+                });
             }
             items.push(("project_files.delete", "Delete"));
             let menu = jackdaw_feathers::context_menu::spawn_context_menu(

--- a/src/remote/server.rs
+++ b/src/remote/server.rs
@@ -1089,7 +1089,7 @@ fn asset_kind(path: &str) -> &'static str {
         "glb" | "gltf" | "obj" | "fbx" => "model",
         "png" | "jpg" | "jpeg" | "ktx2" | "basis" | "exr" | "hdr" | "dds" => "image",
         "ogg" | "wav" | "flac" | "mp3" => "audio",
-        "bsn" | "jsn" | "scn" | "ron" => "scene",
+        "bsn" | "bsb" | "jsn" | "scn" | "ron" => "scene",
         "ttf" | "otf" => "font",
         "wgsl" | "glsl" | "spv" => "shader",
         _ => "file",

--- a/src/scene_io/load.rs
+++ b/src/scene_io/load.rs
@@ -57,7 +57,7 @@ pub fn spawn_open_dialog(world: &mut World) {
     let dialog =
         crate::native_dialog::file_dialog(world, crate::native_dialog::DialogPurpose::Scene)
             .set_title("Open scene")
-            .add_filter("Jackdaw scene", &["bsn", "jsn"]);
+            .add_filter("Jackdaw scene", &["bsn", "bsb", "jsn"]);
     let task =
         bevy::tasks::AsyncComputeTaskPool::get().spawn(async move { dialog.pick_file().await });
     world.insert_resource(SceneDialogTask::Open(task));
@@ -126,7 +126,16 @@ pub fn load_scene_from_file_with_outcome(
 fn finish_load_scene(world: &mut World, chosen: &std::path::Path) -> LoadOutcome {
     let mut path = chosen.to_string_lossy().to_string();
 
-    let json = match std::fs::read_to_string(&path) {
+    let bytes = match std::fs::read(&path) {
+        Ok(bytes) => bytes,
+        Err(err) => {
+            return refuse(
+                RefusalCategory::Unreadable,
+                format!("failed to read scene file '{path}': {err}"),
+            );
+        }
+    };
+    let json = match jackdaw_bsn::document_text_from_bytes(&bytes, Path::new(&path)) {
         Ok(json) => json,
         Err(err) => {
             return refuse(
@@ -183,7 +192,7 @@ fn finish_load_scene(world: &mut World, chosen: &std::path::Path) -> LoadOutcome
         // editor opens that. The conversion is held in memory until the
         // document below is accepted, so a refused scene leaves nothing behind.
         // The legacy metadata and camera framing carry over below.
-        let (bsn_text, legacy_jsn, pending_conversion) = if path.ends_with(".bsn") {
+        let (bsn_text, legacy_jsn, pending_conversion) = if !path.ends_with(".jsn") {
             (json, None, None)
         } else {
             let jsn = match jackdaw_jsn::format::parse_scene(&json) {
@@ -222,9 +231,13 @@ fn finish_load_scene(world: &mut World, chosen: &std::path::Path) -> LoadOutcome
         };
 
         // Hash of what was read rather than of a later look at disk, so an edit
-        // landing in between still registers as an external edit.
+        // landing in between still registers as an external edit, and as the
+        // bytes it was stored as, which is what the watcher reads back.
         loaded_hash = Some(crate::scenes::external_watch::hash_bytes(
-            bsn_text.as_bytes(),
+            match legacy_jsn.is_none() {
+                true => &bytes,
+                false => bsn_text.as_bytes(),
+            },
         ));
 
         // Migrate reflect type-paths for scenes written under an older Bevy,

--- a/src/scene_io/save.rs
+++ b/src/scene_io/save.rs
@@ -46,7 +46,7 @@ fn spawn_save_dialog(world: &mut World) {
         crate::native_dialog::DialogPurpose::Scene,
         "scene.bsn",
     )
-    .add_filter("BSN Scene", &["bsn"]);
+    .add_filter("BSN Scene", &["bsn", "bsb"]);
 
     let task = AsyncComputeTaskPool::get().spawn(async move { dialog.save_file().await });
     world.insert_resource(SceneDialogTask::Save(task));
@@ -330,13 +330,15 @@ pub(crate) fn save_scene_inner(world: &mut World) -> Result<(), BevyError> {
             ))
         })?;
     }
-    write_atomic(Path::new(&path), contents.as_bytes())
+    let contents = jackdaw_bsn::document_bytes(Path::new(&path), &contents)
+        .map_err(|err| BevyError::from(format!("failed to write scene file {path}: {err}")))?;
+    write_atomic(Path::new(&path), &contents)
         .map_err(|err| BevyError::from(format!("failed to write scene file {path}: {err}")))?;
     info!("Scene saved to {path}");
 
     // Record the written bytes so the open-tab watcher does not read this
     // write back as an outside edit.
-    crate::scenes::external_watch::note_known_content(world, Path::new(&path), contents.as_bytes());
+    crate::scenes::external_watch::note_known_content(world, Path::new(&path), &contents);
 
     // A terrain bake writes its own artifact when it finishes; this covers a scene that has
     // moved since, keeping the two files named after each other.

--- a/src/scenes/operators.rs
+++ b/src/scenes/operators.rs
@@ -276,7 +276,7 @@ pub fn scene_open_system(world: &mut World, path: &std::path::Path) {
     }
 
     // Read the file.
-    let file_text = match std::fs::read_to_string(&canonical) {
+    let file_text = match jackdaw_bsn::read_document_text(&canonical) {
         Ok(t) => t,
         Err(err) => {
             warn!("scene.open: failed to read {canonical:?}: {err}");
@@ -284,34 +284,33 @@ pub fn scene_open_system(world: &mut World, path: &std::path::Path) {
         }
     };
 
-    // `.bsn` parses directly. Legacy `.jsn` converts to a `.bsn` document held
-    // in memory until it is accepted below.
+    // A BSN document parses directly. Legacy `.jsn` converts to a `.bsn`
+    // document held in memory until it is accepted below.
     let mut saved_camera: Option<Transform> = None;
     // The path the user picked; `canonical` becomes the conversion's target,
     // which does not exist until the commit below.
     let opened = canonical.clone();
-    let (canonical, file_text, pending_conversion) =
-        if canonical.extension().is_some_and(|e| e == "bsn") {
-            (canonical, file_text, None)
-        } else {
-            // Read the camera framing sidecar before the source is renamed.
-            saved_camera = serde_json::from_str::<jackdaw_jsn::format::JsnScene>(&file_text)
-                .ok()
-                .and_then(|jsn| jsn.editor.as_ref().and_then(|e| e.camera.clone()))
-                .map(std::convert::Into::into);
-            let pending = match crate::jsn_to_bsn::convert_scene_file_pending(world, &canonical) {
-                Ok(pending) => pending,
-                Err(err) => {
-                    warn!("scene.open: legacy conversion of {canonical:?} failed: {err}");
-                    return;
-                }
-            };
-            (
-                pending.bsn_path.clone(),
-                pending.scene_bsn.clone(),
-                Some(pending),
-            )
+    let (canonical, file_text, pending_conversion) = if jackdaw_bsn::is_document_path(&canonical) {
+        (canonical, file_text, None)
+    } else {
+        // Read the camera framing sidecar before the source is renamed.
+        saved_camera = serde_json::from_str::<jackdaw_jsn::format::JsnScene>(&file_text)
+            .ok()
+            .and_then(|jsn| jsn.editor.as_ref().and_then(|e| e.camera.clone()))
+            .map(std::convert::Into::into);
+        let pending = match crate::jsn_to_bsn::convert_scene_file_pending(world, &canonical) {
+            Ok(pending) => pending,
+            Err(err) => {
+                warn!("scene.open: legacy conversion of {canonical:?} failed: {err}");
+                return;
+            }
         };
+        (
+            pending.bsn_path.clone(),
+            pending.scene_bsn.clone(),
+            Some(pending),
+        )
+    };
     let dirty = false;
     let doc = match jackdaw_bsn::parse_bsn_text(&file_text) {
         Ok(doc) => doc,
@@ -344,7 +343,8 @@ pub fn scene_open_system(world: &mut World, path: &std::path::Path) {
     }
     // Record the bytes before the tab exists: the watcher starts with the tab,
     // and an edit landing in that gap still has to be reported.
-    crate::scenes::external_watch::note_known_content(world, &canonical, file_text.as_bytes());
+    let known = std::fs::read(&canonical).unwrap_or_else(|_| file_text.clone().into_bytes());
+    crate::scenes::external_watch::note_known_content(world, &canonical, &known);
 
     let is_prefab = document_is_prefab(&doc);
 

--- a/tests/stage/asset_references.rs
+++ b/tests/stage/asset_references.rs
@@ -344,6 +344,75 @@ fn material_apply_takes_the_path_of_a_material_file() {
     );
 }
 
+#[test]
+fn a_reference_resolves_to_the_material_it_names_after_that_file_turns_binary() {
+    let (mut app, tmp) = editor_with_outfits();
+    file_material(&mut app, "materials/slate.material.bsn");
+    let filed = tmp.path().join("assets/materials/slate.material.bsn");
+
+    call(
+        &mut app,
+        "file.convert_to_binary",
+        &[("path", filed.to_string_lossy().into_owned().into())],
+    );
+    jackdaw::asset_index::rescan_asset_index(app.world_mut());
+    app.update();
+
+    assert!(!filed.exists(), "the text file gave way to its twin");
+    assert!(
+        tmp.path()
+            .join("assets/materials/slate.material.bsb")
+            .exists()
+    );
+    assert!(
+        round_trip_scene(&mut app, &tmp, "materials/slate.material.bsn")
+            .contains("materials/slate.material.bsn"),
+        "the reference the scene was written with still names the asset it found"
+    );
+}
+
+#[test]
+fn converting_a_document_a_tab_has_open_is_refused() {
+    let (mut app, tmp) = editor_with_outfits();
+    file_material(&mut app, "materials/slate.material.bsn");
+    round_trip_scene(&mut app, &tmp, "materials/slate.material.bsn");
+    let open = tmp.path().join("assets/zone.bsn");
+    app.world_mut()
+        .resource_mut::<jackdaw::scenes::Scenes>()
+        .push_tab(jackdaw::scenes::SceneTab {
+            path: Some(open.clone()),
+            display_name: "zone".to_string(),
+            dirty: false,
+            kind: jackdaw::scenes::TabKind::Scene,
+            content: jackdaw::scenes::TabContent::Scene(None),
+            view_state: jackdaw::scenes::ViewState::default(),
+            history: jackdaw::commands::CommandHistory::default(),
+            terrain_data_store: jackdaw::terrain::TerrainDataStore::default(),
+            navmesh: jackdaw::terrain::navmesh_bake::TabNavmesh::default(),
+            history_depth_at_last_check: 0,
+            refusal: None,
+        });
+
+    let result = app
+        .world_mut()
+        .operator("file.convert_to_binary")
+        .settings(CallOperatorSettings {
+            execution_context: ExecutionContext::Invoke,
+            creates_history_entry: true,
+        })
+        .param("path", open.to_string_lossy().into_owned())
+        .call()
+        .expect("the operator dispatched");
+    app.update();
+
+    assert_eq!(result, OperatorResult::Cancelled);
+    assert!(
+        open.exists(),
+        "the file the tab is written back to is still there"
+    );
+    assert!(!tmp.path().join("assets/zone.bsb").exists());
+}
+
 fn open_outfit(app: &App) -> OutfitDef {
     let value =
         jackdaw::definition_assets::open_definition_value(app.world()).expect("an asset is open");


### PR DESCRIPTION
A BSN document could only be stored as text, the right form for a repository but not for a shipped game or for large files nobody diffs.

Every document now has a binary twin, .bsb, read by sniffing the first bytes, saved in the form it was opened in, treated as one asset with its text file, and produced by a per-file convert or a whole-tree export.

LLM disclaimer: Claude Code was used to help plan and implement this change, but all code was human reviewed by myself!
